### PR TITLE
fix: set default FuseSoC target to stage3

### DIFF
--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -76,7 +76,7 @@ filesets:
 
 targets:
   default:
-    filesets: [files_rtl_s2]
+    filesets: [files_rtl_s3]
     toplevel: kronos_top
 
   lint:


### PR DESCRIPTION
## Summary
- Updates the default FuseSoC target in `kronos_riscv.core` to point to `files_rtl_s3` instead of `files_rtl_s2`, reflecting that stage3 is the active development stage.

## Test plan
- [ ] Verify `fusesoc --cores-root=. run --target=lint opensoc:ip:kronos_riscv` resolves to stage3 RTL after merge