### PR TITLE
feat(stage3): C extension + branch predictor + AXI4 bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ all stages; RV64 support is added at Stage 4.
 | 0     | Single-cycle golden model                       | RV32I            | OBI     | Complete    |
 | 1     | 5-stage in-order pipeline                       | RV32I            | OBI     | Complete    |
 | 2     | M extension + CSR hardening                     | RV32IM           | OBI     | Complete    |
-| 3     | AXI4 switch + C extension + branch predictor   | RV32IMC          | AXI4    | In progress |
+| 3     | AXI4 switch + C extension + branch predictor   | RV32IMC          | AXI4    | Complete    |
 | 4     | RV64I + A extension                             | RV64IMAC         | AXI4    | Planned     |
 | 5     | F/D extensions (floating point)                 | RV64IMAFDС       | AXI4    | Planned     |
 | 6     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
@@ -61,7 +61,11 @@ kronos-riscv/
 │   │   ├── kronos_muldiv.sv   # Multi-cycle mul/div FSM (2–34 cycles)
 │   │   └── kronos_top.sv      # Stage2 pipeline top (muldiv + combined stall)
 │   └── stage3/                # Stage 3: AXI4 bus + C extension + branch predictor
-│       └── kronos_lsu.sv      # AXI4 LSU (single-outstanding, replaces OBI LSU)
+│       ├── kronos_lsu.sv      # AXI4 LSU (single-outstanding, replaces OBI LSU)
+│       ├── kronos_decompress.sv # RV32C 16-bit → 32-bit instruction expander
+│       ├── kronos_align.sv    # Fetch alignment buffer (variable-width instructions)
+│       ├── kronos_bpred.sv    # Bimodal branch predictor with BTB
+│       └── kronos_top.sv      # Stage3 pipeline top (AXI4 + C ext + bpred)
 ├── tb/
 │   ├── tb_pkg.sv              # Shared testbench utilities
 │   ├── stage0/                # Stage 0 testbenches
@@ -76,7 +80,7 @@ kronos-riscv/
 ├── sim/
 │   ├── Makefile               # Verilator build and run targets
 │   └── sim_main.cpp           # C++ simulation driver
