### PR TITLE
feat(stage3): replace OBI with native AXI4 master ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ obj_dir/
 docs/superpowers/
 __pycache__/
 riscv-arch-test/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,9 @@ Commit message convention: `type(scope): description`
 ## Branch Workflow
 
 One branch per stage. Open it when you start, commit freely during development,
-squash to a single commit when the stage is done, then fast-forward merge to `main`.
+squash to a single commit when the stage is done, then merge to `main` via PR.
+
+Direct pushes to `main` are blocked — all changes must go through a pull request.
 
 ```bash
 # 1. Open a stage branch
@@ -175,15 +177,16 @@ git pull --rebase --autostash origin main
 git reset --soft origin/main
 git commit -m "feat(stage3): C extension + branch predictor"
 
-# 5. Fast-forward merge, push, and clean up
+# 5. Open a pull request and merge
+git push -u origin stage3
+# Then open a PR on GitHub; merge via squash merge to main
 git checkout main
-git merge --ff-only stage3
-git push origin main
+git pull origin main
 git branch -d stage3
 ```
 
 `main` always has exactly one commit per completed stage, plus the skeleton and docs
-commits. No merge commits, no squash PRs.
+commits. Use squash merge on GitHub PRs.
 
 Do not include any reference to Claude or AI tools in commit messages
 (no `🤖 Generated with Claude Code`, no `Co-Authored-By`, no similar footers).

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ all stages; RV64 support is added at Stage 4.
 
 ## Staged Development
 
-| Stage | Description                         | ISA              | Bus     | Status      |
-|-------|-------------------------------------|------------------|---------|-------------|
-| 0     | Single-cycle golden model           | RV32I            | OBI     | Complete    |
-| 1     | 5-stage in-order pipeline           | RV32I            | OBI     | Complete    |
-| 2     | M extension + CSR hardening         | RV32IM           | OBI     | Complete    |
-| 3     | C extension + branch predictor      | RV32IMC          | OBI     | Planned     |
-| 4     | RV64I + A extension                 | RV64IMAC         | OBI     | Planned     |
-| 5     | F/D extensions (floating point)     | RV64IMAFDС       | OBI     | Planned     |
-| 6     | Out-of-order execution (BOOM style) | RV64IMAFDС       | AXI4    | Planned     |
+| Stage | Description                                     | ISA              | Bus     | Status      |
+|-------|-------------------------------------------------|------------------|---------|-------------|
+| 0     | Single-cycle golden model                       | RV32I            | OBI     | Complete    |
+| 1     | 5-stage in-order pipeline                       | RV32I            | OBI     | Complete    |
+| 2     | M extension + CSR hardening                     | RV32IM           | OBI     | Complete    |
+| 3     | AXI4 switch + C extension + branch predictor   | RV32IMC          | AXI4    | In progress |
+| 4     | RV64I + A extension                             | RV64IMAC         | AXI4    | Planned     |
+| 5     | F/D extensions (floating point)                 | RV64IMAFDС       | AXI4    | Planned     |
+| 6     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same
 `kronos_top` module interface, so the testbench and SoC integration point never
@@ -34,11 +34,15 @@ change between stages.
 
 ## Bus Interface
 
-**Stages 0–5:** OBI (Open Bus Interface) — a simple req/gnt/rvalid handshake
+**Stages 0–2:** OBI (Open Bus Interface) — a simple req/gnt/rvalid handshake
 with one outstanding transaction per port (instruction fetch + data).
 
-**Stage 6:** Native AXI4 — the out-of-order LSU requires multiple outstanding
-memory requests with tagged, out-of-order responses.
+**Stages 3–5:** Native AXI4 — single-outstanding AXI4 master ports (one
+in-flight transaction per channel). The `axi_from_mem` bridge used in earlier
+stages is removed; the core connects directly to the AXI crossbar.
+
+**Stage 6:** AXI4 with multiple outstanding IDs — the out-of-order LSU issues
+multiple in-flight memory requests with tagged, out-of-order responses.
 
 ## Repository Structure
 
@@ -52,22 +56,26 @@ kronos-riscv/
 │   │   ├── kronos_forward.sv  # Data forwarding mux selects (pure comb)
 │   │   ├── kronos_hazard.sv   # Stall/flush control (pure comb)
 │   │   └── kronos_top.sv      # Pipeline top (IF→ID→EX→MEM→WB)
-│   └── stage2/                # Stage 2: RV32M multiply/divide
-│       ├── kronos_decode.sv   # RV32I+M decoder (extends stage0)
-│       ├── kronos_muldiv.sv   # Multi-cycle mul/div FSM (2–34 cycles)
-│       └── kronos_top.sv      # Stage2 pipeline top (muldiv + combined stall)
+│   ├── stage2/                # Stage 2: RV32M multiply/divide
+│   │   ├── kronos_decode.sv   # RV32I+M decoder (extends stage0)
+│   │   ├── kronos_muldiv.sv   # Multi-cycle mul/div FSM (2–34 cycles)
+│   │   └── kronos_top.sv      # Stage2 pipeline top (muldiv + combined stall)
+│   └── stage3/                # Stage 3: AXI4 bus + C extension + branch predictor
+│       └── kronos_lsu.sv      # AXI4 LSU (single-outstanding, replaces OBI LSU)
 ├── tb/
 │   ├── tb_pkg.sv              # Shared testbench utilities
 │   ├── stage0/                # Stage 0 testbenches
 │   ├── stage1/                # Stage 1 unit testbenches
-│   └── stage2/                # Stage 2 unit testbenches
+│   ├── stage2/                # Stage 2 unit testbenches
+│   └── stage3/                # Stage 3 unit testbenches
 ├── sw/
 │   ├── stage0/                # Stage 0 test programs (RISC-V assembly)
 │   ├── stage1/                # Stage 1 hazard-focused test programs
-│   └── stage2/                # Stage 2 M-extension test programs
+│   ├── stage2/                # Stage 2 M-extension test programs
+│   └── stage3/                # Stage 3 test programs
 ├── sim/
 │   ├── Makefile               # Verilator build and run targets
-│   └── sim_main.cpp           # C++ OBI memory model and driver
+│   └── sim_main.cpp           # C++ simulation driver
 ├── kronos_riscv.core          # FuseSoC core descriptor (active: stage2)
 ├── LICENSE
 └── CLAUDE.md                  # Claude Code project instructions
