### PR TITLE
fix(decompress): correct sign-extend replicate widths in RV32C expander

### DIFF
--- a/rtl/stage3/kronos_decompress.sv
+++ b/rtl/stage3/kronos_decompress.sv
@@ -84,12 +84,12 @@ module kronos_decompress (
         unique case (funct3)
 
           3'b000: begin  // C.NOP / C.ADDI → ADDI rd, rd, nzimm
-            nzimm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            nzimm = {{27{instr16_i[12]}}, instr16_i[6:2]};
             instr32_o = {nzimm[11:0], rd, 3'b000, rd, OP_IMM};
           end
 
           3'b001: begin  // C.JAL → JAL x1, offset
-            imm = {{10{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
+            imm = {{21{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
                    instr16_i[6], instr16_i[7], instr16_i[2], instr16_i[11],
                    instr16_i[5:3], 1'b0};
             instr32_o = {imm[20], imm[10:1], imm[11], imm[19:12],
@@ -97,7 +97,7 @@ module kronos_decompress (
           end
 
           3'b010: begin  // C.LI → ADDI rd, x0, imm
-            imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            imm = {{27{instr16_i[12]}}, instr16_i[6:2]};
             instr32_o = {imm[11:0], 5'd0, 3'b000, rd, OP_IMM};
           end
 
@@ -131,7 +131,7 @@ module kronos_decompress (
               end
 
               2'b10: begin  // C.ANDI → ANDI rs1', rs1', imm
-                imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+                imm = {{27{instr16_i[12]}}, instr16_i[6:2]};
                 instr32_o = {imm[11:0], rs1_full, 3'b111, rs1_full, OP_IMM};
               end
 
@@ -158,7 +158,7 @@ module kronos_decompress (
           end
 
           3'b101: begin  // C.J → JAL x0, offset
-            imm = {{10{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
+            imm = {{21{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
                    instr16_i[6], instr16_i[7], instr16_i[2], instr16_i[11],
                    instr16_i[5:3], 1'b0};
             instr32_o = {imm[20], imm[10:1], imm[11], imm[19:12],


### PR DESCRIPTION
## Summary
- `rtl/stage3/kronos_decompress.sv` had five RHS concatenations whose widths did not match the 32-bit destination, tripping Verilator `WIDTHEXPAND` warnings and violating the project's \"lint must be clean\" rule.
- ADDI/LI/ANDI immediates: `{26{sign}}` + 5 data bits = 31 → bumped to `{27{sign}}`.
- C.JAL / C.J offsets: `{10{sign}}` + 11 data bits = 21 → bumped to `{21{sign}}` (not 11 as originally reported — the concat already had 11 data bits, so 11 replicas would still leave it 10 bits short of 32).
- Functionally harmless on RV32 because only the low 12 / 20 bits flowed downstream, but the upper bits were zero-extended by the width mismatch instead of sign-extended.

## Test plan
- [x] `verilator --lint-only -Wall -Wno-UNUSED` on `kronos_decompress.sv` — 0 warnings.
- [x] `make sim-decompress` (RV32C expander tb) — PASS.
- [x] All other unit tbs (alu, regfile, decode, lsu-s1, forward, hazard, muldiv, align, lsu-s3, bpred) — PASS.
- [x] `make sim-compliance-s1` — 38/38 rv32ui + 9/9 sw/ programs.
- [x] `make sim-compliance-s2` — 38/38 rv32ui + 14/14 sw/ programs.
- [x] `make sim-compliance-s3` — 17/17 sw/ programs (stages 0–3, incl. RV32C paths).