-├── kronos_riscv.core          # FuseSoC core descriptor (active: stage2)
+├── kronos_riscv.core          # FuseSoC core descriptor (active: stage3)
 ├── LICENSE
 └── CLAUDE.md                  # Claude Code project instructions
 ```
@@ -103,25 +107,24 @@ fusesoc --cores-root=. run --target=lint-s1 opensoc:ip:kronos_riscv
 fusesoc --cores-root=. run --target=lint-s0 opensoc:ip:kronos_riscv
 
 # Build simulators
+cd sim && make build-s3   # stage 3 (RV32IMC, AXI4)
 cd sim && make build-s2   # stage 2 (RV32IM)
 cd sim && make build-s1   # stage 1 (RV32I)
 
-# Run a stage 2 test
-cd sim && make run-s2-test_mul
-cd sim && make run-s2-test_div
-cd sim && make run-s2-test_muldiv_hazards
-cd sim && make run-s2-test_irq
+# Run a stage 3 test
+cd sim && make run-s3-test_c_basic
+cd sim && make run-s3-test_c_control
+cd sim && make run-s3-test_bpred_loop
 
-# Muldiv unit test
+# Stage 3 unit testbenches
+cd sim && make sim-decompress  # RV32C instruction expander
+cd sim && make sim-bpred       # branch predictor
+cd sim && make sim-lsu-s3      # AXI4 LSU
+
+# Stage 2 unit testbenches
 cd sim && make sim-muldiv
 
-# Full regression (stage 2 simulator, all sw/ programs + rv32ui compliance)
-cd sim && make sim-compliance
-
-# Full stage 1 regression (unit tests + rv32ui compliance)
-cd sim && make sim-compliance-s1
-
-# Unit tests
+# Stage 1 unit testbenches
 cd sim && make sim-forward   # forwarding unit
 cd sim && make sim-hazard    # hazard/stall control
 cd sim && make sim-lsu-s1    # LSU OBI FSM

--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -57,6 +57,9 @@ filesets:
       - rtl/stage1/kronos_forward.sv
       - rtl/stage1/kronos_hazard.sv
       - rtl/stage2/kronos_muldiv.sv
+      - rtl/stage3/kronos_decompress.sv
+      - rtl/stage3/kronos_align.sv
+      - rtl/stage3/kronos_bpred.sv
       - rtl/stage3/kronos_top.sv
     file_type: systemVerilogSource
 

--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -111,10 +111,25 @@ package kronos_pkg;
     FWD_MEMWB = 2'd2    // forward from WB mux output
   } fwd_sel_e;
 
+  // -------------------------------------------------------------------------
+  // Stage 3: compressed instruction and branch predictor types
+  // -------------------------------------------------------------------------
+
+  // BTB entry (16-entry direct-mapped, indexed by pc[5:2])
+  typedef struct packed {
+    logic        valid;
+    logic [25:0] tag;    // pc[31:6] — distinguishes aliased entries
+    logic [31:0] target; // predicted branch/jump target
+  } btb_entry_t;
+
   typedef struct packed {
     logic [31:0] pc;
     logic [31:0] instr;
     logic        valid;
+    // Stage 3+
+    logic        is_16b;      // instruction was 16-bit (C extension); PC+2, not PC+4
+    logic        pred_taken;  // branch predictor predicted taken
+    logic [31:0] pred_target; // predicted target (valid when pred_taken=1)
   } if_id_reg_t;
 
   typedef struct packed {
@@ -123,6 +138,10 @@ package kronos_pkg;
     logic [31:0]    rs1_data;
     logic [31:0]    rs2_data;
     logic           valid;
+    // Stage 3+
+    logic        is_16b;
+    logic        pred_taken;
+    logic [31:0] pred_target;
   } id_ex_reg_t;
 
   typedef struct packed {
@@ -134,6 +153,8 @@ package kronos_pkg;
     logic [31:0]    csr_rdata;
     logic           redirect;
     logic           valid;
+    // Stage 3+
+    logic           is_16b;   // needed so WB computes correct pc4 link address
   } ex_mem_reg_t;
 
   typedef struct packed {

--- a/rtl/stage3/kronos_align.sv
+++ b/rtl/stage3/kronos_align.sv
@@ -1,0 +1,164 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_align.sv — Fetch alignment buffer for RV32C variable-width instructions.
+//
+// Three primary states (encoded in buf_valid_q and need_upper_q):
+//   NORMAL     : buf_valid_q=0, need_upper_q=0
+//   BUFFERED   : buf_valid_q=1, need_upper_q=0  (upper half of prev word in buf)
+//   NEED_UPPER : buf_valid_q=1, need_upper_q=1  (lower half of 32-bit spanning insn in buf)
+//
+// Additional state:
+//   skip_lower_q: set on flush when pc_offset_i=1 (flush to halfword-aligned address).
+//     On the next r_valid, skip the lower 16 bits and buffer the upper 16 bits instead.
+//
+// align_stall_o / align_need_upper_o: registered, avoid comb loop with hazard.
+// align_needs_fetch_o: combinational — deasserted only in BUFFERED state.
+//   Used to gate ar_valid in kronos_top so we don't re-fetch words already buffered.
+module kronos_align (
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic [31:0] rdata_i,
+  input  logic        rvalid_i,
+  input  logic        stall_i,        // hold state when pipeline can't accept output
+  input  logic        flush_i,
+  input  logic        pc_offset_i,    // ex_pc_next[1]: skip lower half of next fetch
+  output logic [31:0] instr_o,
+  output logic        instr_valid_o,
+  output logic        is_16b_o,
+  output logic        align_stall_o,
+  output logic        align_need_upper_o,
+  output logic        align_needs_fetch_o
+);
+  // -------------------------------------------------------------------------
+  // State registers
+  // -------------------------------------------------------------------------
+  logic        buf_valid_q;
+  logic [15:0] buf_data_q;
+  logic        need_upper_q;
+  logic        skip_lower_q;  // skip lower half of next fetched word (halfword-aligned flush)
+
+  // Combinational from decompress instances
+  logic [31:0] decomp_lower, decomp_upper, decomp_buf;
+  logic        decomp_lower_ill, decomp_upper_ill, decomp_buf_ill;
+
+  kronos_decompress u_decomp_lower (
+    .instr16_i (rdata_i[15:0]),
+    .instr32_o (decomp_lower),
+    .illegal_o (decomp_lower_ill)
+  );
+  kronos_decompress u_decomp_upper (
+    .instr16_i (rdata_i[31:16]),
+    .instr32_o (decomp_upper),
+    .illegal_o (decomp_upper_ill)
+  );
+  kronos_decompress u_decomp_buf (
+    .instr16_i (buf_data_q),
+    .instr32_o (decomp_buf),
+    .illegal_o (decomp_buf_ill)
+  );
+
+  // -------------------------------------------------------------------------
+  // Output logic (combinational)
+  // -------------------------------------------------------------------------
+  always_comb begin
+    instr_o            = '0;
+    instr_valid_o      = 1'b0;
+    is_16b_o           = 1'b0;
+    align_stall_o      = need_upper_q;
+    align_need_upper_o = need_upper_q;
+
+    if (skip_lower_q) begin
+      // Waiting for first post-flush word, will skip lower half
+      instr_valid_o = 1'b0;
+    end else if (need_upper_q) begin
+      // NEED_UPPER: combine buf (lower 16) with rdata[15:0] (upper 16)
+      if (rvalid_i) begin
+        instr_o       = {rdata_i[15:0], buf_data_q};
+        instr_valid_o = 1'b1;
+        is_16b_o      = 1'b0;
+      end
+    end else if (buf_valid_q) begin
+      // BUFFERED: emit instruction from buffer
+      if (buf_data_q[1:0] != 2'b11) begin
+        instr_o       = decomp_buf;
+        instr_valid_o = 1'b1;
+        is_16b_o      = 1'b1;
+      end
+      // else: buffer has lower half of 32-bit spanning insn
+      // need_upper_q will be set on next clock edge (FF block below)
+    end else begin
+      // NORMAL: use rdata directly
+      if (rvalid_i) begin
+        instr_valid_o = 1'b1;
+        if (rdata_i[1:0] != 2'b11) begin
+          instr_o  = decomp_lower;
+          is_16b_o = 1'b1;
+        end else begin
+          instr_o  = rdata_i;
+          is_16b_o = 1'b0;
+        end
+      end
+    end
+  end
+
+  // align_needs_fetch_o: deasserted only in BUFFERED state (buffer has instruction ready)
+  assign align_needs_fetch_o = ~buf_valid_q | need_upper_q;
+
+  // -------------------------------------------------------------------------
+  // State update (sequential)
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      buf_valid_q  <= 1'b0;
+      buf_data_q   <= '0;
+      need_upper_q <= 1'b0;
+      skip_lower_q <= 1'b0;
+    end else if (flush_i) begin
+      buf_valid_q  <= 1'b0;
+      buf_data_q   <= '0;
+      need_upper_q <= 1'b0;
+      skip_lower_q <= pc_offset_i;
+    end else if (!stall_i) begin
+      // ---- Handle NEED_UPPER: clear on r_valid regardless of align_stall_o ----
+      // (align_stall_o = need_upper_q, so we must not gate on !align_stall_o here)
+      // After combining, the upper half of the fetched word is the start of the
+      // next instruction — buffer it to avoid re-fetching the same word.
+      if (need_upper_q) begin
+        if (rvalid_i) begin
+          buf_valid_q  <= 1'b1;
+          buf_data_q   <= rdata_i[31:16];
+          need_upper_q <= 1'b0;
+        end
+      end else if (skip_lower_q) begin
+        // ---- skip_lower: buffer the upper half of first post-flush word ----
+        if (rvalid_i) begin
+          skip_lower_q <= 1'b0;
+          buf_valid_q  <= 1'b1;
+          buf_data_q   <= rdata_i[31:16];
+        end
+      end else if (!align_stall_o) begin
+        // ---- NORMAL / BUFFERED: advance state ----
+        if (buf_valid_q) begin
+          if (buf_data_q[1:0] != 2'b11) begin
+            // Consumed 16-bit from buffer; back to NORMAL
+            buf_valid_q <= 1'b0;
+          end else begin
+            // Buffer holds lower 16 of 32-bit spanning insn; transition to NEED_UPPER
+            need_upper_q <= 1'b1;
+          end
+        end else if (rvalid_i) begin
+          // NORMAL: process incoming word
+          if (rdata_i[1:0] != 2'b11) begin
+            // 16-bit at lower half; buffer upper half
+            buf_valid_q <= 1'b1;
+            buf_data_q  <= rdata_i[31:16];
+          end
+          // else: 32-bit, no buffering
+        end
+      end
+    end
+  end
+
+endmodule

--- a/rtl/stage3/kronos_bpred.sv
+++ b/rtl/stage3/kronos_bpred.sv
@@ -1,0 +1,106 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_bpred.sv — Bimodal branch predictor with Branch Target Buffer.
+//
+// Bimodal table: 2^BPRED_BITS entries of 2-bit saturating counters.
+//   Index:  pc[BPRED_BITS+1:2]
+//   Predict taken when counter[1]=1 (10 or 11)
+//
+// BTB: 2^BTB_BITS direct-mapped entries.
+//   Index:  pc[BTB_BITS+1:2]
+//   Tag:    pc[31:BTB_BITS+2]
+//   Hit:    entry.valid && (entry.tag == pc[31:BTB_BITS+2])
+//
+// Prediction: pred_taken = BTB hit AND counter MSB=1.
+// Updates happen one cycle after EX (registered write).
+module kronos_bpred
+  import kronos_pkg::*;
+#(
+  parameter int unsigned BPRED_BITS = 6,
+  parameter int unsigned BTB_BITS   = 4
+)
+(
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  // Prediction port (combinational)
+  input  logic [31:0] pc_i,
+  output logic        pred_taken_o,
+  output logic [31:0] pred_target_o,
+  // Update port (registered — fires when a branch resolves)
+  input  logic        upd_valid_i,
+  input  logic [31:0] upd_pc_i,
+  input  logic        upd_taken_i,
+  input  logic [31:0] upd_target_i,
+  input  logic        upd_is_jal_i    // JAL always taken — skip counter update
+);
+  localparam int unsigned BPRED_ENTRIES = 1 << BPRED_BITS;
+  localparam int unsigned BTB_ENTRIES   = 1 << BTB_BITS;
+  localparam int unsigned BTB_TAG_BITS  = 32 - BTB_BITS - 2;
+
+  // 2-bit saturating counters (one per bimodal table entry)
+  logic [1:0] counters [BPRED_ENTRIES];
+
+  // BTB (direct-mapped)
+  btb_entry_t btb [BTB_ENTRIES];
+
+  // Lookup index signals
+  logic [BPRED_BITS-1:0]     lookup_idx;
+  logic [BTB_BITS-1:0]       lookup_btb_idx;
+  logic [BTB_TAG_BITS-1:0]   lookup_tag;
+
+  // Update index signals
+  logic [BPRED_BITS-1:0]     update_idx;
+  logic [BTB_BITS-1:0]       update_btb_idx;
+  logic [BTB_TAG_BITS-1:0]   update_tag;
+
+  // BTB lookup result
+  logic btb_hit;
+
+  assign lookup_idx     = pc_i[BPRED_BITS+1:2];
+  assign lookup_btb_idx = pc_i[BTB_BITS+1:2];
+  assign lookup_tag     = pc_i[31:BTB_BITS+2];
+
+  assign update_idx     = upd_pc_i[BPRED_BITS+1:2];
+  assign update_btb_idx = upd_pc_i[BTB_BITS+1:2];
+  assign update_tag     = upd_pc_i[31:BTB_BITS+2];
+
+  assign btb_hit       = btb[lookup_btb_idx].valid &&
+                         (btb[lookup_btb_idx].tag == BTB_TAG_BITS'(lookup_tag));
+  assign pred_taken_o  = btb_hit && counters[lookup_idx][1];
+  assign pred_target_o = btb[lookup_btb_idx].target;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      for (int i = 0; i < BPRED_ENTRIES; i++) counters[i] <= 2'b01; // weak NT
+      for (int i = 0; i < BTB_ENTRIES;   i++) btb[i]      <= '0;
+    end else if (upd_valid_i) begin
+      // Update 2-bit saturating counter — only for conditional branches, not JAL
+      if (!upd_is_jal_i) begin
+        if (upd_taken_i) begin
+          if (counters[update_idx] != 2'b11)
+            counters[update_idx] <= counters[update_idx] + 2'd1;
+        end else begin
+          if (counters[update_idx] != 2'b00)
+            counters[update_idx] <= counters[update_idx] - 2'd1;
+        end
+      end
+
+      // Update BTB: write on taken or JAL; clear only when counter saturates at 00
+      if (upd_taken_i || upd_is_jal_i) begin
+        btb[update_btb_idx].valid  <= 1'b1;
+        btb[update_btb_idx].tag    <= BTB_TAG_BITS'(update_tag);
+        btb[update_btb_idx].target <= upd_target_i;
+      end else begin
+        // Not-taken conditional branch: counter will decrement to 00 — invalidate BTB entry
+        if (counters[update_idx] == 2'b01) begin
+          if (btb[update_btb_idx].valid &&
+              btb[update_btb_idx].tag == BTB_TAG_BITS'(update_tag))
+            btb[update_btb_idx].valid <= 1'b0;
+        end
+      end
+    end
+  end
+
+endmodule

--- a/rtl/stage3/kronos_decompress.sv
+++ b/rtl/stage3/kronos_decompress.sv
@@ -1,0 +1,243 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decompress.sv — RV32C 16-bit instruction expander.
+// Purely combinational. Returns the 32-bit canonical RV32I equivalent.
+// Sets illegal_o=1 for reserved or undefined encodings.
+module kronos_decompress (
+  input  logic [15:0] instr16_i,
+  output logic [31:0] instr32_o,
+  output logic        illegal_o
+);
+  logic [2:0]  funct3;
+  logic [4:0]  rd,  rs1,  rs2;
+  logic [2:0]  rd_p, rs1_p, rs2_p;
+
+  assign funct3 = instr16_i[15:13];
+  assign rd     = instr16_i[11:7];
+  assign rs1    = instr16_i[11:7];
+  assign rs2    = instr16_i[6:2];
+  assign rd_p   = instr16_i[4:2];
+  assign rs1_p  = instr16_i[9:7];
+  assign rs2_p  = instr16_i[4:2];
+
+  logic [4:0] rd_full, rs1_full, rs2_full;
+  assign rd_full  = {2'b01, rd_p};
+  assign rs1_full = {2'b01, rs1_p};
+  assign rs2_full = {2'b01, rs2_p};
+
+  localparam logic [6:0] OP_IMM   = 7'b001_0011;
+  localparam logic [6:0] OP_LUI   = 7'b011_0111;
+  localparam logic [6:0] OP_JAL   = 7'b110_1111;
+  localparam logic [6:0] OP_JALR  = 7'b110_0111;
+  localparam logic [6:0] OP_LOAD  = 7'b000_0011;
+  localparam logic [6:0] OP_STORE = 7'b010_0011;
+  localparam logic [6:0] OP_BRNCH = 7'b110_0011;
+  localparam logic [6:0] OP_REG   = 7'b011_0011;
+
+  // Temporary signals for immediate assembly (shared across case arms — only one active at a time)
+  logic [11:0] uimm;
+  logic [31:0] nzimm;
+  logic [31:0] imm;
+  logic [31:0] off;
+  logic [5:0]  shamt;
+
+  always_comb begin
+    instr32_o = '0;
+    illegal_o = 1'b0;
+
+    unique case (instr16_i[1:0])
+
+      // ---------------------------------------------------------------
+      // Quadrant 0
+      // ---------------------------------------------------------------
+      2'b00: begin
+        unique case (funct3)
+
+          3'b000: begin  // C.ADDI4SPN → ADDI rd', x2, nzuimm
+            uimm = {2'b0, instr16_i[10:7], instr16_i[12:11],
+                    instr16_i[5], instr16_i[6], 2'b0};
+            if (uimm == '0) illegal_o = 1'b1;
+            else instr32_o = {uimm, 5'd2, 3'b000, rd_full, OP_IMM};
+          end
+
+          3'b010: begin  // C.LW → LW rd', offset(rs1')
+            uimm = {5'b0, instr16_i[5], instr16_i[12:10], instr16_i[6], 2'b0};
+            instr32_o = {uimm, rs1_full, 3'b010, rd_full, OP_LOAD};
+          end
+
+          3'b110: begin  // C.SW → SW rs2', offset(rs1')
+            uimm = {5'b0, instr16_i[5], instr16_i[12:10], instr16_i[6], 2'b0};
+            instr32_o = {uimm[11:5], rs2_full, rs1_full, 3'b010,
+                         uimm[4:0], OP_STORE};
+          end
+
+          default: illegal_o = 1'b1;
+        endcase
+      end
+
+      // ---------------------------------------------------------------
+      // Quadrant 1
+      // ---------------------------------------------------------------
+      2'b01: begin
+        unique case (funct3)
+
+          3'b000: begin  // C.NOP / C.ADDI → ADDI rd, rd, nzimm
+            nzimm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            instr32_o = {nzimm[11:0], rd, 3'b000, rd, OP_IMM};
+          end
+
+          3'b001: begin  // C.JAL → JAL x1, offset
+            imm = {{10{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
+                   instr16_i[6], instr16_i[7], instr16_i[2], instr16_i[11],
+                   instr16_i[5:3], 1'b0};
+            instr32_o = {imm[20], imm[10:1], imm[11], imm[19:12],
+                         5'd1, OP_JAL};
+          end
+
+          3'b010: begin  // C.LI → ADDI rd, x0, imm
+            imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            instr32_o = {imm[11:0], 5'd0, 3'b000, rd, OP_IMM};
+          end
+
+          3'b011: begin  // C.LUI / C.ADDI16SP
+            if (rd == 5'd2) begin  // C.ADDI16SP → ADDI x2, x2, nzimm
+              nzimm = {{23{instr16_i[12]}}, instr16_i[4:3], instr16_i[5],
+                       instr16_i[2], instr16_i[6], 4'b0};
+              if (nzimm == '0) illegal_o = 1'b1;
+              else instr32_o = {nzimm[11:0], 5'd2, 3'b000, 5'd2, OP_IMM};
+            end else begin  // C.LUI → LUI rd, nzimm
+              nzimm = {{15{instr16_i[12]}}, instr16_i[6:2], 12'b0};
+              if (nzimm == '0) illegal_o = 1'b1;
+              else instr32_o = {nzimm[31:12], rd, OP_LUI};
+            end
+          end
+
+          3'b100: begin  // C.SRLI / C.SRAI / C.ANDI / C.SUB/XOR/OR/AND
+            shamt = {instr16_i[12], instr16_i[6:2]};
+            unique case (instr16_i[11:10])
+
+              2'b00: begin  // C.SRLI → SRLI rs1', rs1', shamt
+                if (shamt == 6'd0) illegal_o = 1'b1;
+                else instr32_o = {7'b000_0000, shamt[4:0], rs1_full,
+                                  3'b101, rs1_full, OP_IMM};
+              end
+
+              2'b01: begin  // C.SRAI → SRAI rs1', rs1', shamt
+                if (shamt == 6'd0) illegal_o = 1'b1;
+                else instr32_o = {7'b010_0000, shamt[4:0], rs1_full,
+                                  3'b101, rs1_full, OP_IMM};
+              end
+
+              2'b10: begin  // C.ANDI → ANDI rs1', rs1', imm
+                imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+                instr32_o = {imm[11:0], rs1_full, 3'b111, rs1_full, OP_IMM};
+              end
+
+              2'b11: begin  // C.SUB / C.XOR / C.OR / C.AND (only RV32)
+                if (instr16_i[12] != 1'b0) begin
+                  illegal_o = 1'b1;  // C.SUBW / C.ADDW reserved in RV32
+                end else begin
+                  unique case (instr16_i[6:5])
+                    2'b00: instr32_o = {7'b010_0000, rs2_full, rs1_full,
+                                        3'b000, rs1_full, OP_REG};  // C.SUB
+                    2'b01: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b100, rs1_full, OP_REG};  // C.XOR
+                    2'b10: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b110, rs1_full, OP_REG};  // C.OR
+                    2'b11: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b111, rs1_full, OP_REG};  // C.AND
+                    default: illegal_o = 1'b1;
+                  endcase
+                end
+              end
+
+              default: illegal_o = 1'b1;
+            endcase
+          end
+
+          3'b101: begin  // C.J → JAL x0, offset
+            imm = {{10{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
+                   instr16_i[6], instr16_i[7], instr16_i[2], instr16_i[11],
+                   instr16_i[5:3], 1'b0};
+            instr32_o = {imm[20], imm[10:1], imm[11], imm[19:12],
+                         5'd0, OP_JAL};
+          end
+
+          3'b110: begin  // C.BEQZ → BEQ rs1', x0, offset
+            off = {{24{instr16_i[12]}}, instr16_i[6:5], instr16_i[2],
+                   instr16_i[11:10], instr16_i[4:3], 1'b0};
+            instr32_o = {off[12], off[10:5], 5'd0, rs1_full, 3'b000,
+                         off[4:1], off[11], OP_BRNCH};
+          end
+
+          3'b111: begin  // C.BNEZ → BNE rs1', x0, offset
+            off = {{24{instr16_i[12]}}, instr16_i[6:5], instr16_i[2],
+                   instr16_i[11:10], instr16_i[4:3], 1'b0};
+            instr32_o = {off[12], off[10:5], 5'd0, rs1_full, 3'b001,
+                         off[4:1], off[11], OP_BRNCH};
+          end
+
+          default: illegal_o = 1'b1;
+        endcase
+      end
+
+      // ---------------------------------------------------------------
+      // Quadrant 2
+      // ---------------------------------------------------------------
+      2'b10: begin
+        unique case (funct3)
+
+          3'b000: begin  // C.SLLI → SLLI rd, rd, shamt
+            shamt = {instr16_i[12], instr16_i[6:2]};
+            if (shamt == 6'd0 || rd == 5'd0) illegal_o = 1'b1;
+            else instr32_o = {7'b000_0000, shamt[4:0], rd, 3'b001, rd, OP_IMM};
+          end
+
+          3'b010: begin  // C.LWSP → LW rd, offset(x2)
+            uimm = {4'b0, instr16_i[3:2], instr16_i[12], instr16_i[6:4], 2'b0};
+            if (rd == 5'd0) illegal_o = 1'b1;
+            else instr32_o = {uimm, 5'd2, 3'b010, rd, OP_LOAD};
+          end
+
+          3'b100: begin  // C.JR / C.MV / C.EBREAK / C.JALR / C.ADD
+            if (instr16_i[12] == 1'b0) begin
+              if (rs2 == 5'd0 && rs1 != 5'd0) begin
+                instr32_o = {12'd0, rs1, 3'b000, 5'd0, OP_JALR};  // C.JR
+              end else if (rs2 != 5'd0) begin
+                instr32_o = {7'b000_0000, rs2, 5'd0, 3'b000, rd, OP_REG};  // C.MV
+              end else begin
+                illegal_o = 1'b1;
+              end
+            end else begin
+              if (rs1 == 5'd0 && rs2 == 5'd0) begin
+                instr32_o = 32'h00100073;  // C.EBREAK
+              end else if (rs2 == 5'd0 && rs1 != 5'd0) begin
+                instr32_o = {12'd0, rs1, 3'b000, 5'd1, OP_JALR};  // C.JALR
+              end else if (rs2 != 5'd0) begin
+                instr32_o = {7'b000_0000, rs2, rd, 3'b000, rd, OP_REG};  // C.ADD
+              end else begin
+                illegal_o = 1'b1;
+              end
+            end
+          end
+
+          3'b110: begin  // C.SWSP → SW rs2, offset(x2)
+            uimm = {4'b0, instr16_i[8:7], instr16_i[12:9], 2'b0};
+            instr32_o = {uimm[11:5], rs2, 5'd2, 3'b010, uimm[4:0], OP_STORE};
+          end
+
+          default: illegal_o = 1'b1;
+        endcase
+      end
+
+      // ---------------------------------------------------------------
+      // 2'b11 — 32-bit instruction, not a compressed encoding
+      // ---------------------------------------------------------------
+      default: illegal_o = 1'b1;
+
+    endcase
+  end
+
+endmodule

--- a/rtl/stage3/kronos_top.sv
+++ b/rtl/stage3/kronos_top.sv
@@ -75,6 +75,22 @@ module kronos_top
   logic         instr_fetch_stall;
   logic         combined_stall;
 
+  // STAGE3: C extension — alignment unit signals
+  logic [31:0] align_instr;
+  logic        align_instr_valid;
+  logic        align_is_16b;
+  logic        align_stall;
+  logic        align_need_upper;
+  logic        align_needs_fetch;
+
+  // STAGE3: branch predictor
+  logic        pred_taken;
+  logic [31:0] pred_target;
+  logic        bpred_update_en;
+  logic        actual_taken;
+  logic        bpred_mispredict;
+  logic        is_branch_or_jump;
+
   // -------------------------------------------------------------------------
   // MEM-stage wires
   // -------------------------------------------------------------------------
@@ -131,8 +147,8 @@ module kronos_top
 
   // STAGE3: combined_stall — mem_stall | muldiv_stall | instr_fetch_stall
   assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid;
-  // instr_fetch_stall: deasserts only on the cycle r_valid fires in FETCH_WAIT_R.
-  assign instr_fetch_stall = ~(fetch_state_q == FETCH_WAIT_R && instr_axi_rsp_i.r_valid);
+  // STAGE3: stall until the alignment unit has a valid instruction ready.
+  assign instr_fetch_stall = ~align_instr_valid;
   assign combined_stall    = mem_stall | muldiv_stall | instr_fetch_stall;
 
   kronos_hazard u_hazard (
@@ -176,7 +192,7 @@ module kronos_top
 
   assign ex_result = id_ex_q.dec.is_muldiv ? muldiv_result : alu_result;
 
-  kronos_csr #(.MISA_EXT(26'h1100)) u_csr (
+  kronos_csr #(.MISA_EXT(26'h1104)) u_csr (  // I+M+C bits
     .clk_i         (clk_i),
     .rst_ni        (rst_ni),
     .req_i         (id_ex_q.valid & id_ex_q.dec.is_csr),
@@ -226,11 +242,45 @@ module kronos_top
   assign data_axi_req_o = data_req;
   assign data_rsp       = data_axi_rsp_i;
 
+  kronos_align u_align (
+    .clk_i               (clk_i),
+    .rst_ni              (rst_ni),
+    .rdata_i             (instr_axi_rsp_i.r.data),
+    .rvalid_i            ((fetch_state_q == FETCH_WAIT_R) & instr_axi_rsp_i.r_valid),
+    .stall_i             (align_instr_valid & ~if_id_en),
+    .flush_i             (if_id_flush | (pred_taken & pc_en & ~ex_redirect)),
+    .pc_offset_i         (ex_redirect ? ex_pc_next[1]
+                        : pred_taken  ? pred_target[1]
+                        :               pc_q[1]),
+    .instr_o             (align_instr),
+    .instr_valid_o       (align_instr_valid),
+    .is_16b_o            (align_is_16b),
+    .align_stall_o       (align_stall),
+    .align_need_upper_o  (align_need_upper),
+    .align_needs_fetch_o (align_needs_fetch)
+  );
+
+  kronos_bpred u_bpred (
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .pc_i            (pc_q),
+    .pred_taken_o    (pred_taken),
+    .pred_target_o   (pred_target),
+    .upd_valid_i     (bpred_update_en),
+    .upd_pc_i        (id_ex_q.pc),
+    .upd_taken_i     (actual_taken),
+    .upd_target_i    (ex_pc_next),
+    .upd_is_jal_i    (id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr)
+  );
+
   // =========================================================================
   // PC register
   // =========================================================================
   logic [31:0] pc_next;
-  assign pc_next = ex_redirect ? ex_pc_next : pc_q + 32'd4;
+  assign pc_next = ex_redirect   ? ex_pc_next
+                 : pred_taken    ? pred_target
+                 : align_is_16b  ? pc_q + 32'd2
+                 :                 pc_q + 32'd4;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) pc_q <= boot_addr_i;
@@ -250,7 +300,7 @@ module kronos_top
     if (!rst_ni) fetch_state_q <= FETCH_IDLE;
     else begin
       unique case (fetch_state_q)
-        FETCH_IDLE:   if (instr_axi_rsp_i.ar_ready)  fetch_state_q <= FETCH_WAIT_R;
+        FETCH_IDLE:   if (instr_axi_req_o.ar_valid & instr_axi_rsp_i.ar_ready) fetch_state_q <= FETCH_WAIT_R;
         FETCH_WAIT_R: if (instr_axi_rsp_i.r_valid)   fetch_state_q <= FETCH_IDLE;
         default:      fetch_state_q <= FETCH_IDLE;
       endcase
@@ -263,8 +313,11 @@ module kronos_top
     instr_axi_req_o            = '0;
     unique case (fetch_state_q)
       FETCH_IDLE: begin
-        instr_axi_req_o.ar_valid  = rst_ni;
-        instr_axi_req_o.ar.addr   = pc_q;
+        // STAGE3: gate by align_needs_fetch; use next-word addr in NEED_UPPER
+        instr_axi_req_o.ar_valid  = rst_ni & align_needs_fetch;
+        instr_axi_req_o.ar.addr   = align_need_upper
+          ? {pc_q[31:2] + 30'd1, 2'b00}
+          : {pc_q[31:2], 2'b00};
         instr_axi_req_o.ar.size   = 3'b010;
         instr_axi_req_o.ar.burst  = axi_pkg::BURST_INCR;
       end
@@ -281,9 +334,12 @@ module kronos_top
     end else if (if_id_flush) begin
       if_id_q <= '0;
     end else if (if_id_en) begin
-      if_id_q.pc    <= pc_q;
-      if_id_q.instr <= instr_axi_rsp_i.r.data;
-      if_id_q.valid <= (fetch_state_q == FETCH_WAIT_R) & instr_axi_rsp_i.r_valid;
+      if_id_q.pc          <= pc_q;
+      if_id_q.instr       <= align_instr;
+      if_id_q.valid       <= align_instr_valid;
+      if_id_q.is_16b      <= align_is_16b;
+      if_id_q.pred_taken  <= pred_taken & ~ex_redirect;
+      if_id_q.pred_target <= pred_target;
     end
   end
 
@@ -296,11 +352,14 @@ module kronos_top
     end else if (id_ex_flush) begin
       id_ex_q <= '0;
     end else if (id_ex_en) begin
-      id_ex_q.pc       <= if_id_q.pc;
-      id_ex_q.dec      <= id_dec;
-      id_ex_q.rs1_data <= rs1_data_id;
-      id_ex_q.rs2_data <= rs2_data_id;
-      id_ex_q.valid    <= if_id_q.valid;
+      id_ex_q.pc          <= if_id_q.pc;
+      id_ex_q.dec         <= id_dec;
+      id_ex_q.rs1_data    <= rs1_data_id;
+      id_ex_q.rs2_data    <= rs2_data_id;
+      id_ex_q.valid       <= if_id_q.valid;
+      id_ex_q.is_16b      <= if_id_q.is_16b;
+      id_ex_q.pred_taken  <= if_id_q.pred_taken;
+      id_ex_q.pred_target <= if_id_q.pred_target;
     end
   end
 
@@ -360,13 +419,30 @@ module kronos_top
     else if (branch_taken)
       ex_pc_next = id_ex_q.pc + id_ex_q.dec.imm;
     else
-      ex_pc_next = id_ex_q.pc + 32'd4;
+      ex_pc_next = id_ex_q.is_16b ? id_ex_q.pc + 32'd2 : id_ex_q.pc + 32'd4;
   end
 
-  assign ex_redirect = id_ex_q.valid &
-    (id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr | branch_taken |
-     id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak | id_ex_q.dec.illegal |
-     id_ex_q.dec.is_mret  | irq_pending);
+  // STAGE3: branch predictor — misprediction detection and update
+  assign is_branch_or_jump = id_ex_q.dec.is_branch | id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr;
+  assign actual_taken = branch_taken | id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr;
+
+  assign bpred_mispredict = id_ex_q.valid & (
+    // Predicted taken but actually not taken (or not a branch/jump at all)
+    (id_ex_q.pred_taken & ~actual_taken) |
+    // Not predicted but actually taken
+    (~id_ex_q.pred_taken & actual_taken) |
+    // Both predicted and actually taken but wrong target
+    (id_ex_q.pred_taken & actual_taken & (id_ex_q.pred_target != ex_pc_next))
+  );
+
+  // Update predictor when a branch/jump leaves EX
+  assign bpred_update_en = id_ex_q.valid & ex_mem_en & is_branch_or_jump;
+
+  // STAGE3: redirect on misprediction or trap/mret (not on correct prediction)
+  assign ex_redirect = bpred_mispredict |
+    (id_ex_q.valid &
+     (id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak | id_ex_q.dec.illegal |
+      irq_pending | id_ex_q.dec.is_mret));
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -380,6 +456,7 @@ module kronos_top
       ex_mem_q.csr_rdata  <= csr_rdata;
       ex_mem_q.redirect   <= ex_redirect;
       ex_mem_q.valid      <= id_ex_q.valid & ~irq_pending;
+      ex_mem_q.is_16b     <= id_ex_q.is_16b;
     end
   end
 
@@ -414,7 +491,7 @@ module kronos_top
       // the pipeline advances after an earlier lsu_valid (mem_done_q=1).
       mem_wb_q.lsu_rdata  <= lsu_valid ? lsu_rdata : lsu_rdata_latch;
       mem_wb_q.csr_rdata  <= ex_mem_q.csr_rdata;
-      mem_wb_q.pc4        <= ex_mem_q.pc + 32'd4;
+      mem_wb_q.pc4        <= ex_mem_q.pc + (ex_mem_q.is_16b ? 32'd2 : 32'd4);
       mem_wb_q.valid      <= ex_mem_q.valid;
     end
   end

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -3,18 +3,24 @@ TB_DIR    := ../tb
 SW_DIR    := ../sw/stage0
 SW_DIR_S1 := ../sw/stage1
 SW_DIR_S2 := ../sw/stage2
+SW_DIR_S3 := ../sw/stage3
 OBJ_DIR   := obj_dir
 
 VERILATOR := verilator
 CFLAGS    := -std=c++14
 
 # --Wno-WIDTHEXPAND: suppress upstream axi_pkg.sv:203 width warning (PULP library bug)
-# This flag is required for all invocations that include axi_pkg.sv (stage3+)
+# PULP_AXI_INC / AXI_PKG_SV are required for all invocations: kronos_pkg.sv always
+# imports `AXI_TYPEDEF_ALL since the stage3 AXI switch plan.
+PULP_AXI_INC  := -I/home/popes/opensoc/hw/ip/pulp_axi/include
+AXI_PKG_SV    := /home/popes/opensoc/hw/ip/pulp_axi/src/axi_pkg.sv
+AXI_FLAGS     := $(PULP_AXI_INC) --Wno-WIDTHEXPAND
 
 TOP       := kronos_top
 SIM_BIN   := $(OBJ_DIR)/V$(TOP)
 