@@ -123,8 +131,10 @@ cd sim && make sim-lsu-s1    # LSU OBI FSM
 
 kronos-riscv is designed to plug into
 [OpenSoC](https://github.com/vladdum/opensoc) as a git submodule at
-`hw/ip/kronos_riscv`, replacing the Ibex core. The OBI port list matches
-OpenSoC's existing `axi_from_mem` bridges exactly.
+`hw/ip/kronos_riscv`, replacing the Ibex core. Stages 0–2 use OBI and connect
+via OpenSoC's existing `axi_from_mem` bridges. From Stage 3 onward the core
+exposes native AXI4 master ports and connects directly to the AXI crossbar,
+removing the need for the bridge.
 
 ## License
 

--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -44,6 +44,22 @@ filesets:
       - rtl/stage2/kronos_top.sv
     file_type: systemVerilogSource
 
+  files_rtl_s3:
+    depend:
+      - pulp-platform.org::axi:0.39.9
+    files:
+      - rtl/kronos_pkg.sv
+      - rtl/stage0/kronos_alu.sv
+      - rtl/stage2/kronos_decode.sv
+      - rtl/stage0/kronos_regfile.sv
+      - rtl/stage0/kronos_csr.sv
+      - rtl/stage3/kronos_lsu.sv
+      - rtl/stage1/kronos_forward.sv
+      - rtl/stage1/kronos_hazard.sv
+      - rtl/stage2/kronos_muldiv.sv
+      - rtl/stage3/kronos_top.sv
+    file_type: systemVerilogSource
+
   files_tb_s0:
     files:
       - tb/stage0/tb_alu.sv
@@ -87,5 +103,14 @@ targets:
       verilator:
         mode: lint-only
         verilator_options: [--Wall, --Wno-UNUSED]
+    toplevel: kronos_top
+    default_tool: verilator
+
+  lint-s3:
+    filesets: [files_rtl_s3]
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options: [--Wall, --Wno-UNUSED, --Wno-WIDTHEXPAND]
     toplevel: kronos_top
     default_tool: verilator

--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -2,7 +2,25 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "axi/typedef.svh"
+
 package kronos_pkg;
+
+  // -------------------------------------------------------------------------
+  // Stage 3+: AXI4 master port types
+  // -------------------------------------------------------------------------
+  typedef logic [31:0] kronos_axi_addr_t;
+  typedef logic [ 0:0] kronos_axi_id_t;
+  typedef logic [31:0] kronos_axi_data_t;
+  typedef logic [ 3:0] kronos_axi_strb_t;
+  typedef logic [ 0:0] kronos_axi_user_t;
+
+  // Generates: kronos_axi_aw_chan_t, kronos_axi_w_chan_t, kronos_axi_b_chan_t,
+  //            kronos_axi_ar_chan_t, kronos_axi_r_chan_t,
+  //            kronos_axi_req_t, kronos_axi_resp_t
+  `AXI_TYPEDEF_ALL(kronos_axi,
+    kronos_axi_addr_t, kronos_axi_id_t, kronos_axi_data_t,
+    kronos_axi_strb_t, kronos_axi_user_t)
 
   // ALU operation select
   typedef enum logic [3:0] {

--- a/rtl/stage3/kronos_lsu.sv
+++ b/rtl/stage3/kronos_lsu.sv
@@ -1,0 +1,210 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_lsu.sv (stage3) — load/store unit with AXI4 master FSM.
+// Replaces the stage1 OBI FSM with a 7-state AXI4 FSM.
+// Pipeline interface is unchanged (req/we/addr/wdata/funct3/rdata/valid/mem_stall).
+module kronos_lsu
+  import kronos_pkg::*;
+(
+  input  logic             clk_i,
+  input  logic             rst_ni,
+  // Pipeline interface
+  input  logic             req_i,
+  input  logic             we_i,
+  input  logic [31:0]      addr_i,
+  input  logic [31:0]      wdata_i,
+  input  logic [2:0]       funct3_i,
+  output logic [31:0]      rdata_o,
+  output logic             valid_o,
+  output logic             mem_stall_o,
+  // AXI4 data port
+  output kronos_axi_req_t  axi_req_o,
+  input  kronos_axi_resp_t axi_rsp_i
+);
+
+  // -------------------------------------------------------------------------
+  // FSM state
+  // -------------------------------------------------------------------------
+  typedef enum logic [2:0] {
+    IDLE       = 3'd0,
+    LOAD_ADDR  = 3'd1,
+    LOAD_DATA  = 3'd2,
+    LOAD_DONE  = 3'd3,
+    STORE_SEND = 3'd4,
+    STORE_RESP = 3'd5,
+    STORE_DONE = 3'd6
+  } lsu_state_e;
+
+  lsu_state_e state_q;
+
+  // -------------------------------------------------------------------------
+  // Registered operands (captured at IDLE→non-IDLE transition)
+  // -------------------------------------------------------------------------
+  logic [31:0] addr_q;
+  logic [31:0] wdata_q;
+  logic [2:0]  funct3_q;
+  logic [31:0] rdata_q;
+  logic        aw_acked_q;
+  logic        w_acked_q;
+
+  // -------------------------------------------------------------------------
+  // Byte-enable and store-data replication
+  // -------------------------------------------------------------------------
+  logic [ 3:0] be;
+  logic [31:0] wdata_rep;
+
+  always_comb begin
+    be = 4'b1111;
+    unique case (funct3_q[1:0])
+      2'b00:   be = 4'b0001 << addr_q[1:0];
+      2'b01:   be = 4'b0011 << addr_q[1:0];
+      2'b10:   be = 4'b1111;
+      default: be = 4'b1111;
+    endcase
+  end
+
+  always_comb begin
+    wdata_rep = wdata_q;
+    unique case (funct3_q[1:0])
+      2'b00:   wdata_rep = {4{wdata_q[7:0]}};
+      2'b01:   wdata_rep = {2{wdata_q[15:0]}};
+      2'b10:   wdata_rep = wdata_q;
+      default: wdata_rep = wdata_q;
+    endcase
+  end
+
+  // -------------------------------------------------------------------------
+  // Load-data extraction and sign extension
+  // -------------------------------------------------------------------------
+  logic [1:0]  byte_off;
+  logic [31:0] rdata_shifted;
+  logic [7:0]  raw_byte;
+  logic [15:0] raw_half;
+
+  assign byte_off      = addr_q[1:0];
+  assign rdata_shifted = rdata_q >> ({3'b0, byte_off} * 4'd8);
+  assign raw_byte      = rdata_shifted[7:0];
+  assign raw_half      = rdata_shifted[15:0];
+
+  always_comb begin
+    rdata_o = rdata_q;
+    unique case (funct3_q)
+      3'b000:  rdata_o = {{24{raw_byte[7]}},  raw_byte};
+      3'b001:  rdata_o = {{16{raw_half[15]}}, raw_half};
+      3'b010:  rdata_o = rdata_q;
+      3'b100:  rdata_o = {24'b0, raw_byte};
+      3'b101:  rdata_o = {16'b0, raw_half};
+      default: rdata_o = rdata_q;
+    endcase
+  end
+
+  // -------------------------------------------------------------------------
+  // FSM
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q    <= IDLE;
+      addr_q     <= '0;
+      wdata_q    <= '0;
+      funct3_q   <= '0;
+      rdata_q    <= '0;
+      aw_acked_q <= 1'b0;
+      w_acked_q  <= 1'b0;
+    end else begin
+      unique case (state_q)
+
+        IDLE: begin
+          if (req_i) begin
+            addr_q   <= addr_i;
+            wdata_q  <= wdata_i;
+            funct3_q <= funct3_i;
+            if (we_i) begin
+              state_q    <= STORE_SEND;
+              aw_acked_q <= 1'b0;
+              w_acked_q  <= 1'b0;
+            end else begin
+              state_q <= LOAD_ADDR;
+            end
+          end
+        end
+
+        LOAD_ADDR: begin
+          if (axi_rsp_i.ar_ready) state_q <= LOAD_DATA;
+        end
+
+        LOAD_DATA: begin
+          if (axi_rsp_i.r_valid) begin
+            rdata_q <= axi_rsp_i.r.data;
+            state_q <= LOAD_DONE;
+          end
+        end
+
+        LOAD_DONE: begin
+          state_q <= IDLE;  // unconditional — valid_o is a 1-cycle pulse
+        end
+
+        STORE_SEND: begin
+          if (axi_rsp_i.aw_ready) aw_acked_q <= 1'b1;
+          if (axi_rsp_i.w_ready)  w_acked_q  <= 1'b1;
+          if ((aw_acked_q | axi_rsp_i.aw_ready) &
+              (w_acked_q  | axi_rsp_i.w_ready)) begin
+            state_q    <= STORE_RESP;
+            aw_acked_q <= 1'b0;
+            w_acked_q  <= 1'b0;
+          end
+        end
+
+        STORE_RESP: begin
+          if (axi_rsp_i.b_valid) state_q <= STORE_DONE;
+        end
+
+        STORE_DONE: begin
+          state_q <= IDLE;  // unconditional — valid_o is a 1-cycle pulse
+        end
+
+        default: state_q <= IDLE;
+      endcase
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // AXI4 request outputs
+  // -------------------------------------------------------------------------
+  always_comb begin
+    axi_req_o = '0;
+    unique case (state_q)
+      LOAD_ADDR: begin
+        axi_req_o.ar_valid = 1'b1;
+        axi_req_o.ar.addr  = {addr_q[31:2], 2'b00};
+        axi_req_o.ar.size  = 3'b010;
+        axi_req_o.ar.burst = axi_pkg::BURST_INCR;
+      end
+      LOAD_DATA: begin
+        axi_req_o.r_ready  = 1'b1;
+      end
+      STORE_SEND: begin
+        axi_req_o.aw_valid = ~aw_acked_q;
+        axi_req_o.aw.addr  = {addr_q[31:2], 2'b00};
+        axi_req_o.aw.size  = 3'b010;
+        axi_req_o.aw.burst = axi_pkg::BURST_INCR;
+        axi_req_o.w_valid  = ~w_acked_q;
+        axi_req_o.w.data   = wdata_rep;
+        axi_req_o.w.strb   = be;
+        axi_req_o.w.last   = 1'b1;
+      end
+      STORE_RESP: begin
+        axi_req_o.b_ready  = 1'b1;
+      end
+      default: ;
+    endcase
+  end
+
+  // -------------------------------------------------------------------------
+  // Pipeline stall and valid
+  // -------------------------------------------------------------------------
+  assign mem_stall_o = req_i & (state_q != LOAD_DONE) & (state_q != STORE_DONE);
+  assign valid_o     = (state_q == LOAD_DONE) | (state_q == STORE_DONE);
+
+endmodule

--- a/rtl/stage3/kronos_top.sv
+++ b/rtl/stage3/kronos_top.sv
@@ -1,0 +1,454 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_top.sv (stage3) — 5-stage in-order pipeline with RV32M and AXI4 bus.
+// Replaces OBI ports with native AXI4 master ports.
+// Reuses stage0: kronos_regfile, kronos_alu, kronos_csr
+// Reuses stage1: kronos_forward, kronos_hazard
+// Reuses stage2: kronos_decode (RV32I+M), kronos_muldiv
+// New in stage3:  kronos_lsu (AXI4 FSM), fetch FSM in kronos_top
+module kronos_top
+  import kronos_pkg::*;
+(
+  input  logic             clk_i,
+  input  logic             rst_ni,
+
+  // Instruction fetch port (AXI4 read-only master)
+  output kronos_axi_req_t  instr_axi_req_o,
+  input  kronos_axi_resp_t instr_axi_rsp_i,
+
+  // Data port (AXI4 read/write master)
+  output kronos_axi_req_t  data_axi_req_o,
+  input  kronos_axi_resp_t data_axi_rsp_i,
+
+  input  logic             irq_timer_i,
+  input  logic [14:0]      irq_fast_i,
+  input  logic [31:0]      boot_addr_i
+);
+
+  // -------------------------------------------------------------------------
+  // Pipeline registers
+  // -------------------------------------------------------------------------
+  if_id_reg_t  if_id_q;
+  id_ex_reg_t  id_ex_q;
+  ex_mem_reg_t ex_mem_q;
+  mem_wb_reg_t mem_wb_q;
+  logic [31:0] pc_q;
+
+  // -------------------------------------------------------------------------
+  // Hazard / forwarding control
+  // -------------------------------------------------------------------------
+  logic      pc_en, if_id_en, id_ex_en, ex_mem_en, mem_wb_en;
+  logic      if_id_flush, id_ex_flush;
+  fwd_sel_e  fwd_rs1_sel, fwd_rs2_sel;
+
+  // -------------------------------------------------------------------------
+  // ID-stage wires
+  // -------------------------------------------------------------------------
+  decoded_instr_t id_dec;
+  logic [63:0]    rs1_rdata_64, rs2_rdata_64;
+  logic [31:0]    rs1_data_id, rs2_data_id;
+  logic           wb_writing;
+
+  // -------------------------------------------------------------------------
+  // EX-stage wires
+  // -------------------------------------------------------------------------
+  logic [31:0] fwd_rs1_data, fwd_rs2_data;
+  logic [31:0] alu_a, alu_b, alu_result;
+  logic [31:0] ex_result;
+  logic [31:0] ex_pc_next;
+  logic        ex_redirect;
+  logic        branch_taken;
+  logic        irq_pending;
+  logic [31:0] csr_rdata, trap_vector, mepc;
+  logic [31:0] trap_cause;
+
+  // STAGE2: muldiv signals
+  logic [31:0] muldiv_result;
+  logic        muldiv_valid, muldiv_idle;
+  logic        muldiv_stall;
+
+  // STAGE3: fetch FSM
+  typedef enum logic { FETCH_IDLE = 1'b0, FETCH_WAIT_R = 1'b1 } fetch_state_e;
+  fetch_state_e fetch_state_q;
+  logic         instr_fetch_stall;
+  logic         combined_stall;
+
+  // -------------------------------------------------------------------------
+  // MEM-stage wires
+  // -------------------------------------------------------------------------
+  logic [31:0]      lsu_rdata;
+  logic             lsu_valid;
+  logic             mem_stall;
+  // mem_done_q: set when LSU signals valid_o; cleared when MEM/WB register
+  // advances.  Gates req_i so LSU does not re-issue while the pipeline is
+  // frozen by instr_fetch_stall.
+  logic             mem_done_q;
+  logic [31:0]      lsu_rdata_latch;  // holds rdata across the stall gap
+  kronos_axi_req_t  data_req;
+  kronos_axi_resp_t data_rsp;
+
+  // -------------------------------------------------------------------------
+  // WB-stage wires
+  // -------------------------------------------------------------------------
+  logic [31:0] wb_result;
+  logic [63:0] wb_result_64;
+
+  // =========================================================================
+  // Submodule instantiations
+  // =========================================================================
+
+  kronos_decode u_decode (
+    .instr_i (if_id_q.instr),
+    .dec_o   (id_dec)
+  );
+
+  kronos_regfile u_regfile (
+    .clk_i       (clk_i),
+    .rs1_addr_i  (id_dec.rs1),
+    .rs2_addr_i  (id_dec.rs2),
+    .rs1_rdata_o (rs1_rdata_64),
+    .rs2_rdata_o (rs2_rdata_64),
+    .rd_addr_i   (mem_wb_q.dec.rd),
+    .rd_wen_i    (mem_wb_q.valid & mem_wb_q.dec.rd_wen),
+    .rd_wdata_i  (wb_result_64)
+  );
+
+  kronos_forward u_forward (
+    .id_ex_rs1_i      (id_ex_q.dec.rs1),
+    .id_ex_rs1_used_i (id_ex_q.dec.rs1_used),
+    .id_ex_rs2_i      (id_ex_q.dec.rs2),
+    .id_ex_rs2_used_i (id_ex_q.dec.rs2_used),
+    .ex_mem_rd_i      (ex_mem_q.dec.rd),
+    .ex_mem_rd_wen_i  (ex_mem_q.dec.rd_wen & ex_mem_q.valid),
+    .ex_mem_is_load_i (ex_mem_q.dec.is_load),
+    .mem_wb_rd_i      (mem_wb_q.dec.rd),
+    .mem_wb_rd_wen_i  (mem_wb_q.dec.rd_wen & mem_wb_q.valid),
+    .fwd_rs1_sel_o    (fwd_rs1_sel),
+    .fwd_rs2_sel_o    (fwd_rs2_sel)
+  );
+
+  // STAGE3: combined_stall — mem_stall | muldiv_stall | instr_fetch_stall
+  assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid;
+  // instr_fetch_stall: deasserts only on the cycle r_valid fires in FETCH_WAIT_R.
+  assign instr_fetch_stall = ~(fetch_state_q == FETCH_WAIT_R && instr_axi_rsp_i.r_valid);
+  assign combined_stall    = mem_stall | muldiv_stall | instr_fetch_stall;
+
+  kronos_hazard u_hazard (
+    .id_ex_is_load_i  (id_ex_q.dec.is_load),
+    .id_ex_rd_i       (id_ex_q.dec.rd),
+    .id_ex_valid_i    (id_ex_q.valid),
+    .if_id_rs1_used_i (id_dec.rs1_used),
+    .if_id_rs1_i      (id_dec.rs1),
+    .if_id_rs2_used_i (id_dec.rs2_used),
+    .if_id_rs2_i      (id_dec.rs2),
+    .ex_redirect_i    (ex_redirect),
+    .mem_stall_i      (combined_stall),
+    .pc_en_o          (pc_en),
+    .if_id_en_o       (if_id_en),
+    .id_ex_en_o       (id_ex_en),
+    .ex_mem_en_o      (ex_mem_en),
+    .mem_wb_en_o      (mem_wb_en),
+    .if_id_flush_o    (if_id_flush),
+    .id_ex_flush_o    (id_ex_flush)
+  );
+
+  kronos_alu u_alu (
+    .op_i     (id_ex_q.dec.alu_op),
+    .a_i      (alu_a),
+    .b_i      (alu_b),
+    .result_o (alu_result)
+  );
+
+  kronos_muldiv u_muldiv (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+    .req_i    (id_ex_q.valid & id_ex_q.dec.is_muldiv & muldiv_idle & ~mem_stall),
+    .op_i     (id_ex_q.dec.muldiv_op),
+    .a_i      (fwd_rs1_data),
+    .b_i      (fwd_rs2_data),
+    .result_o (muldiv_result),
+    .busy_o   (),
+    .valid_o  (muldiv_valid),
+    .idle_o   (muldiv_idle)
+  );
+
+  assign ex_result = id_ex_q.dec.is_muldiv ? muldiv_result : alu_result;
+
+  kronos_csr #(.MISA_EXT(26'h1100)) u_csr (
+    .clk_i         (clk_i),
+    .rst_ni        (rst_ni),
+    .req_i         (id_ex_q.valid & id_ex_q.dec.is_csr),
+    .addr_i        (id_ex_q.dec.csr_addr),
+    .funct3_i      (id_ex_q.dec.csr_funct3),
+    .use_imm_i     (id_ex_q.dec.csr_use_imm),
+    .rs1_data_i    (fwd_rs1_data),
+    .rs1_addr_i    (id_ex_q.dec.rs1),
+    .rdata_o       (csr_rdata),
+    .valid_o       (),
+    // Gate trap_i and mret_i with ~combined_stall: the CSR must only update state
+    // (MEPC, MCAUSE, mstatus.MIE) when the pipeline is actually advancing.
+    // When combined_stall=1 (e.g. instr_fetch_stall active), the pipeline is frozen
+    // and no redirect occurs, so processing trap_i would clear MIE without the
+    // handler ever running.
+    .trap_i        (id_ex_q.valid & ~combined_stall &
+                    (id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak |
+                     id_ex_q.dec.illegal  | irq_pending)),
+    .trap_pc_i     (id_ex_q.pc),
+    .trap_cause_i  (trap_cause),
+    .mret_i        (id_ex_q.valid & ~combined_stall & id_ex_q.dec.is_mret),
+    .trap_vector_o (trap_vector),
+    .mepc_o        (mepc),
+    .irq_timer_i   (irq_timer_i),
+    .irq_fast_i    (irq_fast_i),
+    .irq_pending_o (irq_pending)
+  );
+
+  // STAGE3: LSU with AXI4 interface.
+  // mem_done_q gates req_i to prevent re-issue while the pipeline is frozen
+  // by instr_fetch_stall after a data response has already been received.
+  kronos_lsu u_lsu (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .req_i       (ex_mem_q.valid & (ex_mem_q.dec.is_load | ex_mem_q.dec.is_store) & ~mem_done_q),
+    .we_i        (ex_mem_q.dec.is_store),
+    .addr_i      (ex_mem_q.alu_result),
+    .wdata_i     (ex_mem_q.rs2_data),
+    .funct3_i    (ex_mem_q.dec.mem_funct3),
+    .rdata_o     (lsu_rdata),
+    .valid_o     (lsu_valid),
+    .mem_stall_o (mem_stall),
+    .axi_req_o   (data_req),
+    .axi_rsp_i   (data_rsp)
+  );
+
+  assign data_axi_req_o = data_req;
+  assign data_rsp       = data_axi_rsp_i;
+
+  // =========================================================================
+  // PC register
+  // =========================================================================
+  logic [31:0] pc_next;
+  assign pc_next = ex_redirect ? ex_pc_next : pc_q + 32'd4;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) pc_q <= boot_addr_i;
+    else if (pc_en) pc_q <= pc_next;
+  end
+
+  // =========================================================================
+  // IF stage — 2-state fetch FSM
+  // =========================================================================
+  // IDLE:      drive ar_valid=1, ar_addr=pc_q.  Transition to FETCH_WAIT_R on ar_ready.
+  // FETCH_WAIT_R: drive r_ready=1.  Transition to IDLE on r_valid.
+  //
+  // instr_fetch_stall deasserts only on the cycle r_valid fires (FETCH_WAIT_R).
+  // The PC and pipeline are frozen in all other cycles.
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) fetch_state_q <= FETCH_IDLE;
+    else begin
+      unique case (fetch_state_q)
+        FETCH_IDLE:   if (instr_axi_rsp_i.ar_ready)  fetch_state_q <= FETCH_WAIT_R;
+        FETCH_WAIT_R: if (instr_axi_rsp_i.r_valid)   fetch_state_q <= FETCH_IDLE;
+        default:      fetch_state_q <= FETCH_IDLE;
+      endcase
+    end
+  end
+
+  // Instr AXI4 request: ar_valid in IDLE, r_ready in FETCH_WAIT_R.
+  // AW/W/B unused on instr port (read-only).
+  always_comb begin
+    instr_axi_req_o            = '0;
+    unique case (fetch_state_q)
+      FETCH_IDLE: begin
+        instr_axi_req_o.ar_valid  = rst_ni;
+        instr_axi_req_o.ar.addr   = pc_q;
+        instr_axi_req_o.ar.size   = 3'b010;
+        instr_axi_req_o.ar.burst  = axi_pkg::BURST_INCR;
+      end
+      FETCH_WAIT_R: begin
+        instr_axi_req_o.r_ready   = 1'b1;
+      end
+      default: ;
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      if_id_q <= '0;
+    end else if (if_id_flush) begin
+      if_id_q <= '0;
+    end else if (if_id_en) begin
+      if_id_q.pc    <= pc_q;
+      if_id_q.instr <= instr_axi_rsp_i.r.data;
+      if_id_q.valid <= (fetch_state_q == FETCH_WAIT_R) & instr_axi_rsp_i.r_valid;
+    end
+  end
+
+  // =========================================================================
+  // ID stage
+  // =========================================================================
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      id_ex_q <= '0;
+    end else if (id_ex_flush) begin
+      id_ex_q <= '0;
+    end else if (id_ex_en) begin
+      id_ex_q.pc       <= if_id_q.pc;
+      id_ex_q.dec      <= id_dec;
+      id_ex_q.rs1_data <= rs1_data_id;
+      id_ex_q.rs2_data <= rs2_data_id;
+      id_ex_q.valid    <= if_id_q.valid;
+    end
+  end
+
+  // =========================================================================
+  // EX stage
+  // =========================================================================
+  always_comb begin
+    unique case (fwd_rs1_sel)
+      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data;
+      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result;
+      FWD_MEMWB: fwd_rs1_data = wb_result;
+      default:   fwd_rs1_data = id_ex_q.rs1_data;
+    endcase
+    unique case (fwd_rs2_sel)
+      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data;
+      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result;
+      FWD_MEMWB: fwd_rs2_data = wb_result;
+      default:   fwd_rs2_data = id_ex_q.rs2_data;
+    endcase
+  end
+
+  assign alu_a = id_ex_q.dec.use_pc  ? id_ex_q.pc      : fwd_rs1_data;
+  assign alu_b = id_ex_q.dec.use_imm ? id_ex_q.dec.imm : fwd_rs2_data;
+
+  always_comb begin
+    branch_taken = 1'b0;
+    if (id_ex_q.valid & id_ex_q.dec.is_branch) begin
+      unique case (id_ex_q.dec.branch_funct3)
+        3'b000:  branch_taken = (fwd_rs1_data == fwd_rs2_data);
+        3'b001:  branch_taken = (fwd_rs1_data != fwd_rs2_data);
+        3'b100:  branch_taken = ($signed(fwd_rs1_data) <  $signed(fwd_rs2_data));
+        3'b101:  branch_taken = ($signed(fwd_rs1_data) >= $signed(fwd_rs2_data));
+        3'b110:  branch_taken = (fwd_rs1_data <  fwd_rs2_data);
+        3'b111:  branch_taken = (fwd_rs1_data >= fwd_rs2_data);
+        default: branch_taken = 1'b0;
+      endcase
+    end
+  end
+
+  always_comb begin
+    if      (irq_pending)          trap_cause = 32'h80000007;
+    else if (id_ex_q.dec.illegal)  trap_cause = 32'd2;
+    else if (id_ex_q.dec.is_ecall) trap_cause = 32'd11;
+    else                           trap_cause = 32'd3;
+  end
+
+  always_comb begin
+    if      (id_ex_q.valid & (id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak |
+                               id_ex_q.dec.illegal  | irq_pending))
+      ex_pc_next = trap_vector;
+    else if (id_ex_q.valid & id_ex_q.dec.is_mret)
+      ex_pc_next = mepc;
+    else if (id_ex_q.valid & id_ex_q.dec.is_jalr)
+      ex_pc_next = (fwd_rs1_data + id_ex_q.dec.imm) & ~32'd1;
+    else if (id_ex_q.valid & id_ex_q.dec.is_jal)
+      ex_pc_next = id_ex_q.pc + id_ex_q.dec.imm;
+    else if (branch_taken)
+      ex_pc_next = id_ex_q.pc + id_ex_q.dec.imm;
+    else
+      ex_pc_next = id_ex_q.pc + 32'd4;
+  end
+
+  assign ex_redirect = id_ex_q.valid &
+    (id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr | branch_taken |
+     id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak | id_ex_q.dec.illegal |
+     id_ex_q.dec.is_mret  | irq_pending);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      ex_mem_q <= '0;
+    end else if (ex_mem_en) begin
+      ex_mem_q.pc         <= id_ex_q.pc;
+      ex_mem_q.dec        <= id_ex_q.dec;
+      ex_mem_q.alu_result <= ex_result;
+      ex_mem_q.rs2_data   <= fwd_rs2_data;
+      ex_mem_q.pc_next    <= ex_pc_next;
+      ex_mem_q.csr_rdata  <= csr_rdata;
+      ex_mem_q.redirect   <= ex_redirect;
+      ex_mem_q.valid      <= id_ex_q.valid & ~irq_pending;
+    end
+  end
+
+  // =========================================================================
+  // MEM stage
+  // =========================================================================
+  // mem_done_q: prevents LSU re-issue while pipeline is frozen by instr_fetch_stall.
+  // lsu_rdata_latch: holds the load data across the gap between data rvalid and
+  // the next instr rvalid that allows the pipeline to advance.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mem_done_q      <= 1'b0;
+      lsu_rdata_latch <= '0;
+    end else begin
+      if (lsu_valid) begin
+        mem_done_q      <= 1'b1;
+        lsu_rdata_latch <= lsu_rdata;
+      end
+      if (mem_wb_en) begin
+        mem_done_q <= 1'b0;  // pipeline advanced — re-arm for next instruction
+      end
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mem_wb_q <= '0;
+    end else if (mem_wb_en) begin
+      mem_wb_q.dec        <= ex_mem_q.dec;
+      mem_wb_q.alu_result <= ex_mem_q.alu_result;
+      // Use current rdata when LSU fires this cycle; use latched value when
+      // the pipeline advances after an earlier lsu_valid (mem_done_q=1).
+      mem_wb_q.lsu_rdata  <= lsu_valid ? lsu_rdata : lsu_rdata_latch;
+      mem_wb_q.csr_rdata  <= ex_mem_q.csr_rdata;
+      mem_wb_q.pc4        <= ex_mem_q.pc + 32'd4;
+      mem_wb_q.valid      <= ex_mem_q.valid;
+    end
+  end
+
+  // =========================================================================
+  // WB→ID bypass
+  // =========================================================================
+  assign wb_writing  = mem_wb_q.valid & mem_wb_q.dec.rd_wen & (mem_wb_q.dec.rd != 5'd0);
+  assign rs1_data_id = (wb_writing && mem_wb_q.dec.rd == id_dec.rs1) ? wb_result
+                                                                       : rs1_rdata_64[31:0];
+  assign rs2_data_id = (wb_writing && mem_wb_q.dec.rd == id_dec.rs2) ? wb_result
+                                                                       : rs2_rdata_64[31:0];
+
+  // =========================================================================
+  // WB stage
+  // =========================================================================
+  always_comb begin
+    unique case (mem_wb_q.dec.wb_sel)
+      WB_ALU:  wb_result = mem_wb_q.alu_result;
+      WB_MEM:  wb_result = mem_wb_q.lsu_rdata;
+      WB_PC4:  wb_result = mem_wb_q.pc4;
+      WB_CSR:  wb_result = mem_wb_q.csr_rdata;
+      default: wb_result = mem_wb_q.alu_result;
+    endcase
+  end
+
+  always_comb begin
+    unique case (mem_wb_q.dec.wb_sel)
+      WB_ALU:  wb_result_64 = {{32{wb_result[31]}}, wb_result};
+      WB_MEM:  wb_result_64 = {{32{wb_result[31]}}, wb_result};
+      WB_PC4:  wb_result_64 = {32'b0, wb_result};
+      WB_CSR:  wb_result_64 = {32'b0, wb_result};
+      default: wb_result_64 = {{32{wb_result[31]}}, wb_result};
+    endcase
+  end
+
+endmodule

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -8,6 +8,9 @@ OBJ_DIR   := obj_dir
 VERILATOR := verilator
 CFLAGS    := -std=c++14
 
+# --Wno-WIDTHEXPAND: suppress upstream axi_pkg.sv:203 width warning (PULP library bug)
+# This flag is required for all invocations that include axi_pkg.sv (stage3+)
+
 TOP       := kronos_top
 SIM_BIN   := $(OBJ_DIR)/V$(TOP)
 
@@ -72,10 +75,10 @@ SV_FILES_S2 := $(RTL_DIR)/kronos_pkg.sv \
 
 SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
 
-.PHONY: build build-s1 build-s2 run-% run-s0-% run-s1-% run-s2-% \
+.PHONY: build build-s1 build-s2 build-s3 run-% run-s0-% run-s1-% run-s2-% run-s3-% run-s3-latency-% \
         sim-alu sim-regfile sim-decode sim-compliance \
         sim-compliance-s1 sim-lsu-s1 sim-forward sim-hazard \
-        sim-muldiv sim-compliance-s2 clean
+        sim-muldiv sim-compliance-s2 sim-lsu-s3 sim-compliance-s3 clean
 
 build: $(SIM_BIN)
 
@@ -188,6 +191,75 @@ sim-compliance-s2: build-s2
 	  fi; \
 	done; \
 	echo "Stage 2 regression: $$pass passed, $$fail failed"; \
+	[ $$fail -eq 0 ]
+
+PULP_AXI_INC  := -I/home/popes/opensoc/hw/ip/pulp_axi/include
+AXI_PKG_SV    := /home/popes/opensoc/hw/ip/pulp_axi/src/axi_pkg.sv
+SW_DIR_S3     := ../sw/stage3
+
+SV_FILES_S3 := $(AXI_PKG_SV) \
+               $(RTL_DIR)/kronos_pkg.sv \
+               $(RTL_DIR)/stage0/kronos_alu.sv \
+               $(RTL_DIR)/stage2/kronos_decode.sv \
+               $(RTL_DIR)/stage0/kronos_regfile.sv \
+               $(RTL_DIR)/stage0/kronos_csr.sv \
+               $(RTL_DIR)/stage3/kronos_lsu.sv \
+               $(RTL_DIR)/stage1/kronos_forward.sv \
+               $(RTL_DIR)/stage1/kronos_hazard.sv \
+               $(RTL_DIR)/stage2/kronos_muldiv.sv \
+               $(RTL_DIR)/stage3/kronos_top.sv \
+               sim_top.sv
+
+TOP_S3     := sim_top
+SIM_BIN_S3 := $(OBJ_DIR)/s3/V$(TOP_S3)
+
+TB_LSU_S3_FILES := $(AXI_PKG_SV) \
+                   $(RTL_DIR)/kronos_pkg.sv \
+                   $(RTL_DIR)/stage3/kronos_lsu.sv \
+                   $(TB_DIR)/stage3/tb_lsu_s3.sv
+
+build-s3: $(SIM_BIN_S3)
+
+$(SIM_BIN_S3): $(SV_FILES_S3) sim_main.cpp
+	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED --Wno-WIDTHEXPAND --Wno-PINCONNECTEMPTY \
+	  --top-module $(TOP_S3) \
+	  $(SV_FILES_S3) sim_main.cpp \
+	  -CFLAGS "$(CFLAGS)" \
+	  -Mdir $(OBJ_DIR)/s3 \
+	  $(PULP_AXI_INC) \
+	  -o V$(TOP_S3)
+
+run-s3-%: build-s3
+	./$(SIM_BIN_S3) $(SW_DIR_S3)/build/$*.hex
+
+run-s3-latency-%: build-s3
+	./$(SIM_BIN_S3) $(SW_DIR_S3)/build/$*.hex 2 4
+
+sim-lsu-s3:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_lsu_s3 $(TB_LSU_S3_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_lsu_s3
+	./$(OBJ_DIR)/tb_lsu_s3/Vtb_lsu_s3
+
+sim-compliance-s3: build-s3
+	$(MAKE) -C $(SW_DIR) all
+	$(MAKE) -C $(SW_DIR_S1) all
+	$(MAKE) -C $(SW_DIR_S2) all
+	$(MAKE) -C $(SW_DIR_S3) all
+	@pass=0; fail=0; \
+	for hex in $(SW_DIR)/build/*.hex $(SW_DIR_S1)/build/*.hex \
+	           $(SW_DIR_S2)/build/*.hex \
+	           $$(ls $(SW_DIR_S3)/build/*.hex 2>/dev/null); do \
+	  [ -f "$$hex" ] || continue; \
+	  out=$$(./$(SIM_BIN_S3) $$hex 2>&1); \
+	  x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	  if [ "$$x10" = "0" ]; then \
+	    pass=$$((pass+1)); \
+	  else \
+	    echo "FAIL: $$hex (x10=$$x10)"; fail=$$((fail+1)); \
+	  fi; \
+	done; \
+	echo "Stage 3 regression: $$pass passed, $$fail failed"; \
 	[ $$fail -eq 0 ]
 
 clean:

--- a/sim/sim_main.cpp
+++ b/sim/sim_main.cpp
@@ -2,52 +2,41 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "Vkronos_top.h"
+// sim_main.cpp — AXI4 memory model for kronos stage3+ simulation.
+// Targets Vsim_top (flat AXI4 ports unpacked by sim_top.sv).
+//
+// Usage: sim <hex_file> [instr_latency] [data_latency]
+//   instr_latency: cycles from AR accepted to R valid (default 1)
+//   data_latency:  cycles from AW+W accepted to B valid / AR to R valid (default 1)
+
+#include "Vsim_top.h"
 #include "verilated.h"
 #include <cstdio>
 #include <cstring>
-#include <fstream>
-#include <string>
+#include <cstdlib>
 
 // 256 KB memory (byte-addressable, word-aligned access)
-static uint32_t mem[65536];  // 256 KB / 4
+static uint32_t mem[65536];
 
-// Parse Intel HEX format (produced by objcopy -O ihex).
-// Supports record types:
-//   00  Data
-//   01  End of File
-//   02  Extended Segment Address  (base = ext << 4)
-//   04  Extended Linear Address   (base = ext << 16)
+// Parse Intel HEX format (unchanged from stage2)
 static void load_hex(const char* path) {
     FILE* f = fopen(path, "r");
-    if (!f) {
-        fprintf(stderr, "[sim] ERROR: cannot open %s\n", path);
-        return;
-    }
+    if (!f) { fprintf(stderr, "[sim] ERROR: cannot open %s\n", path); return; }
     char line[1024];
     uint32_t base_addr = 0;
     while (fgets(line, sizeof(line), f)) {
         if (line[0] != ':') continue;
         unsigned byte_count = 0, addr16 = 0, rec_type = 0;
         sscanf(line + 1, "%02x%04x%02x", &byte_count, &addr16, &rec_type);
-        if (rec_type == 0x01) break; // EOF record
-        if (rec_type == 0x04) {      // Extended linear address
-            unsigned ext = 0;
-            sscanf(line + 9, "%04x", &ext);
-            base_addr = (uint32_t)ext << 16;
-        } else if (rec_type == 0x02) { // Extended segment address
-            unsigned ext = 0;
-            sscanf(line + 9, "%04x", &ext);
-            base_addr = (uint32_t)ext << 4;
-        } else if (rec_type == 0x00) { // Data record
+        if (rec_type == 0x01) break;
+        if (rec_type == 0x04) { unsigned ext = 0; sscanf(line+9,"%04x",&ext); base_addr=(uint32_t)ext<<16; }
+        else if (rec_type == 0x02) { unsigned ext=0; sscanf(line+9,"%04x",&ext); base_addr=(uint32_t)ext<<4; }
+        else if (rec_type == 0x00) {
             uint32_t full_addr = base_addr + addr16;
             for (unsigned i = 0; i < byte_count; i++) {
-                unsigned byte = 0;
-                sscanf(line + 9 + i * 2, "%02x", &byte);
-                uint32_t word_idx = (full_addr / 4) & 0xFFFF;
-                uint32_t byte_off = full_addr % 4;
-                mem[word_idx] = (mem[word_idx] & ~(0xFFu << (byte_off * 8)))
-                              | ((uint32_t)byte << (byte_off * 8));
+                unsigned byte = 0; sscanf(line + 9 + i*2, "%02x", &byte);
+                uint32_t wi = (full_addr/4) & 0xFFFF, bo = full_addr%4;
+                mem[wi] = (mem[wi] & ~(0xFFu << (bo*8))) | ((uint32_t)byte << (bo*8));
                 full_addr++;
             }
         }
@@ -55,126 +44,214 @@ static void load_hex(const char* path) {
     fclose(f);
 }
 
+// -------------------------------------------------------------------------
+// AXI4 single-outstanding read channel state
+// -------------------------------------------------------------------------
+struct AxiRead {
+    bool     pending  = false;
+    uint32_t data     = 0;    // pre-fetched at AR time
+    int      fire_at  = -1;   // cycle when r_valid should be driven
+};
+
+// -------------------------------------------------------------------------
+// AXI4 single-outstanding write channel state
+// -------------------------------------------------------------------------
+struct AxiWrite {
+    bool     aw_done   = false;
+    bool     w_done    = false;
+    uint32_t addr      = 0;
+    uint32_t wdata     = 0;
+    uint8_t  wstrb     = 0;
+    int      fire_at   = -1;   // cycle when b_valid should be driven
+    bool     b_pending = false;
+    bool     irq_write = false; // fire irq_timer_i one cycle after B handshake
+};
+
 int main(int argc, char** argv) {
     Verilated::commandArgs(argc, argv);
-    if (argc < 2) {
-        fprintf(stderr, "Usage: sim <hex_file>\n");
-        return 1;
-    }
+    if (argc < 2) { fprintf(stderr, "Usage: sim <hex_file> [instr_lat] [data_lat]\n"); return 1; }
+
+    int INSTR_LAT = (argc >= 3) ? atoi(argv[2]) : 1;
+    int DATA_LAT  = (argc >= 4) ? atoi(argv[3]) : 1;
 
     memset(mem, 0, sizeof(mem));
     load_hex(argv[1]);
 
-    Vkronos_top* top = new Vkronos_top;
-    top->clk_i        = 0;
-    top->rst_ni       = 0;
-    top->boot_addr_i  = 0x00000000;
-    top->irq_timer_i  = 0;
-    top->irq_fast_i   = 0;
-    top->instr_gnt_i    = 0;
-    top->instr_rvalid_i = 0;
-    top->instr_rdata_i  = 0;
-    top->instr_err_i    = 0;
-    top->data_gnt_i     = 0;
-    top->data_rvalid_i  = 0;
-    top->data_rdata_i   = 0;
-    top->data_err_i     = 0;
+    Vsim_top* top = new Vsim_top;
+
+    // Initialise all inputs
+    top->clk_i           = 0;
+    top->rst_ni          = 0;
+    top->boot_addr_i     = 0x00000000;
+    top->irq_timer_i     = 0;
+    top->irq_fast_i      = 0;
+    top->instr_ar_ready_i = 0;
+    top->instr_r_valid_i  = 0;
+    top->instr_r_data_i   = 0;
+    top->data_ar_ready_i  = 0;
+    top->data_r_valid_i   = 0;
+    top->data_r_data_i    = 0;
+    top->data_aw_ready_i  = 0;
+    top->data_w_ready_i   = 0;
+    top->data_b_valid_i   = 0;
 
     // Hold reset for 4 cycles
-    for (int i = 0; i < 8; i++) {
-        top->clk_i = !top->clk_i;
-        top->eval();
-    }
+    for (int i = 0; i < 8; i++) { top->clk_i = !top->clk_i; top->eval(); }
     top->rst_ni = 1;
     top->eval();
 
-    // After reset: PC=0, instr_req_o=1, instr_addr_o=0.
-    // Pre-fetch the first instruction so it is stable before the first rising edge.
-    // For loads, also pre-fetch the data (combinatorial eval reveals the address).
-    // This ensures every instruction sees both instr_rdata_i and data_rdata_i set
-    // BEFORE the rising edge that executes it — giving a true single-cycle model.
+    AxiRead  instr_r, data_r;
+    AxiWrite data_w;
 
-    auto fetch_instr = [&]() {
-        if (top->instr_req_o) {
-            uint32_t wa       = (top->instr_addr_o >> 2) & 0xFFFF;
-            top->instr_rdata_i  = mem[wa];
-            top->instr_gnt_i    = 1;
-            top->instr_rvalid_i = 1;
-            top->instr_err_i    = 0;
-        } else {
-            top->instr_gnt_i    = 0;
-            top->instr_rvalid_i = 0;
-        }
-    };
-
-    // Call after fetch_instr(). Propagates combinationally to discover data_req_o/addr,
-    // then pre-loads data_rdata_i for loads so the register write is correct.
-    // For stores, gnt+rvalid are asserted immediately (OBI: rvalid fires for all
-    // transactions, rdata is irrelevant for writes).
-    auto prefetch_data = [&]() {
-        top->eval();  // combinational propagation (no new clock edge)
-        if (top->data_req_o) {
-            if (!top->data_we_o) {  // load: provide read data
-                uint32_t wa       = (top->data_addr_o >> 2) & 0xFFFF;
-                top->data_rdata_i = mem[wa];
-            }
-            top->data_gnt_i    = 1;
-            top->data_rvalid_i = 1;
-            top->data_err_i    = 0;
-        } else {
-            top->data_gnt_i    = 0;
-            top->data_rvalid_i = 0;
-            top->data_rdata_i  = 0;
-        }
-    };
-
-    fetch_instr();
-    prefetch_data();
-
-    const int MAX_CYCLES = 100000;
+    const int MAX_CYCLES = 500000;
     int halted = 0;
-    // IRQ trigger: a store to 0x80000000 arms this flag; irq_timer_i is asserted
-    // for exactly one rising edge on the following cycle.
-    bool fire_irq = false;
+    // irq_countdown: cycles remaining for irq_timer_i to stay asserted.
+    // Held for INSTR_LAT*4 + DATA_LAT + 4 cycles so the pipeline can take the
+    // interrupt even if instr_fetch_stall is blocking when irq_timer_i first fires.
+    int irq_countdown = 0;
+    const int IRQ_HOLD = INSTR_LAT * 4 + DATA_LAT + 4;
 
     for (int cycle = 0; cycle < MAX_CYCLES && !halted; cycle++) {
-        // Assert timer IRQ for this cycle if the previous cycle armed it.
-        top->irq_timer_i = fire_irq ? 1 : 0;
-        if (fire_irq) fire_irq = false;
 
-        // ---- Rising edge: execute current instruction ----
-        top->clk_i = 1;
+        // ---- Drive IRQ ----
+        top->irq_timer_i = (irq_countdown > 0) ? 1 : 0;
+        if (irq_countdown > 0) irq_countdown--;
+
+        // ---- Set slave inputs for this cycle (before rising edge) ----
+
+        // AR channels: always ready to accept (assert fatal if already in flight)
+        top->instr_ar_ready_i = 1;
+        top->data_ar_ready_i  = 1;
+
+        // AW/W channels: always ready
+        top->data_aw_ready_i = 1;
+        top->data_w_ready_i  = 1;
+
+        // R response — instr
+        if (instr_r.pending && cycle >= instr_r.fire_at) {
+            top->instr_r_valid_i = 1;
+            top->instr_r_data_i  = instr_r.data;
+        } else {
+            top->instr_r_valid_i = 0;
+            top->instr_r_data_i  = 0;
+        }
+
+        // R response — data
+        if (data_r.pending && cycle >= data_r.fire_at) {
+            top->data_r_valid_i = 1;
+            top->data_r_data_i  = data_r.data;
+        } else {
+            top->data_r_valid_i = 0;
+            top->data_r_data_i  = 0;
+        }
+
+        // B response
+        if (data_w.b_pending && cycle >= data_w.fire_at) {
+            top->data_b_valid_i = 1;
+        } else {
+            top->data_b_valid_i = 0;
+        }
+
+        // ---- Evaluate combinatorial outputs BEFORE rising edge ----
+        // Handshakes are sampled from the pre-clock combinatorial state. After the
+        // rising edge, FSM state updates (e.g. FETCH_IDLE→FETCH_WAIT_R) deassert
+        // ar_valid, making post-clock detection miss accepted transactions.
         top->eval();
 
-        // Handle stores. At this point instr_rdata_i still reflects the instruction
-        // that just executed, so data_req_o/we_o/addr_o/wdata_o are valid for it.
-        if (top->data_req_o && top->data_we_o) {
-            uint32_t be   = top->data_be_o;
-            uint32_t wdat = top->data_wdata_o;
+        // ---- Detect handshakes from pre-clock combinatorial state ----
 
-            if (top->data_addr_o == 0x80000000u) {
-                // Timer IRQ trigger: assert irq_timer_i on the next rising edge.
-                // OBI gnt/rvalid are handled by prefetch_data; no memory write.
-                fire_irq = true;
-            } else if ((top->data_addr_o & 0xC0000000u) == 0x40000000u) {
+        // Instr AR handshake
+        if (top->instr_ar_valid_o && top->instr_ar_ready_i) {
+            if (instr_r.pending) {
+                fprintf(stderr, "[AXI] FATAL: duplicate instr AR at cycle %d (addr=0x%08x)\n",
+                        cycle, (unsigned)top->instr_ar_addr_o);
+                return 1;
+            }
+            uint32_t wa = (top->instr_ar_addr_o >> 2) & 0xFFFF;
+            instr_r.pending = true;
+            instr_r.data    = mem[wa];
+            instr_r.fire_at = cycle + INSTR_LAT;
+        }
+
+        // Instr R handshake complete
+        if (top->instr_r_valid_i && top->instr_r_ready_o) {
+            instr_r.pending = false;
+        }
+
+        // Data AR handshake
+        if (top->data_ar_valid_o && top->data_ar_ready_i) {
+            if (data_r.pending) {
+                fprintf(stderr, "[AXI] FATAL: duplicate data AR at cycle %d\n", cycle);
+                return 1;
+            }
+            uint32_t wa = (top->data_ar_addr_o >> 2) & 0xFFFF;
+            data_r.pending = true;
+            data_r.data    = mem[wa];
+            data_r.fire_at = cycle + DATA_LAT;
+        }
+
+        // Data R handshake complete
+        if (top->data_r_valid_i && top->data_r_ready_o) {
+            data_r.pending = false;
+        }
+
+        // Data AW handshake
+        if (top->data_aw_valid_o && top->data_aw_ready_i) {
+            data_w.addr    = top->data_aw_addr_o;
+            data_w.aw_done = true;
+        }
+
+        // Data W handshake
+        if (top->data_w_valid_o && top->data_w_ready_i) {
+            data_w.wdata  = top->data_w_data_o;
+            data_w.wstrb  = (uint8_t)top->data_w_strb_o;
+            data_w.w_done = true;
+        }
+
+        // Both AW and W accepted: commit write and schedule B
+        if (data_w.aw_done && data_w.w_done && !data_w.b_pending) {
+            uint32_t waddr = data_w.addr;
+            uint32_t wdat  = data_w.wdata;
+            uint8_t  be    = data_w.wstrb;
+
+            if (waddr == 0x80000000u) {
+                // Timer IRQ trigger — fire one cycle after B handshake completes
+                // so the pipeline is not mem-stalled when irq_timer_i asserts.
+                data_w.irq_write = true;
+            } else if ((waddr & 0xC0000000u) == 0x40000000u) {
+                // Halt
                 printf("[sim] halt at cycle %d, x10 = %u\n", cycle, wdat);
                 halted = 1;
-                break;
             } else {
-                uint32_t word_addr = (top->data_addr_o >> 2) & 0xFFFF;
-                uint32_t cur  = mem[word_addr];
+                uint32_t wi  = (waddr >> 2) & 0xFFFF;
+                uint32_t cur = mem[wi];
                 if (be & 1) cur = (cur & ~0x000000FFu) | (wdat & 0x000000FFu);
                 if (be & 2) cur = (cur & ~0x0000FF00u) | (wdat & 0x0000FF00u);
                 if (be & 4) cur = (cur & ~0x00FF0000u) | (wdat & 0x00FF0000u);
                 if (be & 8) cur = (cur & ~0xFF000000u) | (wdat & 0xFF000000u);
-                mem[word_addr] = cur;
+                mem[wi] = cur;
             }
+
+            data_w.aw_done   = false;
+            data_w.w_done    = false;
+            data_w.b_pending = true;
+            data_w.fire_at   = cycle + DATA_LAT;
         }
 
-        // ---- Fetch next instruction and pre-load data for it ----
-        // instr_addr_o now holds the new PC (advanced by the just-executed instruction).
-        fetch_instr();
-        prefetch_data();
+        // B handshake complete
+        if (top->data_b_valid_i && top->data_b_ready_o) {
+            if (data_w.irq_write) {
+                irq_countdown = IRQ_HOLD; // assert irq_timer_i from next cycle
+                data_w.irq_write = false;
+            }
+            data_w.b_pending = false;
+        }
+
+        if (halted) break;
+
+        // ---- Rising edge ----
+        top->clk_i = 1;
+        top->eval();
 
         // ---- Falling edge ----
         top->clk_i = 0;

--- a/sim/sim_top.sv
+++ b/sim/sim_top.sv
@@ -1,0 +1,117 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim_top.sv — Verilator simulation wrapper for kronos_top (stage3).
+// Unpacks kronos_axi_req_t / kronos_axi_resp_t struct ports into flat signals
+// so sim_main.cpp can drive/read them without packed-struct bit manipulation.
+module sim_top
+  import kronos_pkg::*;
+(
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        irq_timer_i,
+  input  logic [14:0] irq_fast_i,
+  input  logic [31:0] boot_addr_i,
+
+  // Instr port — DUT outputs (AR channel)
+  output logic        instr_ar_valid_o,
+  output logic [31:0] instr_ar_addr_o,
+  // Instr port — DUT outputs (R channel)
+  output logic        instr_r_ready_o,
+  // Instr port — slave inputs (AR channel)
+  input  logic        instr_ar_ready_i,
+  // Instr port — slave inputs (R channel)
+  input  logic        instr_r_valid_i,
+  input  logic [31:0] instr_r_data_i,
+
+  // Data port — DUT outputs (AR channel)
+  output logic        data_ar_valid_o,
+  output logic [31:0] data_ar_addr_o,
+  // Data port — DUT outputs (R channel)
+  output logic        data_r_ready_o,
+  // Data port — DUT outputs (AW channel)
+  output logic        data_aw_valid_o,
+  output logic [31:0] data_aw_addr_o,
+  // Data port — DUT outputs (W channel)
+  output logic        data_w_valid_o,
+  output logic [31:0] data_w_data_o,
+  output logic [ 3:0] data_w_strb_o,
+  // Data port — DUT outputs (B channel)
+  output logic        data_b_ready_o,
+  // Data port — slave inputs (AR channel)
+  input  logic        data_ar_ready_i,
+  // Data port — slave inputs (R channel)
+  input  logic        data_r_valid_i,
+  input  logic [31:0] data_r_data_i,
+  // Data port — slave inputs (AW/W channels)
+  input  logic        data_aw_ready_i,
+  input  logic        data_w_ready_i,
+  // Data port — slave inputs (B channel)
+  input  logic        data_b_valid_i
+);
+
+  kronos_axi_req_t  instr_req, data_req;
+  kronos_axi_resp_t instr_rsp, data_rsp;
+
+  // -------------------------------------------------------------------------
+  // Unpack instr DUT outputs
+  // -------------------------------------------------------------------------
+  assign instr_ar_valid_o = instr_req.ar_valid;
+  assign instr_ar_addr_o  = instr_req.ar.addr;
+  assign instr_r_ready_o  = instr_req.r_ready;
+
+  // -------------------------------------------------------------------------
+  // Pack instr slave inputs
+  // -------------------------------------------------------------------------
+  always_comb begin
+    instr_rsp          = '0;
+    instr_rsp.ar_ready = instr_ar_ready_i;
+    instr_rsp.r_valid  = instr_r_valid_i;
+    instr_rsp.r.data   = instr_r_data_i;
+    instr_rsp.r.last   = 1'b1;
+  end
+
+  // -------------------------------------------------------------------------
+  // Unpack data DUT outputs
+  // -------------------------------------------------------------------------
+  assign data_ar_valid_o = data_req.ar_valid;
+  assign data_ar_addr_o  = data_req.ar.addr;
+  assign data_r_ready_o  = data_req.r_ready;
+  assign data_aw_valid_o = data_req.aw_valid;
+  assign data_aw_addr_o  = data_req.aw.addr;
+  assign data_w_valid_o  = data_req.w_valid;
+  assign data_w_data_o   = data_req.w.data;
+  assign data_w_strb_o   = data_req.w.strb;
+  assign data_b_ready_o  = data_req.b_ready;
+
+  // -------------------------------------------------------------------------
+  // Pack data slave inputs
+  // -------------------------------------------------------------------------
+  always_comb begin
+    data_rsp           = '0;
+    data_rsp.ar_ready  = data_ar_ready_i;
+    data_rsp.r_valid   = data_r_valid_i;
+    data_rsp.r.data    = data_r_data_i;
+    data_rsp.r.last    = 1'b1;
+    data_rsp.aw_ready  = data_aw_ready_i;
+    data_rsp.w_ready   = data_w_ready_i;
+    data_rsp.b_valid   = data_b_valid_i;
+  end
+
+  // -------------------------------------------------------------------------
+  // DUT
+  // -------------------------------------------------------------------------
+  kronos_top u_top (
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .instr_axi_req_o (instr_req),
+    .instr_axi_rsp_i (instr_rsp),
+    .data_axi_req_o  (data_req),
+    .data_axi_rsp_i  (data_rsp),
+    .irq_timer_i     (irq_timer_i),
+    .irq_fast_i      (irq_fast_i),
+    .boot_addr_i     (boot_addr_i)
+  );
+
+endmodule

--- a/sw/stage3/Makefile
+++ b/sw/stage3/Makefile
@@ -1,0 +1,21 @@
+CC      := riscv64-unknown-elf-gcc
+CFLAGS  := -march=rv32im_zicsr -mabi=ilp32 -nostdlib -static -T ../stage0/link.ld
+OBJCOPY := riscv64-unknown-elf-objcopy
+
+BUILD_DIR := build
+
+TESTS :=
+
+all: $(addprefix $(BUILD_DIR)/, $(addsuffix .hex, $(TESTS)))
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/%.elf: %.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $@ $< ../stage0/common.S
+
+$(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf
+	$(OBJCOPY) -O ihex $< $@
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/tb/stage3/tb_lsu_s3.sv
+++ b/tb/stage3/tb_lsu_s3.sv
@@ -1,0 +1,206 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// tb_lsu_s3.sv — unit testbench for stage3 kronos_lsu (AXI4 FSM).
+// Tests: LW, SW, LB sign-extend, AW/W split acceptance, back-to-back.
+module tb_lsu_s3;
+  import kronos_pkg::*;
+
+  logic             clk, rst_n;
+  logic             req, we;
+  logic [31:0]      addr, wdata;
+  logic [2:0]       funct3;
+  logic [31:0]      rdata;
+  logic             valid, mem_stall;
+  kronos_axi_req_t  axi_req;
+  kronos_axi_resp_t axi_rsp;
+
+  kronos_lsu u_lsu (
+    .clk_i       (clk),
+    .rst_ni      (rst_n),
+    .req_i       (req),
+    .we_i        (we),
+    .addr_i      (addr),
+    .wdata_i     (wdata),
+    .funct3_i    (funct3),
+    .rdata_o     (rdata),
+    .valid_o     (valid),
+    .mem_stall_o (mem_stall),
+    .axi_req_o   (axi_req),
+    .axi_rsp_i   (axi_rsp)
+  );
+
+  // Clock: 10 ns period
+  initial clk = 0;
+  always #5 clk = ~clk;
+
+  // Helper: assert with message
+  task automatic check(input logic cond, input string msg);
+    if (!cond) begin
+      $display("FAIL: %s", msg);
+      $finish(1);
+    end
+  endtask
+
+  // Helper: single AXI4 rising-edge tick.
+  // Drives slave responses (axi_rsp) before the clock edge, then waits for
+  // posedge.  Verilator's coroutine resumes after the NBA region so state_q
+  // and all combinatorial outputs are stable when the task returns.
+  task automatic tick(
+    input logic ar_ready, r_valid, logic [31:0] r_data,
+    input logic aw_ready, w_ready, b_valid
+  );
+    axi_rsp          = '0;
+    axi_rsp.ar_ready = ar_ready;
+    axi_rsp.r_valid  = r_valid;
+    axi_rsp.r.data   = r_data;
+    axi_rsp.r.last   = 1'b1;
+    axi_rsp.aw_ready = aw_ready;
+    axi_rsp.w_ready  = w_ready;
+    axi_rsp.b_valid  = b_valid;
+    @(posedge clk);
+  endtask
+
+  int fail = 0;
+
+  initial begin
+    // ---- Reset ----
+    rst_n  = 0; req = 0; we = 0;
+    addr   = '0; wdata = '0; funct3 = 3'b010;
+    axi_rsp = '0;
+    @(posedge clk); @(posedge clk);
+    rst_n = 1;
+    @(posedge clk);
+
+    // ==============================================================
+    // TEST 1: LW — load word, 1-cycle AR latency, 1-cycle R latency
+    // ==============================================================
+    req = 1; we = 0; addr = 32'h0000_0100; funct3 = 3'b010; // LW
+
+    // Tick 1: IDLE → LOAD_ADDR.  ar_valid is driven; slave not yet ready.
+    tick(0,0,0, 0,0,0);
+    check(axi_req.ar_valid,                    "T1: ar_valid not asserted in LOAD_ADDR");
+    check(axi_req.ar.addr == 32'h0000_0100,    "T1: ar_addr wrong");
+    check(mem_stall,                           "T1: mem_stall should be asserted");
+    check(!valid,                              "T1: valid should not be asserted");
+
+    // Tick 2: LOAD_ADDR → LOAD_DATA.  Slave accepts AR (ar_ready=1).
+    tick(1,0,0, 0,0,0);
+    check(!axi_req.ar_valid,  "T1: ar_valid should be 0 in LOAD_DATA");
+    check(axi_req.r_ready,    "T1: r_ready should be 1 in LOAD_DATA");
+
+    // Tick 3: LOAD_DATA → LOAD_DONE.  Slave sends read data.
+    tick(0, 1, 32'hDEAD_BEEF, 0,0,0);
+    check(valid,                   "T1: valid should be asserted in LOAD_DONE");
+    check(!mem_stall,              "T1: mem_stall should clear in LOAD_DONE");
+    check(rdata == 32'hDEAD_BEEF,  "T1: rdata wrong");
+
+    // De-assert req → LSU returns to IDLE
+    req = 0;
+    tick(0,0,0, 0,0,0);
+    check(!valid, "T1: valid should clear after req=0");
+    $display("TEST 1 PASS: LW");
+
+    // ==============================================================
+    // TEST 2: SW — store word
+    // ==============================================================
+    req = 1; we = 1; addr = 32'h0000_0200; wdata = 32'h1234_5678; funct3 = 3'b010; // SW
+
+    // Tick 1: IDLE → STORE_SEND.  AW and W should both be asserted.
+    tick(0,0,0, 0,0,0);
+    check(axi_req.aw_valid,                          "T2: aw_valid not asserted");
+    check(axi_req.w_valid,                           "T2: w_valid not asserted");
+    check(axi_req.aw.addr == 32'h0000_0200,          "T2: aw_addr wrong");
+    check(axi_req.w.data  == 32'h1234_5678,          "T2: w_data wrong");
+    check(axi_req.w.strb  == 4'hF,                   "T2: w_strb wrong for SW");
+    check(axi_req.w.last,                            "T2: w_last should be 1");
+    check(mem_stall,                                 "T2: mem_stall should be asserted");
+
+    // Tick 2: STORE_SEND → STORE_RESP.  Slave accepts AW and W simultaneously.
+    tick(0,0,0, 1,1,0);
+    check(!axi_req.aw_valid,  "T2: aw_valid should clear after aw_ready");
+    check(!axi_req.w_valid,   "T2: w_valid should clear after w_ready");
+    check(axi_req.b_ready,    "T2: b_ready should be asserted in STORE_RESP");
+
+    // Tick 3: STORE_RESP → STORE_DONE.  Slave sends B response.
+    tick(0,0,0, 0,0,1);
+    check(valid,     "T2: valid should fire in STORE_DONE");
+    check(!mem_stall, "T2: mem_stall should clear in STORE_DONE");
+
+    req = 0;
+    tick(0,0,0, 0,0,0);
+    check(!valid, "T2: valid should clear after req=0");
+    $display("TEST 2 PASS: SW");
+
+    // ==============================================================
+    // TEST 3: LB — load byte, sign-extend from byte 1 (addr=0x101)
+    // ==============================================================
+    req = 1; we = 0; addr = 32'h0000_0101; funct3 = 3'b000; // LB
+    tick(0,0,0, 0,0,0);           // IDLE → LOAD_ADDR
+    tick(1,0,0, 0,0,0);           // LOAD_ADDR → LOAD_DATA (AR accepted)
+    // r_data: raw word = 32'h0000_8F00 → byte 1 = 0x8F → sign-extended = 32'hFFFF_FF8F
+    tick(0, 1, 32'h0000_8F00, 0,0,0); // LOAD_DATA → LOAD_DONE
+    check(rdata == 32'hFFFF_FF8F,  "T3: LB sign-extension wrong");
+    req = 0;
+    tick(0,0,0, 0,0,0);           // LOAD_DONE → IDLE
+    $display("TEST 3 PASS: LB sign-extend");
+
+    // ==============================================================
+    // TEST 4: AW and W accepted in different cycles
+    // ==============================================================
+    req = 1; we = 1; addr = 32'h0000_0300; wdata = 32'hABCD_EF01; funct3 = 3'b010;
+    tick(0,0,0, 0,0,0);  // IDLE → STORE_SEND (nothing accepted yet)
+    // Accept AW only
+    tick(0,0,0, 1,0,0);
+    check(!axi_req.aw_valid,  "T4: aw_valid should clear after aw_ready");
+    check(axi_req.w_valid,    "T4: w_valid should still be asserted");
+    // Accept W
+    tick(0,0,0, 0,1,0);
+    check(!axi_req.w_valid,  "T4: w_valid should clear after w_ready");
+    check(axi_req.b_ready,   "T4: b_ready should be asserted");
+    // B fires
+    tick(0,0,0, 0,0,1);
+    check(valid, "T4: valid should fire");
+    req = 0;
+    tick(0,0,0, 0,0,0);
+    $display("TEST 4 PASS: AW/W split acceptance");
+
+    // ==============================================================
+    // TEST 5: Back-to-back (LW then SW)
+    // ==============================================================
+    // LW
+    req = 1; we = 0; addr = 32'h0000_0400; funct3 = 3'b010;
+    tick(0,0,0, 0,0,0);            // IDLE → LOAD_ADDR
+    tick(1,0,0, 0,0,0);            // LOAD_ADDR → LOAD_DATA
+    tick(0,1,32'hCAFE_F00D, 0,0,0); // LOAD_DATA → LOAD_DONE
+    check(rdata == 32'hCAFE_F00D,  "T5: LW rdata wrong");
+    // Release LOAD_DONE
+    we = 1; addr = 32'h0000_0500; wdata = 32'hBEEF_CAFE;
+    req = 0;
+    tick(0,0,0, 0,0,0); // LOAD_DONE → IDLE
+    // SW
+    req = 1;
+    tick(0,0,0, 0,0,0);  // IDLE → STORE_SEND
+    tick(0,0,0, 1,1,0);  // STORE_SEND → STORE_RESP
+    tick(0,0,0, 0,0,1);  // STORE_RESP → STORE_DONE
+    check(valid, "T5: SW valid should fire");
+    req = 0;
+    tick(0,0,0, 0,0,0);
+    $display("TEST 5 PASS: back-to-back LW->SW");
+
+    if (fail == 0) begin
+      $display("ALL TESTS PASSED");
+      $finish(0);
+    end else begin
+      $finish(1);
+    end
+  end
+
+  // Timeout watchdog
+  initial begin
+    #50000;
+    $display("TIMEOUT");
+    $finish(1);
+  end
+endmodule


### PR DESCRIPTION
## Summary

- Replace OBI bus interface with native AXI4 on both instruction-fetch and data ports
- New 7-state AXI4 LSU FSM handles loads and stores with byte granularity and back-to-back sequencing
- New 2-state instruction-fetch FSM in `kronos_top` (stage3); `mem_done_q` prevents LSU re-issue; `trap_i`/`mret_i` gated by `~combined_stall` so interrupts are only taken when the pipeline is advancing
- Verilator simulation harness extended with configurable per-channel latency and an IRQ hold counter
- All 13 regression tests pass at latency=(1,1) and latency=(2,4)

## Changes

| File | Change |
|------|--------|
| `rtl/kronos_pkg.sv` | PULP AXI4 typedefs (`kronos_axi_req_t` / `kronos_axi_resp_t`) |
| `rtl/stage3/kronos_lsu.sv` | New — AXI4 LSU, 7-state FSM |
| `rtl/stage3/kronos_top.sv` | New — stage3 top, 2-state fetch FSM |
| `sim/sim_top.sv` | New — flat AXI4 port unpacker for Verilator |
| `sim/sim_main.cpp` | AXI4 memory model, configurable latency, IRQ countdown |
| `sim/Makefile` | stage3 build and compliance targets |
| `sw/stage3/Makefile` | stage3 software build skeleton |
| `tb/stage3/tb_lsu_s3.sv` | New — 5-test AXI4 LSU unit bench |
| `docs/`, `README.md` | Status update |

## Test plan

- [ ] `make sim-lsu-s3` — AXI4 LSU unit tests (5 tests)
- [ ] `make sim-compliance-s3` — full regression at latency=1 (13 tests)
- [ ] Custom latency loop `make run-s3-latency-<test>` at INSTR_LAT=2, DATA_LAT=4 (13 tests)