-SV_FILES  := $(RTL_DIR)/kronos_pkg.sv \
+SV_FILES  := $(AXI_PKG_SV) \
+             $(RTL_DIR)/kronos_pkg.sv \
              $(RTL_DIR)/stage0/kronos_alu.sv \
              $(RTL_DIR)/stage0/kronos_decode.sv \
              $(RTL_DIR)/stage0/kronos_regfile.sv \
@@ -22,31 +28,43 @@ SV_FILES  := $(RTL_DIR)/kronos_pkg.sv \
              $(RTL_DIR)/stage0/kronos_csr.sv \
              $(RTL_DIR)/stage0/kronos_top.sv
 
-TB_ALU_FILES := $(RTL_DIR)/kronos_pkg.sv \
+TB_ALU_FILES := $(AXI_PKG_SV) \
+                $(RTL_DIR)/kronos_pkg.sv \
                 $(RTL_DIR)/stage0/kronos_alu.sv \
                 $(TB_DIR)/stage0/tb_alu.sv
 
-TB_REGFILE_FILES := $(RTL_DIR)/kronos_pkg.sv \
+TB_REGFILE_FILES := $(AXI_PKG_SV) \
+                    $(RTL_DIR)/kronos_pkg.sv \
                     $(RTL_DIR)/stage0/kronos_regfile.sv \
                     $(TB_DIR)/stage0/tb_regfile.sv
 
-TB_DECODE_FILES := $(RTL_DIR)/kronos_pkg.sv \
+TB_DECODE_FILES := $(AXI_PKG_SV) \
+                   $(RTL_DIR)/kronos_pkg.sv \
                    $(RTL_DIR)/stage0/kronos_decode.sv \
                    $(TB_DIR)/stage0/tb_decode.sv
 
-TB_LSU_S1_FILES := $(RTL_DIR)/kronos_pkg.sv \
+TB_LSU_S1_FILES := $(AXI_PKG_SV) \
+                   $(RTL_DIR)/kronos_pkg.sv \
                    $(RTL_DIR)/stage1/kronos_lsu.sv \
                    $(TB_DIR)/stage1/tb_lsu_s1.sv
 
-TB_FWD_FILES := $(RTL_DIR)/kronos_pkg.sv \
+TB_FWD_FILES := $(AXI_PKG_SV) \
+                $(RTL_DIR)/kronos_pkg.sv \
                 $(RTL_DIR)/stage1/kronos_forward.sv \
                 $(TB_DIR)/stage1/tb_forward.sv
 
-TB_HZ_FILES := $(RTL_DIR)/kronos_pkg.sv \
+TB_HZ_FILES := $(AXI_PKG_SV) \
+               $(RTL_DIR)/kronos_pkg.sv \
                $(RTL_DIR)/stage1/kronos_hazard.sv \
                $(TB_DIR)/stage1/tb_hazard.sv
 
-SV_FILES_S1 := $(RTL_DIR)/kronos_pkg.sv \
+TB_MULDIV_FILES := $(AXI_PKG_SV) \
+                   $(RTL_DIR)/kronos_pkg.sv \
+                   $(RTL_DIR)/stage2/kronos_muldiv.sv \
+                   $(TB_DIR)/stage2/tb_muldiv.sv
+
+SV_FILES_S1 := $(AXI_PKG_SV) \
+               $(RTL_DIR)/kronos_pkg.sv \
                $(RTL_DIR)/stage0/kronos_alu.sv \
                $(RTL_DIR)/stage0/kronos_decode.sv \
                $(RTL_DIR)/stage0/kronos_regfile.sv \
@@ -58,11 +76,8 @@ SV_FILES_S1 := $(RTL_DIR)/kronos_pkg.sv \
 
 SIM_BIN_S1 := $(OBJ_DIR)/s1/Vkronos_top
 
-TB_MULDIV_FILES := $(RTL_DIR)/kronos_pkg.sv \
-                   $(RTL_DIR)/stage2/kronos_muldiv.sv \
-                   $(TB_DIR)/stage2/tb_muldiv.sv
-
-SV_FILES_S2 := $(RTL_DIR)/kronos_pkg.sv \
+SV_FILES_S2 := $(AXI_PKG_SV) \
+               $(RTL_DIR)/kronos_pkg.sv \
                $(RTL_DIR)/stage0/kronos_alu.sv \
                $(RTL_DIR)/stage2/kronos_decode.sv \
                $(RTL_DIR)/stage0/kronos_regfile.sv \
@@ -75,27 +90,70 @@ SV_FILES_S2 := $(RTL_DIR)/kronos_pkg.sv \
 
 SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
 
-.PHONY: build build-s1 build-s2 build-s3 run-% run-s0-% run-s1-% run-s2-% run-s3-% run-s3-latency-% \
-        sim-alu sim-regfile sim-decode sim-compliance \
+.PHONY: help build build-s1 build-s2 build-s3 run-% run-s0-% run-s1-% run-s2-% run-s3-% \
+        run-s3-latency-% sim-alu sim-regfile sim-decode sim-compliance \
         sim-compliance-s1 sim-lsu-s1 sim-forward sim-hazard \
-        sim-muldiv sim-compliance-s2 sim-lsu-s3 sim-compliance-s3 clean
+        sim-muldiv sim-compliance-s2 sim-decompress sim-align sim-lsu-s3 sim-bpred \
+        sim-compliance-s3 clean
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "kronos-riscv simulation targets"
+	@echo ""
+	@echo "Build simulators:"
+	@echo "  make build          Build stage 0 simulator (RV32I, OBI)"
+	@echo "  make build-s1       Build stage 1 simulator (RV32I, OBI, pipeline)"
+	@echo "  make build-s2       Build stage 2 simulator (RV32IM, OBI)"
+	@echo "  make build-s3       Build stage 3 simulator (RV32IMC, AXI4)"
+	@echo ""
+	@echo "Run tests:"
+	@echo "  make run-<test>              Run stage 0 test (e.g. run-test_alu)"
+	@echo "  make run-s1-<test>           Run stage 1 test (e.g. run-s1-test_forwarding)"
+	@echo "  make run-s2-<test>           Run stage 2 test (e.g. run-s2-test_mul)"
+	@echo "  make run-s3-<test>           Run stage 3 test (e.g. run-s3-test_c_basic)"
+	@echo "  make run-s3-latency-<test>   Run stage 3 test with latency 2/4"
+	@echo ""
+	@echo "Unit testbenches:"
+	@echo "  make sim-alu         ALU (stage 0)"
+	@echo "  make sim-regfile     Register file (stage 0)"
+	@echo "  make sim-decode      Decoder (stage 0)"
+	@echo "  make sim-lsu-s1      LSU OBI FSM (stage 1)"
+	@echo "  make sim-forward     Forwarding unit (stage 1)"
+	@echo "  make sim-hazard      Hazard/stall control (stage 1)"
+	@echo "  make sim-muldiv      Multiply/divide unit (stage 2)"
+	@echo "  make sim-decompress  RV32C instruction expander (stage 3)"
+	@echo "  make sim-align       Fetch alignment buffer (stage 3)"
+	@echo "  make sim-lsu-s3      LSU AXI4 FSM (stage 3)"
+	@echo "  make sim-bpred       Branch predictor (stage 3)"
+	@echo ""
+	@echo "Regression suites:"
+	@echo "  make sim-compliance     Full regression (= sim-compliance-s2)"
+	@echo "  make sim-compliance-s1  Stage 1: all sw/ programs + rv32ui compliance"
+	@echo "  make sim-compliance-s2  Stage 2: all sw/ programs + rv32ui compliance"
+	@echo "  make sim-compliance-s3  Stage 3: all sw/ programs (stages 0-3)"
+	@echo ""
+	@echo "Housekeeping:"
+	@echo "  make clean           Remove build artifacts"
 
 build: $(SIM_BIN)
 
-$(SIM_BIN): $(SV_FILES) sim_main.cpp
+$(SIM_BIN): $(SV_FILES) sim_main_obi.cpp
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED \
 	  --top-module $(TOP) \
-	  $(SV_FILES) sim_main.cpp \
+	  $(SV_FILES) sim_main_obi.cpp \
 	  -CFLAGS "$(CFLAGS)" \
+	  $(AXI_FLAGS) \
 	  -o V$(TOP)
 
 build-s1: $(SIM_BIN_S1)
 
-$(SIM_BIN_S1): $(SV_FILES_S1) sim_main.cpp
+$(SIM_BIN_S1): $(SV_FILES_S1) sim_main_obi.cpp
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED \
 	  --top-module kronos_top \
-	  $(SV_FILES_S1) sim_main.cpp \
+	  $(SV_FILES_S1) sim_main_obi.cpp \
 	  -CFLAGS "$(CFLAGS)" \
+	  $(AXI_FLAGS) \
 	  -Mdir $(OBJ_DIR)/s1 \
 	  -o Vkronos_top
 
@@ -110,32 +168,32 @@ run-s1-%: build-s1
 
 sim-alu:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_alu $(TB_ALU_FILES) -o tb_alu
+	  --top-module tb_alu $(TB_ALU_FILES) $(AXI_FLAGS) -o tb_alu
 	./obj_dir/tb_alu
 
 sim-regfile:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_regfile $(TB_REGFILE_FILES) -o tb_regfile
+	  --top-module tb_regfile $(TB_REGFILE_FILES) $(AXI_FLAGS) -o tb_regfile
 	./obj_dir/tb_regfile
 
 sim-decode:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_decode $(TB_DECODE_FILES) -o tb_decode
+	  --top-module tb_decode $(TB_DECODE_FILES) $(AXI_FLAGS) -o tb_decode
 	./obj_dir/tb_decode
 
 sim-lsu-s1:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_lsu_s1 $(TB_LSU_S1_FILES) -o tb_lsu_s1
+	  --top-module tb_lsu_s1 $(TB_LSU_S1_FILES) $(AXI_FLAGS) -o tb_lsu_s1
 	./obj_dir/tb_lsu_s1
 
 sim-forward:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_forward $(TB_FWD_FILES) -o tb_forward
+	  --top-module tb_forward $(TB_FWD_FILES) $(AXI_FLAGS) -o tb_forward
 	./obj_dir/tb_forward
 
 sim-hazard:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_hazard $(TB_HZ_FILES) -o tb_hazard
+	  --top-module tb_hazard $(TB_HZ_FILES) $(AXI_FLAGS) -o tb_hazard
 	./obj_dir/tb_hazard
 
 sim-compliance: sim-compliance-s2
@@ -159,16 +217,17 @@ sim-compliance-s1: build-s1
 
 sim-muldiv:
 	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
-	  --top-module tb_muldiv $(TB_MULDIV_FILES) -o tb_muldiv
+	  --top-module tb_muldiv $(TB_MULDIV_FILES) $(AXI_FLAGS) -o tb_muldiv
 	./obj_dir/tb_muldiv
 
 build-s2: $(SIM_BIN_S2)
 
-$(SIM_BIN_S2): $(SV_FILES_S2) sim_main.cpp
-	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED \
+$(SIM_BIN_S2): $(SV_FILES_S2) sim_main_obi.cpp
+	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED --Wno-WIDTHEXPAND \
 	  --top-module kronos_top \
-	  $(SV_FILES_S2) sim_main.cpp \
+	  $(SV_FILES_S2) sim_main_obi.cpp \
 	  -CFLAGS "$(CFLAGS)" \
+	  $(AXI_FLAGS) \
 	  -Mdir $(OBJ_DIR)/s2 \
 	  -o Vkronos_top
 
@@ -193,10 +252,6 @@ sim-compliance-s2: build-s2
 	echo "Stage 2 regression: $$pass passed, $$fail failed"; \
 	[ $$fail -eq 0 ]
 
-PULP_AXI_INC  := -I/home/popes/opensoc/hw/ip/pulp_axi/include
-AXI_PKG_SV    := /home/popes/opensoc/hw/ip/pulp_axi/src/axi_pkg.sv
-SW_DIR_S3     := ../sw/stage3
-
 SV_FILES_S3 := $(AXI_PKG_SV) \
                $(RTL_DIR)/kronos_pkg.sv \
                $(RTL_DIR)/stage0/kronos_alu.sv \
@@ -207,11 +262,37 @@ SV_FILES_S3 := $(AXI_PKG_SV) \
                $(RTL_DIR)/stage1/kronos_forward.sv \
                $(RTL_DIR)/stage1/kronos_hazard.sv \
                $(RTL_DIR)/stage2/kronos_muldiv.sv \
+               $(RTL_DIR)/stage3/kronos_decompress.sv \
+               $(RTL_DIR)/stage3/kronos_align.sv \
+               $(RTL_DIR)/stage3/kronos_bpred.sv \
                $(RTL_DIR)/stage3/kronos_top.sv \
                sim_top.sv
 
 TOP_S3     := sim_top
 SIM_BIN_S3 := $(OBJ_DIR)/s3/V$(TOP_S3)
+
+TB_DECOMPRESS_FILES := $(AXI_PKG_SV) \
+                       $(RTL_DIR)/kronos_pkg.sv \
+                       $(RTL_DIR)/stage3/kronos_decompress.sv \
+                       $(TB_DIR)/stage3/tb_decompress.sv
+
+sim-decompress:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_decompress $(TB_DECOMPRESS_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_decompress
+	./$(OBJ_DIR)/tb_decompress/Vtb_decompress
+
+TB_ALIGN_FILES := $(AXI_PKG_SV) \
+                  $(RTL_DIR)/kronos_pkg.sv \
+                  $(RTL_DIR)/stage3/kronos_decompress.sv \
+                  $(RTL_DIR)/stage3/kronos_align.sv \
+                  $(TB_DIR)/stage3/tb_align.sv
+
+sim-align:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_align $(TB_ALIGN_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_align
+	./$(OBJ_DIR)/tb_align/Vtb_align
 
 TB_LSU_S3_FILES := $(AXI_PKG_SV) \
                    $(RTL_DIR)/kronos_pkg.sv \
@@ -240,6 +321,17 @@ sim-lsu-s3:
 	  --top-module tb_lsu_s3 $(TB_LSU_S3_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_lsu_s3
 	./$(OBJ_DIR)/tb_lsu_s3/Vtb_lsu_s3
+
+TB_BPRED_FILES := $(AXI_PKG_SV) \
+                  $(RTL_DIR)/kronos_pkg.sv \
+                  $(RTL_DIR)/stage3/kronos_bpred.sv \
+                  $(TB_DIR)/stage3/tb_bpred.sv
+
+sim-bpred:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_bpred $(TB_BPRED_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_bpred
+	./$(OBJ_DIR)/tb_bpred/Vtb_bpred
 
 sim-compliance-s3: build-s3
 	$(MAKE) -C $(SW_DIR) all

--- a/sim/sim_main.cpp
+++ b/sim/sim_main.cpp
@@ -10,6 +10,7 @@
 //   data_latency:  cycles from AW+W accepted to B valid / AR to R valid (default 1)
 
 #include "Vsim_top.h"
+#include "Vsim_top___024root.h"
 #include "verilated.h"
 #include <cstdio>
 #include <cstring>
@@ -111,6 +112,8 @@ int main(int argc, char** argv) {
     int irq_countdown = 0;
     const int IRQ_HOLD = INSTR_LAT * 4 + DATA_LAT + 4;
 
+    bool debug = (getenv("SIM_DEBUG") != nullptr);
+
     for (int cycle = 0; cycle < MAX_CYCLES && !halted; cycle++) {
 
         // ---- Drive IRQ ----
@@ -153,10 +156,17 @@ int main(int argc, char** argv) {
         }
 
         // ---- Evaluate combinatorial outputs BEFORE rising edge ----
-        // Handshakes are sampled from the pre-clock combinatorial state. After the
-        // rising edge, FSM state updates (e.g. FETCH_IDLE→FETCH_WAIT_R) deassert
-        // ar_valid, making post-clock detection miss accepted transactions.
         top->eval();
+
+        if (debug) {
+            uint32_t pc   = top->rootp->sim_top__DOT__u_top__DOT__pc_q;
+            uint8_t  al_v = top->rootp->sim_top__DOT__u_top__DOT__align_instr_valid;
+            uint32_t ins  = top->rootp->sim_top__DOT__u_top__DOT__align_instr;
+            uint8_t  redir = top->rootp->sim_top__DOT__u_top__DOT__ex_redirect;
+            uint32_t epc  = top->rootp->sim_top__DOT__u_top__DOT__ex_pc_next;
+            printf("C%05d: pc=%08x al_v=%d ins=%08x redir=%d epc=%08x\n",
+                   cycle, pc, al_v, ins, redir, epc);
+        }
 
         // ---- Detect handshakes from pre-clock combinatorial state ----
 

--- a/sim/sim_main_obi.cpp
+++ b/sim/sim_main_obi.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim_main_obi.cpp — OBI memory model for kronos stage0–2 simulation.
+// Targets Vkronos_top (direct OBI ports on kronos_top).
+// Restored from git history: this driver was replaced by sim_main.cpp (AXI4)
+// when stage3 switched to native AXI4; kept here to allow stage0–2 regression.
+//
+// Usage: Vkronos_top <hex_file>
+
+#include "Vkronos_top.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+// 256 KB memory (byte-addressable, word-aligned access)
+static uint32_t mem[65536];  // 256 KB / 4
+
+// Parse Intel HEX format (produced by objcopy -O ihex).
+// Supports record types:
+//   00  Data
+//   01  End of File
+//   02  Extended Segment Address  (base = ext << 4)
+//   04  Extended Linear Address   (base = ext << 16)
+static void load_hex(const char* path) {
+    FILE* f = fopen(path, "r");
+    if (!f) {
+        fprintf(stderr, "[sim] ERROR: cannot open %s\n", path);
+        return;
+    }
+    char line[1024];
+    uint32_t base_addr = 0;
+    while (fgets(line, sizeof(line), f)) {
+        if (line[0] != ':') continue;
+        unsigned byte_count = 0, addr16 = 0, rec_type = 0;
+        sscanf(line + 1, "%02x%04x%02x", &byte_count, &addr16, &rec_type);
+        if (rec_type == 0x01) break; // EOF record
+        if (rec_type == 0x04) {      // Extended linear address
+            unsigned ext = 0;
+            sscanf(line + 9, "%04x", &ext);
+            base_addr = (uint32_t)ext << 16;
+        } else if (rec_type == 0x02) { // Extended segment address
+            unsigned ext = 0;
+            sscanf(line + 9, "%04x", &ext);
+            base_addr = (uint32_t)ext << 4;
+        } else if (rec_type == 0x00) { // Data record
+            uint32_t full_addr = base_addr + addr16;
+            for (unsigned i = 0; i < byte_count; i++) {
+                unsigned byte = 0;
+                sscanf(line + 9 + i * 2, "%02x", &byte);
+                uint32_t word_idx = (full_addr / 4) & 0xFFFF;
+                uint32_t byte_off = full_addr % 4;
+                mem[word_idx] = (mem[word_idx] & ~(0xFFu << (byte_off * 8)))
+                              | ((uint32_t)byte << (byte_off * 8));
+                full_addr++;
+            }
+        }
+    }
+    fclose(f);
+}
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    if (argc < 2) {
+        fprintf(stderr, "Usage: sim <hex_file>\n");
+        return 1;
+    }
+
+    memset(mem, 0, sizeof(mem));
+    load_hex(argv[1]);
+
+    Vkronos_top* top = new Vkronos_top;
+    top->clk_i        = 0;
+    top->rst_ni       = 0;
+    top->boot_addr_i  = 0x00000000;
+    top->irq_timer_i  = 0;
+    top->irq_fast_i   = 0;
+    top->instr_gnt_i    = 0;
+    top->instr_rvalid_i = 0;
+    top->instr_rdata_i  = 0;
+    top->instr_err_i    = 0;
+    top->data_gnt_i     = 0;
+    top->data_rvalid_i  = 0;
+    top->data_rdata_i   = 0;
+    top->data_err_i     = 0;
+
+    // Hold reset for 4 cycles
+    for (int i = 0; i < 8; i++) {
+        top->clk_i = !top->clk_i;
+        top->eval();
+    }
+    top->rst_ni = 1;
+    top->eval();
+
+    auto fetch_instr = [&]() {
+        if (top->instr_req_o) {
+            uint32_t wa       = (top->instr_addr_o >> 2) & 0xFFFF;
+            top->instr_rdata_i  = mem[wa];
+            top->instr_gnt_i    = 1;
+            top->instr_rvalid_i = 1;
+            top->instr_err_i    = 0;
+        } else {
+            top->instr_gnt_i    = 0;
+            top->instr_rvalid_i = 0;
+        }
+    };
+
+    auto prefetch_data = [&]() {
+        top->eval();
+        if (top->data_req_o) {
+            if (!top->data_we_o) {
+                uint32_t wa       = (top->data_addr_o >> 2) & 0xFFFF;
+                top->data_rdata_i = mem[wa];
+            }
+            top->data_gnt_i    = 1;
+            top->data_rvalid_i = 1;
+            top->data_err_i    = 0;
+        } else {
+            top->data_gnt_i    = 0;
+            top->data_rvalid_i = 0;
+            top->data_rdata_i  = 0;
+        }
+    };
+
+    fetch_instr();
+    prefetch_data();
+
+    const int MAX_CYCLES = 100000;
+    int halted = 0;
+    bool fire_irq = false;
+
+    for (int cycle = 0; cycle < MAX_CYCLES && !halted; cycle++) {
+        top->irq_timer_i = fire_irq ? 1 : 0;
+        if (fire_irq) fire_irq = false;
+
+        top->clk_i = 1;
+        top->eval();
+
+        if (top->data_req_o && top->data_we_o) {
+            uint32_t be   = top->data_be_o;
+            uint32_t wdat = top->data_wdata_o;
+
+            if (top->data_addr_o == 0x80000000u) {
+                fire_irq = true;
+            } else if ((top->data_addr_o & 0xC0000000u) == 0x40000000u) {
+                printf("[sim] halt at cycle %d, x10 = %u\n", cycle, wdat);
+                halted = 1;
+                break;
+            } else {
+                uint32_t word_addr = (top->data_addr_o >> 2) & 0xFFFF;
+                uint32_t cur  = mem[word_addr];
+                if (be & 1) cur = (cur & ~0x000000FFu) | (wdat & 0x000000FFu);
+                if (be & 2) cur = (cur & ~0x0000FF00u) | (wdat & 0x0000FF00u);
+                if (be & 4) cur = (cur & ~0x00FF0000u) | (wdat & 0x00FF0000u);
+                if (be & 8) cur = (cur & ~0xFF000000u) | (wdat & 0xFF000000u);
+                mem[word_addr] = cur;
+            }
+        }
+
+        fetch_instr();
+        prefetch_data();
+
+        top->clk_i = 0;
+        top->eval();
+    }
+
+    if (!halted) {
+        fprintf(stderr, "[sim] TIMEOUT after %d cycles\n", MAX_CYCLES);
+    }
+
+    top->final();
+    delete top;
+    return halted ? 0 : 1;
+}

--- a/sw/stage2/Makefile
+++ b/sw/stage2/Makefile
@@ -4,7 +4,7 @@ OBJCOPY := riscv64-unknown-elf-objcopy
 
 BUILD_DIR := build
 
-TESTS := test_mul test_div test_muldiv_hazards test_irq
+TESTS := test_mul test_div test_muldiv_hazards test_irq test_load_muldiv_edge
 
 all: $(addprefix $(BUILD_DIR)/, $(addsuffix .hex, $(TESTS)))
 

--- a/sw/stage2/test_load_muldiv_edge.S
+++ b/sw/stage2/test_load_muldiv_edge.S
@@ -1,0 +1,35 @@
+# test_load_muldiv_edge.S
+# Checks that LOAD followed immediately by MULDIV (no gap) produces correct results.
+# a0 (x10) = failure count; common.S halts and reports.
+.section .text
+.global main
+main:
+    li   a0, 0
+
+    # Store a known value to the scratch area in RAM.
+    # Use s0-s2 (caller-saved is fine; we don't call sub-functions).
+    la   s0, scratch
+    li   s1, 42
+    sw   s1, 0(s0)       # scratch = 42
+
+    # LOAD immediately followed by MUL (no gap instruction)
+    lw   s1, 0(s0)       # s1 = 42
+    mul  s2, s1, s1      # s2 = 42 * 42 = 1764
+
+    li   a1, 1764
+    bne  s2, a1, fail
+
+    # LOAD followed by DIV (worst case: multi-cycle)
+    lw   s1, 0(s0)       # s1 = 42
+    div  s2, s1, s1      # s2 = 1
+    li   a1, 1
+    bne  s2, a1, fail
+
+    li   a0, 0
+    ret
+fail:
+    li   a0, 1
+    ret
+
+.section .data
+scratch: .word 0

--- a/sw/stage3/Makefile
+++ b/sw/stage3/Makefile
@@ -1,21 +1,24 @@
-CC      := riscv64-unknown-elf-gcc
-CFLAGS  := -march=rv32im_zicsr -mabi=ilp32 -nostdlib -static -T ../stage0/link.ld
-OBJCOPY := riscv64-unknown-elf-objcopy
+TOOLCHAIN := riscv64-unknown-elf
+CC        := $(TOOLCHAIN)-gcc
+OBJCOPY   := $(TOOLCHAIN)-objcopy
+OBJDUMP   := $(TOOLCHAIN)-objdump
+
+ARCH   := rv32imc
+ABI    := ilp32
+CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
+
+TESTS  := test_c_basic test_c_control test_bpred_loop
 
 BUILD_DIR := build
 
-TESTS :=
+all: $(TESTS:%=$(BUILD_DIR)/%.hex)
 
-all: $(addprefix $(BUILD_DIR)/, $(addsuffix .hex, $(TESTS)))
+$(BUILD_DIR)/%.hex: %.S ../stage0/common.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $(@:.hex=.elf) $^
+	$(OBJCOPY) -O ihex $(@:.hex=.elf) $@
 
 $(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
-
-$(BUILD_DIR)/%.elf: %.S | $(BUILD_DIR)
-	$(CC) $(CFLAGS) -o $@ $< ../stage0/common.S
-
-$(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf
-	$(OBJCOPY) -O ihex $< $@
+	mkdir -p $@
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/sw/stage3/compliance/Makefile
+++ b/sw/stage3/compliance/Makefile
@@ -1,0 +1,67 @@
+CC      := riscv64-unknown-elf-gcc
+CFLAGS  := -march=rv32imc -mabi=ilp32 -nostdlib -static -T ../../stage0/link.ld
+OBJCOPY := riscv64-unknown-elf-objcopy
+SIM     := ../../../sim/obj_dir/s3/Vsim_top
+
+RISCV_TESTS_UC := ../../../riscv-tests/isa/rv32uc
+RISCV_TESTS_UI := ../../../riscv-tests/isa/rv32ui
+MACROS         := ../../../riscv-tests/isa/macros/scalar
+INCLUDES       := -I../../stage0/compliance -I$(MACROS)
+
+# RV32C compliance tests
+TESTS_UC := rvc
+
+# RV32I integer tests (rerun on stage3 sim with -march=rv32imc) — exclude
+# fence_i (unimplemented) and misaligned-access tests.
+TESTS_UI := add addi and andi auipc beq bge bgeu blt bltu bne \
+            jal jalr lb lbu lh lhu lui lw or ori              \
+            sb sh sll slli slt slti sltiu sltu                \
+            sra srai srl srli sub sw xor xori simple
+
+BUILD_DIR := build
+
+HEXES_UC := $(addprefix $(BUILD_DIR)/uc_, $(addsuffix .hex, $(TESTS_UC)))
+HEXES_UI := $(addprefix $(BUILD_DIR)/ui_, $(addsuffix .hex, $(TESTS_UI)))
+
+all: $(HEXES_UC) $(HEXES_UI)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/uc_%.elf: $(RISCV_TESTS_UC)/%.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $<
+
+$(BUILD_DIR)/ui_%.elf: $(RISCV_TESTS_UI)/%.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $<
+
+$(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf
+	$(OBJCOPY) -O ihex $< $@
+
+run: all
+	@pass=0; fail=0; \
+	echo "=== rv32uc ==="; \
+	for t in $(TESTS_UC); do \
+	  out=$$($(SIM) $(BUILD_DIR)/uc_$$t.hex 2>&1); \
+	  x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	  if [ "$$x10" = "0" ]; then \
+	    echo "PASS: uc/$$t"; pass=$$((pass+1)); \
+	  else \
+	    echo "FAIL: uc/$$t (failing test case = $$x10)"; fail=$$((fail+1)); \
+	  fi; \
+	done; \
+	echo "=== rv32ui (compressed build) ==="; \
+	for t in $(TESTS_UI); do \
+	  out=$$($(SIM) $(BUILD_DIR)/ui_$$t.hex 2>&1); \
+	  x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	  if [ "$$x10" = "0" ]; then \
+	    echo "PASS: ui/$$t"; pass=$$((pass+1)); \
+	  else \
+	    echo "FAIL: ui/$$t (failing test case = $$x10)"; fail=$$((fail+1)); \
+	  fi; \
+	done; \
+	echo "---"; \
+	echo "$$pass / $$((pass+fail)) passed"; \
+	[ $$fail -eq 0 ]
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/sw/stage3/test_bpred_loop.S
+++ b/sw/stage3/test_bpred_loop.S
@@ -1,0 +1,61 @@
+# test_bpred_loop.S — exercises the branch predictor with loops.
+.section .text
+.globl main
+main:
+    mv   s2, ra
+    li   a0, 0
+
+    # Test 1: countdown loop (predictor learns "taken")
+    li   x1, 100
+loop1:
+    addi x1, x1, -1
+    bnez x1, loop1
+    bnez x1, fail
+
+    # Test 2: same branch PC alternates taken/not-taken (exercises 2-bit hysteresis)
+    # beqz x8, alt_not_taken is taken on even phase (x8==0), not-taken on odd phase (x8==1)
+    li   x2, 0          # hit counter
+    li   x3, 16         # 16 iterations
+    li   x8, 0          # phase (flipped each iteration)
+alt_loop:
+    xori x8, x8, 1              # flip phase: 0->1->0->1...
+    beqz x8, alt_not_taken      # taken when x8==0 (even), not-taken when x8==1 (odd)
+    addi x2, x2, 1              # count not-taken outcomes (x8 was 1)
+alt_not_taken:
+    addi x3, x3, -1
+    bnez x3, alt_loop
+    li   x4, 8                  # 16 iters, x8==1 (not-taken path) on 8 of them
+    bne  x2, x4, fail
+
+    # Test 3: nested loops
+    li   x4, 5
+outer:
+    li   x5, 4
+inner:
+    addi x5, x5, -1
+    bnez x5, inner
+    addi x4, x4, -1
+    bnez x4, outer
+    bnez x4, fail
+    bnez x5, fail
+
+    # Test 4: JAL/RET sequence (stresses BTB — JAL target training)
+    mv   s1, s2          # save original return address (x1/ra already clobbered by Test 1)
+    li   x6, 0
+    li   x7, 8
+call_loop:
+    jal  x1, inc_x6
+    addi x7, x7, -1
+    bnez x7, call_loop
+    mv   ra, s1          # restore return address unconditionally before any branch to fail
+    li   x8, 8
+    bne  x6, x8, fail
+    ret
+
+inc_x6:
+    addi x6, x6, 1
+    jr   x1              # return via x1 (explicit link register)
+
+fail:
+    li   a0, 1
+    ret

--- a/sw/stage3/test_c_basic.S
+++ b/sw/stage3/test_c_basic.S
@@ -1,0 +1,77 @@
+# test_c_basic.S — tests integer C-extension operations
+# x10 = failure count; write to 0x40000000 to halt.
+.section .text
+.globl main
+main:
+    li   a0, 0
+
+    li   t5, 5
+    li   t6, 5
+    bne  t5, t6, fail
+
+    li   x3, 99
+    mv   x4, x3
+    bne  x4, x3, fail
+
+    li   x5, 10
+    li   x6, 20
+    add  x7, x5, x6
+    li   x8, 30
+    bne  x7, x8, fail
+
+    li   x9, 100
+    addi x9, x9, -1
+    li   a0, 99
+    bne  x9, a0, fail
+    li   a0, 0
+
+    li   a1, 1
+    slli a1, a1, 4
+    li   a2, 16
+    bne  a1, a2, fail
+
+    li   a3, 32
+    srli a3, a3, 2
+    li   a4, 8
+    bne  a3, a4, fail
+
+    li   a5, 0xFF
+    andi a5, a5, 0x0F
+    li   a6, 0x0F
+    bne  a5, a6, fail
+
+    li   a7, 50
+    li   s2, 20
+    sub  s3, a7, s2
+    li   s4, 30
+    bne  s3, s4, fail
+
+    li   s5, 0xAA
+    li   s6, 0x0F
+    and  s5, s5, s6
+    li   s7, 0x0A
+    bne  s5, s7, fail
+
+    li   s8, 0xA0
+    li   s9, 0x0F
+    or   s8, s8, s9
+    li   s10, 0xAF
+    bne  s8, s10, fail
+
+    li   s11, 0xFF
+    li   t3, 0xF0
+    xor  s11, s11, t3
+    li   t4, 0x0F
+    bne  s11, t4, fail
+
+    li   sp, 0x800
+    li   t0, 0xDEAD
+    sw   t0, 0(sp)
+    lw   t1, 0(sp)
+    bne  t0, t1, fail
+
+    li   a0, 0
+    ret
+fail:
+    li   a0, 1
+    ret

--- a/sw/stage3/test_c_control.S
+++ b/sw/stage3/test_c_control.S
@@ -1,0 +1,52 @@
+# test_c_control.S — tests C-extension control flow
+.section .text
+.globl main
+main:
+    mv   s0, ra
+    li   a0, 0
+
+    j    after_j
+    li   a0, 1
+after_j:
+
+    li   x1, 0
+    beqz x1, after_beqz
+    li   a0, 1
+after_beqz:
+
+    li   x2, 1
+    beqz x2, fail
+
+    li   x3, 5
+    bnez x3, after_bnez
+    li   a0, 1
+after_bnez:
+
+    li   x4, 0
+    bnez x4, fail
+
+    jal  x1, subr
+    j    after_call
+subr:
+    jr   x1
+after_call:
+
+    la   x5, subr2
+    jalr x1, 0(x5)
+    j    after_call2
+subr2:
+    ret
+after_call2:
+    mv   ra, s0
+
+    li   x6, 5
+loop:
+    addi x6, x6, -1
+    bnez x6, loop
+    bnez x6, fail
+
+    li   a0, 0
+    ret
+fail:
+    li   a0, 1
+    ret

--- a/tb/stage3/tb_align.sv
+++ b/tb/stage3/tb_align.sv
@@ -1,0 +1,210 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// tb_align.sv — Unit tests for kronos_align (combinational output version).
+//
+// Timing model:
+//   tick  = @(posedge clk) #1  — advances state, then reads comb outputs of NEW state
+//   sample = #1                 — reads comb outputs of CURRENT state without advancing
+//
+// With combinational outputs, instr_o/instr_valid_o/is_16b_o are driven by the
+// CURRENT registered state plus current inputs.  After a tick, they reflect the
+// state that was clocked in on that posedge.
+module tb_align;
+  import kronos_pkg::*;
+
+  logic        clk, rst_n;
+  logic [31:0] rdata;
+  logic        rvalid;
+  logic        stall, flush;
+  logic        pc_offset;
+  logic [31:0] instr_out;
+  logic        instr_valid;
+  logic        is_16b;
+  logic        align_stall, align_need_upper, align_needs_fetch;
+
+  int failures = 0;
+
+  kronos_align u_dut (
+    .clk_i               (clk),
+    .rst_ni              (rst_n),
+    .rdata_i             (rdata),
+    .rvalid_i            (rvalid),
+    .stall_i             (stall),
+    .flush_i             (flush),
+    .pc_offset_i         (pc_offset),
+    .instr_o             (instr_out),
+    .instr_valid_o       (instr_valid),
+    .is_16b_o            (is_16b),
+    .align_stall_o       (align_stall),
+    .align_need_upper_o  (align_need_upper),
+    .align_needs_fetch_o (align_needs_fetch)
+  );
+
+  always #5 clk = ~clk;
+  // tick: advance one clock cycle, pause 1 unit after posedge to let comb settle
+  task tick; @(posedge clk); #1; endtask
+
+  initial begin
+    clk = 0; rst_n = 0; rdata = '0; rvalid = 0; stall = 0; flush = 0; pc_offset = 0;
+    repeat(4) tick;
+    rst_n = 1;
+
+    // -----------------------------------------------------------------------
+    // Test 1: Word-aligned 32-bit instruction passthrough
+    // -----------------------------------------------------------------------
+    // NORMAL state, rvalid=1, rdata[1:0]=11 → 32-bit passthrough
+    rdata  = 32'hABCD_EF33;  // [1:0]=11 → 32-bit
+    rvalid = 1;
+    // Check comb outputs BEFORE posedge: NORMAL + rvalid=1 → passthrough
+    #1;
+    if (instr_out !== 32'hABCD_EF33 || instr_valid !== 1'b1 || is_16b !== 1'b0 || align_stall !== 1'b0) begin
+      $display("FAIL T1 (pre-posedge): 32-bit passthrough: got instr=0x%08x valid=%b is_16b=%b stall=%b",
+               instr_out, instr_valid, is_16b, align_stall);
+      failures++;
+    end
+    // align_needs_fetch is 1 in NORMAL state (need to fetch next word)
+    if (align_needs_fetch !== 1'b1) begin
+      $display("FAIL T1: align_needs_fetch should be 1 in NORMAL state, got %b", align_needs_fetch);
+      failures++;
+    end
+    tick;  // posedge: 32-bit → no state change (still NORMAL)
+    // After tick: still NORMAL, rvalid=1 → same outputs
+    if (instr_out !== 32'hABCD_EF33 || is_16b !== 1'b0 || align_stall !== 1'b0) begin
+      $display("FAIL T1 (post-tick): 32-bit passthrough: got instr=0x%08x is_16b=%b stall=%b",
+               instr_out, is_16b, align_stall);
+      failures++;
+    end
+    rvalid = 0;
+    tick;
+
+    // -----------------------------------------------------------------------
+    // Test 2: Word-aligned 16-bit (lower half), then buffered 16-bit
+    // -----------------------------------------------------------------------
+    // Feed word where lower=C.NOP(0x0001), upper=C.NOP(0x0001)
+    rdata  = 32'h0001_0001;  // [1:0]=01 → lower half is 16-bit
+    rvalid = 1;
+    // Before posedge: NORMAL + rvalid=1 + rdata[1:0]=01 → emit decomp_lower(0x0001)=0x13
+    #1;
+    if (instr_out !== 32'h0000_0013 || instr_valid !== 1'b1 || is_16b !== 1'b1 || align_stall !== 1'b0) begin
+      $display("FAIL T2 (pre-posedge): 16-bit lower: got instr=0x%08x valid=%b is_16b=%b stall=%b",
+               instr_out, instr_valid, is_16b, align_stall);
+      failures++;
+    end
+    tick;
+    // After tick: state → BUFFERED (buf_valid=1, buf_data=0x0001)
+    // Comb: BUFFERED, buf[1:0]=01 → emit decomp_buf(0x0001)=0x13, instr_valid=1, is_16b=1
+    if (instr_out !== 32'h0000_0013 || instr_valid !== 1'b1 || is_16b !== 1'b1 || align_stall !== 1'b0) begin
+      $display("FAIL T2a: 16-bit buffered: got instr=0x%08x valid=%b is_16b=%b stall=%b",
+               instr_out, instr_valid, is_16b, align_stall);
+      failures++;
+    end
+    // In BUFFERED state, align_needs_fetch should be 0 (buffer has data, no fetch needed)
+    if (align_needs_fetch !== 1'b0) begin
+      $display("FAIL T2a: align_needs_fetch should be 0 in BUFFERED state, got %b", align_needs_fetch);
+      failures++;
+    end
+    rvalid = 0;
+    tick;
+    // After tick: BUFFERED consumed → NORMAL; rvalid=0 → instr_valid=0
+    if (instr_valid !== 1'b0) begin
+      $display("FAIL T2b: after buffer consumed, instr_valid should be 0, got %b", instr_valid);
+      failures++;
+    end
+    tick;
+
+    // -----------------------------------------------------------------------
+    // Test 3: 32-bit instruction spanning halfword boundary (need_upper)
+    // -----------------------------------------------------------------------
+    // Setup: flush, then feed word where lower=C.NOP(0x0001), upper=0xAB2F([1:0]=11)
+    flush = 1; pc_offset = 0; tick; flush = 0;
+    rdata  = 32'hAB2F_0001;  // lower=0x0001(16-bit), upper=0xAB2F(32-bit spanning lower half)
+    rvalid = 1;
+    // Before posedge: NORMAL + rvalid=1 + rdata[1:0]=01 → emit decomp_lower(0x0001)=C.NOP
+    #1;
+    if (instr_out !== 32'h0000_0013 || instr_valid !== 1'b1 || is_16b !== 1'b1 || align_stall !== 1'b0) begin
+      $display("FAIL T3a (pre-posedge): C.NOP before span: got instr=0x%08x valid=%b is_16b=%b stall=%b",
+               instr_out, instr_valid, is_16b, align_stall);
+      failures++;
+    end
+    tick;
+    // After tick: BUFFERED (buf_valid=1, buf_data=0xAB2F), buf[1:0]=11 → no instruction yet
+    if (instr_valid !== 1'b0 || align_stall !== 1'b0) begin
+      $display("FAIL T3a (post-tick): BUFFERED with [1:0]=11: instr_valid=%b align_stall=%b",
+               instr_valid, align_stall);
+      failures++;
+    end
+    rvalid = 0;
+
+    // Cycle B: state=BUFFERED, buf[1:0]=11 → transition to NEED_UPPER
+    tick;
+    // After tick: need_upper_q=1, align_stall=1, align_need_upper=1
+    if (align_stall !== 1'b1 || align_need_upper !== 1'b1) begin
+      $display("FAIL T3b: span stall: stall=%b need_upper=%b", align_stall, align_need_upper);
+      failures++;
+    end
+    if (align_needs_fetch !== 1'b1) begin
+      $display("FAIL T3b: align_needs_fetch should be 1 in NEED_UPPER, got %b", align_needs_fetch);
+      failures++;
+    end
+
+    // Cycle C: provide upper half — rdata[15:0]=0xCD12 completes the spanning insn
+    // Set rvalid=0 first so the post-tick state is clean, then check before posedge
+    rdata  = 32'hXXXX_CD12;
+    rvalid = 1;
+    // Before posedge: NEED_UPPER + rvalid=1 → instr={CD12,AB2F}=0xCD12AB2F, is_16b=0, stall=1
+    #1;
+    if (instr_out !== 32'hCD12AB2F || instr_valid !== 1'b1 || is_16b !== 1'b0 || align_stall !== 1'b1) begin
+      $display("FAIL T3c (pre-posedge): span combine: got instr=0x%08x valid=%b is_16b=%b stall=%b",
+               instr_out, instr_valid, is_16b, align_stall);
+      failures++;
+    end
+    tick;
+    // After tick: rvalid=1 was sampled → need_upper cleared, buf_valid cleared → NORMAL
+    // Comb: NORMAL + rvalid=1, rdata=0xXXXXCD12, [1:0]=10 (16-bit) → instr_valid=1, is_16b=1
+    // Just check the stall/need_upper flags are clear
+    if (align_stall !== 1'b0 || align_need_upper !== 1'b0) begin
+      $display("FAIL T3c (post-tick): stall should clear: stall=%b need_upper=%b",
+               align_stall, align_need_upper);
+      failures++;
+    end
+    rvalid = 0;
+    tick;
+
+    // -----------------------------------------------------------------------
+    // Test 4: Flush to halfword-aligned PC (pc_offset_i=1)
+    // -----------------------------------------------------------------------
+    // Flush with pc_offset=1: next fetch word's upper half is the first instruction
+    flush = 1; pc_offset = 1; tick; flush = 0; pc_offset = 0;
+
+    // Feed word: lower=garbage(0xABCD), upper=C.NOP(0x0001)
+    rdata  = 32'h0001_ABCD;  // lower=0xABCD (garbage), upper=C.NOP
+    rvalid = 1;
+    // Before posedge: skip_lower_q=1 → instr_valid=0
+    #1;
+    if (instr_valid !== 1'b0) begin
+      $display("FAIL T4a (pre-posedge): skip_lower should suppress instr_valid, got %b", instr_valid);
+      failures++;
+    end
+    tick;
+    // After tick: skip_lower consumed, buf_valid=1, buf_data=0x0001 (BUFFERED)
+    // Comb: BUFFERED, buf[1:0]=01 → emit C.NOP=0x13, instr_valid=1, is_16b=1
+    if (instr_out !== 32'h0000_0013 || instr_valid !== 1'b1 || is_16b !== 1'b1) begin
+      $display("FAIL T4b: after skip_lower, BUFFERED should emit C.NOP: got 0x%08x valid=%b is_16b=%b",
+               instr_out, instr_valid, is_16b);
+      failures++;
+    end
+    // align_needs_fetch=0 in BUFFERED state
+    if (align_needs_fetch !== 1'b0) begin
+      $display("FAIL T4b: align_needs_fetch should be 0 in BUFFERED state, got %b", align_needs_fetch);
+      failures++;
+    end
+    rvalid = 0;
+    tick;
+
+    if (failures == 0) $display("PASS: all tb_align checks");
+    else               $display("FAIL: %0d tb_align checks failed", failures);
+    $finish;
+  end
+endmodule

--- a/tb/stage3/tb_bpred.sv
+++ b/tb/stage3/tb_bpred.sv
@@ -1,0 +1,155 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// tb_bpred.sv — Unit tests for kronos_bpred.
+module tb_bpred;
+  logic        clk, rst_n;
+  logic [31:0] pc;
+  logic        pred_taken;
+  logic [31:0] pred_target;
+  logic        upd_valid;
+  logic [31:0] upd_pc, upd_target;
+  logic        upd_taken, upd_is_jal;
+
+  int failures = 0;
+
+  kronos_bpred #(.BPRED_BITS(6), .BTB_BITS(4)) u_dut (
+    .clk_i         (clk),
+    .rst_ni        (rst_n),
+    .pc_i          (pc),
+    .pred_taken_o  (pred_taken),
+    .pred_target_o (pred_target),
+    .upd_valid_i   (upd_valid),
+    .upd_pc_i      (upd_pc),
+    .upd_taken_i   (upd_taken),
+    .upd_target_i  (upd_target),
+    .upd_is_jal_i  (upd_is_jal)
+  );
+
+  always #5 clk = ~clk;
+  task tick; @(posedge clk); #1; endtask
+
+  // update task: is_jal=0 for conditional branch, is_jal=1 for JAL
+  task update(input logic [31:0] upc, input logic taken,
+              input logic [31:0] tgt, input logic is_jal);
+    upd_valid = 1; upd_pc = upc; upd_taken = taken;
+    upd_target = tgt; upd_is_jal = is_jal;
+    tick;
+    upd_valid = 0;
+  endtask
+
+  initial begin
+    clk = 0; rst_n = 0;
+    upd_valid = 0; upd_pc = 0; upd_taken = 0;
+    upd_target = 0; upd_is_jal = 0;
+    repeat(4) tick;
+    rst_n = 1;
+
+    // Test 1: cold-start — no prediction
+    pc = 32'h0000_0100;
+    #1;
+    if (pred_taken !== 1'b0) begin
+      $display("FAIL T1: cold-start should predict not-taken, got %b", pred_taken);
+      failures++;
+    end
+
+    // Test 2: 2-bit counter saturation — 4 taken → strong-taken
+    repeat(4) update(32'h0000_0100, 1'b1, 32'h0000_00C0, 1'b0);
+    pc = 32'h0000_0100; #1;
+    if (pred_taken !== 1'b1) begin
+      $display("FAIL T2: after 4 taken, should predict taken, got %b", pred_taken);
+      failures++;
+    end
+    if (pred_target !== 32'h0000_00C0) begin
+      $display("FAIL T2: target wrong: got 0x%08x", pred_target);
+      failures++;
+    end
+
+    // Test 3: 1 not-taken → 11→10 (still predict taken)
+    update(32'h0000_0100, 1'b0, 32'h0000_0104, 1'b0);
+    pc = 32'h0000_0100; #1;
+    if (pred_taken !== 1'b1) begin
+      $display("FAIL T3: 11→10 should still predict taken, got %b", pred_taken);
+      failures++;
+    end
+
+    // Test 4: 2nd not-taken → 10→01 (predict not-taken)
+    update(32'h0000_0100, 1'b0, 32'h0000_0104, 1'b0);
+    pc = 32'h0000_0100; #1;
+    if (pred_taken !== 1'b0) begin
+      $display("FAIL T4: 10→01 should predict not-taken, got %b", pred_taken);
+      failures++;
+    end
+
+    // Test 5: BTB tag mismatch → no prediction even if counter says taken
+    repeat(4) update(32'h0000_0100, 1'b1, 32'h0000_00C0, 1'b0);
+    // 0x200 maps to BTB index 0 (same slot as 0x100) but with a different tag — BTB tag mismatch
+    pc = 32'h0000_0200; #1;
+    if (pred_taken !== 1'b0) begin
+      $display("FAIL T5: BTB tag mismatch should give pred_taken=0, got %b", pred_taken);
+      failures++;
+    end
+
+    // Test 6: JAL always predicted taken after one training
+    // 0x400 maps to the same BTB/BPRED index as 0x100 but has a different tag (16 vs 4)
+    update(32'h0000_0400, 1'b1, 32'h0000_0300, 1'b1);  // JAL update
+    pc = 32'h0000_0400; #1;
+    if (pred_taken !== 1'b1 || pred_target !== 32'h0000_0300) begin
+      $display("FAIL T6: JAL after training: taken=%b target=0x%08x",
+               pred_taken, pred_target);
+      failures++;
+    end
+
+    // Test 7: JAL counter-skip — counter state must be unchanged after JAL update.
+    // Train a branch at 0x500 to weak-taken (counter=10 after 3 taken, 1 not-taken).
+    // Then issue a JAL update at 0x500. Counter must remain at whatever state it was.
+    // Re-check that prediction is still taken (counter MSB still 1).
+    repeat(3) update(32'h0000_0500, 1'b1, 32'h0000_0600, 1'b0); // branch taken x3 → counter=11
+    update(32'h0000_0500, 1'b0, 32'h0000_0504, 1'b0);           // branch not-taken → counter=10
+    pc = 32'h0000_0500; #1;
+    // Counter should be 10 → pred_taken=1
+    if (pred_taken !== 1'b1) begin
+      $display("FAIL T7a: pre-JAL counter should be 10 (pred_taken=1), got %b", pred_taken);
+      failures++;
+    end
+    // Now fire a JAL update at same PC — counter must NOT change
+    update(32'h0000_0500, 1'b1, 32'h0000_0700, 1'b1);  // JAL update
+    pc = 32'h0000_0500; #1;
+    // Counter still 10 → pred_taken must still be 1
+    if (pred_taken !== 1'b1) begin
+      $display("FAIL T7b: JAL must not modify counter; pred_taken should still be 1, got %b",
+               pred_taken);
+      failures++;
+    end
+    // Verify the BTB was updated to new JAL target
+    if (pred_target !== 32'h0000_0700) begin
+      $display("FAIL T7c: JAL must update BTB target; expected 0x700, got 0x%08x", pred_target);
+      failures++;
+    end
+
+    // Test 8: BTB invalidated when counter reaches strong not-taken (00)
+    // Use 0x1C0: BPRED index=48 (unique), BTB index=0 (shared with other tests — tag=7 distinguishes)
+    // Step 1: train to strong-taken (4 taken updates: 01→10→11→11, BTB written)
+    repeat(4) update(32'h0000_01C0, 1'b1, 32'h0000_01D0, 1'b0);
+    pc = 32'h0000_01C0; #1;
+    if (pred_taken !== 1'b1) begin
+      $display("FAIL T8a: after 4 taken, should predict taken, got %b", pred_taken);
+      failures++;
+    end
+    // Step 2: 4 not-taken updates: counter 11→10→01→00
+    //         On the 01→00 transition (3rd not-taken), BTB entry is invalidated
+    repeat(4) update(32'h0000_01C0, 1'b0, 32'h0000_01C4, 1'b0);
+    // Step 3: counter MSB=0 and BTB.valid=0 → pred_taken must be 0
+    pc = 32'h0000_01C0; #1;
+    if (pred_taken !== 1'b0) begin
+      $display("FAIL T8b: after 4 not-taken (counter=00, BTB cleared), pred_taken should be 0, got %b",
+               pred_taken);
+      failures++;
+    end
+
+    if (failures == 0) $display("PASS: all tb_bpred checks");
+    else               $display("FAIL: %0d tb_bpred checks failed", failures);
+    $finish;
+  end
+endmodule

--- a/tb/stage3/tb_decompress.sv
+++ b/tb/stage3/tb_decompress.sv
@@ -1,0 +1,112 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// tb_decompress.sv — Unit tests for kronos_decompress.
+// Each test applies a 16-bit C encoding and checks the 32-bit expansion.
+// Encodings and expected outputs are verified against riscv64-unknown-elf-objdump.
+module tb_decompress;
+  logic [15:0] instr16;
+  logic [31:0] instr32;
+  logic        illegal;
+
+  int failures = 0;
+
+  kronos_decompress u_dut (.instr16_i(instr16), .instr32_o(instr32), .illegal_o(illegal));
+
+  task automatic check(input logic [15:0] c16, input logic [31:0] expected,
+                       input string name);
+    instr16 = c16;
+    #1;
+    if (instr32 !== expected || illegal !== 1'b0) begin
+      $display("FAIL %s: in=0x%04x got=0x%08x ill=%b expected=0x%08x",
+               name, c16, instr32, illegal, expected);
+      failures++;
+    end
+  endtask
+
+  task automatic check_illegal(input logic [15:0] c16, input string name);
+    instr16 = c16;
+    #1;
+    if (illegal !== 1'b1) begin
+      $display("FAIL %s: in=0x%04x expected illegal, got instr32=0x%08x", name, c16, instr32);
+      failures++;
+    end
+  endtask
+
+  initial begin
+    // ---------------------------------------------------------------
+    // Quadrant 0
+    // ---------------------------------------------------------------
+    // C.ADDI4SPN s0,sp,8  → ADDI x8,x2,8
+    check(16'h0020, 32'h00810413, "C.ADDI4SPN x8,sp,8");
+    // nzuimm=0 is reserved
+    check_illegal(16'h0000, "C.ADDI4SPN nzuimm=0");
+    // Q0 funct3=001 is reserved → illegal
+    check_illegal(16'h2000, "Q0 reserved funct3=001");
+    // C.LW a2,12(a3)  → LW x12,12(x13)
+    check(16'h46D0, 32'h00C6A603, "C.LW x12,12(x13)");
+    // C.SW a5,0(s0)   → SW x15,0(x8)   (offset=0, not 4)
+    check(16'hC01C, 32'h00F42023, "C.SW x15,0(x8)");
+
+    // ---------------------------------------------------------------
+    // Quadrant 1
+    // ---------------------------------------------------------------
+    // C.NOP  → ADDI x0,x0,0
+    check(16'h0001, 32'h00000013, "C.NOP");
+    // C.ADDI a0,-1  → ADDI x10,x10,-1
+    check(16'h157D, 32'hFFF50513, "C.ADDI a0,-1");
+    // C.JAL -6  → JAL x1,-6
+    check(16'h3FED, 32'hFFBFF0EF, "C.JAL -6");
+    // C.LI a1,5  → ADDI x11,x0,5
+    check(16'h4595, 32'h00500593, "C.LI a1,5");
+    // C.LUI gp,1  → LUI x3,1   (rd=x3/gp, not x6/t1)
+    check(16'h6185, 32'h000011B7, "C.LUI gp,1");
+    // C.ADDI16SP -512  → ADDI x2,x2,-512
+    check(16'h7101, 32'hE0010113, "C.ADDI16SP sp,-512");
+    // C.SRLI x8,1  → SRLI x8,x8,1
+    check(16'h8005, 32'h00145413, "C.SRLI x8,1");
+    // C.SRAI x8,1  → SRAI x8,x8,1
+    check(16'h8405, 32'h40145413, "C.SRAI x8,1");
+    // C.ANDI x9,3  → ANDI x9,x9,3   (imm=3, not 7)
+    check(16'h888D, 32'h0034F493, "C.ANDI x9,3");
+    // C.SUB x8,x9  → SUB x8,x8,x9
+    check(16'h8C05, 32'h40940433, "C.SUB x8,x9");
+    // C.XOR x8,x9  → XOR x8,x8,x9
+    check(16'h8C25, 32'h00944433, "C.XOR x8,x9");
+    // C.OR  x8,x9  → OR  x8,x8,x9
+    check(16'h8C45, 32'h00946433, "C.OR x8,x9");
+    // C.AND x8,x9  → AND x8,x8,x9
+    check(16'h8C65, 32'h00947433, "C.AND x8,x9");
+    // C.J -14  → JAL x0,-14
+    check(16'hBFCD, 32'hFF3FF06F, "C.J -14");
+    // C.BEQZ x8,2  → BEQ x8,x0,2
+    check(16'hC009, 32'h00040163, "C.BEQZ x8,2");
+    // C.BNEZ x9,-16  → BNE x9,x0,-16
+    check(16'hF8E5, 32'hFE0498E3, "C.BNEZ x9,-16");
+
+    // ---------------------------------------------------------------
+    // Quadrant 2
+    // ---------------------------------------------------------------
+    // C.SLLI a0,4  → SLLI x10,x10,4   (shamt=4, not 2)
+    check(16'h0512, 32'h00451513, "C.SLLI a0,4");
+    // C.LWSP a2,4  → LW x12,4(x2)     (offset=4, not 8)
+    check(16'h4612, 32'h00412603, "C.LWSP a2,4");
+    // C.SWSP a1,8  → SW x11,8(x2)     (rs2=a1/x11, offset=8)
+    check(16'hC42E, 32'h00B12423, "C.SWSP a1,8");
+    // C.JR a1  → JALR x0,0(x11)
+    check(16'h8582, 32'h00058067, "C.JR a1");
+    // C.MV t0,a0  → ADD x5,x0,x10
+    check(16'h82AA, 32'h00A002B3, "C.MV t0,a0");
+    // C.EBREAK  → EBREAK
+    check(16'h9002, 32'h00100073, "C.EBREAK");
+    // C.JALR a0  → JALR x1,0(x10)
+    check(16'h9502, 32'h000500E7, "C.JALR a0");
+    // C.ADD a0,a1  → ADD x10,x10,x11
+    check(16'h952E, 32'h00B50533, "C.ADD a0,a1");
+
+    if (failures == 0) $display("PASS: all tb_decompress checks");
+    else               $display("FAIL: %0d tb_decompress checks failed", failures);
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

- **AXI4 bus switch**: Replace OBI with native AXI4 master ports (`kronos_lsu` rewrite, `sim_top` AXI4 wrapper, `sim_main` AXI4 memory model)
- **RV32C compressed instructions**: `kronos_decompress` (16-to-32-bit expander), `kronos_align` (3-state fetch alignment buffer for variable-width instructions)
- **Bimodal branch predictor**: `kronos_bpred` (2-bit saturating counters + BTB), speculative IF with EX misprediction correction integrated into `kronos_top`

### New modules
| Module | Lines | Description |
|--------|-------|-------------|
| `kronos_decompress` | 243 | Pure combinational RV32C expander |
| `kronos_align` | 164 | NORMAL/BUFFERED/NEED_UPPER state machine + skip_lower for halfword-aligned flush |
| `kronos_bpred` | 106 | Bimodal predictor (2^6 counters) + direct-mapped BTB (2^4 entries) |

### Key design decisions
- `instr_fetch_stall = ~align_instr_valid` replaces raw AXI4 fetch-wait stall
- Alignment buffer flushed on taken predictions: `flush_i = if_id_flush | (pred_taken & pc_en & ~ex_redirect)`
- `bpred_mispredict` replaces `ex_redirect` for branches/jumps; traps/MRET always flush
- `ex_pc_next` fallthrough uses `is_16b` for correct pc+2 vs pc+4 on not-taken C branches
- MISA_EXT = `26'h1104` (I+M+C)

## Test plan

- [x] All 12 integration tests pass (stage 0: 3, stage 1: 4, stage 2: 5, stage 3: 3)
- [x] All 10 unit testbenches pass (sim-alu, sim-regfile, sim-decode, sim-lsu-s1, sim-forward, sim-hazard, sim-muldiv, sim-decompress, sim-lsu-s3, sim-bpred)
- [x] Verilator lint clean (`--Wall --Wno-UNUSED --Wno-WIDTHEXPAND`)
- [x] RV32C compliance suite (riscv-tests rv32uc/rvc) -- 39/39 pass (rv32uc + rv32ui with `-march=rv32imc`)