### PR TITLE
fix(muldiv): latch MUL operands in IDLE, register product in MUL_BUSY

### DIFF
--- a/rtl/stage2/kronos_muldiv.sv
+++ b/rtl/stage2/kronos_muldiv.sv
@@ -56,21 +56,26 @@ module kronos_muldiv
   logic [31:0] result_q;
 
   // -------------------------------------------------------------------------
-  // MUL: combinational 66-bit product using 33-bit sign-extended operands.
-  // Computed immediately from a_i/b_i/op_i during the IDLE cycle when req fires.
+  // MUL: operands latched on req_i; combinational 66-bit product is computed
+  // from the latched copies during MUL_BUSY and registered into result_q.
+  // This gives synthesis a full clock period for the multiply path
+  // (a_q/b_q flops → mul_product → result_q flop) with no XDC needed.
   // -------------------------------------------------------------------------
+  logic [31:0]   mul_a_q, mul_b_q;
+  muldiv_op_e    mul_op_q;
+
   logic        mul_signed_a, mul_signed_b;
   logic [32:0] mul_a33, mul_b33;
   logic signed [65:0] mul_product;
 
-  assign mul_signed_a = (op_i == MULDIV_MUL) | (op_i == MULDIV_MULH) | (op_i == MULDIV_MULHSU);
-  assign mul_signed_b = (op_i == MULDIV_MUL) | (op_i == MULDIV_MULH);
-  assign mul_a33      = mul_signed_a ? {a_i[31], a_i} : {1'b0, a_i};
-  assign mul_b33      = mul_signed_b ? {b_i[31], b_i} : {1'b0, b_i};
+  assign mul_signed_a = (mul_op_q == MULDIV_MUL) | (mul_op_q == MULDIV_MULH) | (mul_op_q == MULDIV_MULHSU);
+  assign mul_signed_b = (mul_op_q == MULDIV_MUL) | (mul_op_q == MULDIV_MULH);
+  assign mul_a33      = mul_signed_a ? {mul_a_q[31], mul_a_q} : {1'b0, mul_a_q};
+  assign mul_b33      = mul_signed_b ? {mul_b_q[31], mul_b_q} : {1'b0, mul_b_q};
   assign mul_product  = $signed(mul_a33) * $signed(mul_b33);
 
   logic [31:0] mul_result_comb;
-  assign mul_result_comb = (op_i == MULDIV_MUL) ? mul_product[31:0] : mul_product[63:32];
+  assign mul_result_comb = (mul_op_q == MULDIV_MUL) ? mul_product[31:0] : mul_product[63:32];
 
   // -------------------------------------------------------------------------
   // DIV: registers for iterative restoring division
@@ -100,6 +105,9 @@ module kronos_muldiv
     if (!rst_ni) begin
       state_q     <= IDLE;
       result_q    <= '0;
+      mul_a_q     <= '0;
+      mul_b_q     <= '0;
+      mul_op_q    <= MULDIV_MUL;
       dividend_q  <= '0;
       remainder_q <= '0;
       quotient_q  <= '0;
@@ -116,8 +124,10 @@ module kronos_muldiv
           if (req_i) begin
             unique case (op_i)
               MULDIV_MUL, MULDIV_MULH, MULDIV_MULHSU, MULDIV_MULHU: begin
-                // Capture combinational product; spend one cycle in MUL_BUSY
-                result_q <= mul_result_comb;
+                // Latch operands; product is computed and registered in MUL_BUSY
+                mul_a_q  <= a_i;
+                mul_b_q  <= b_i;
+                mul_op_q <= op_i;
                 state_q  <= MUL_BUSY;
               end
 
@@ -170,9 +180,10 @@ module kronos_muldiv
 
         // ---------------------------------------------------------------
         MUL_BUSY: begin
-          // result_q already holds the product from the IDLE cycle.
-          // Spend exactly one busy cycle, then expose the result.
-          state_q <= DONE;
+          // Operands are stable in mul_a_q/mul_b_q; register the product now.
+          // Synthesis sees a full clock period: mul_a/b_q flops → mul_product → result_q.
+          result_q <= mul_result_comb;
+          state_q  <= DONE;
         end
 
         // ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

`kronos_muldiv` was computing the 33×33 signed product combinationally from `a_i`/`b_i` and capturing it into `result_q` in the same IDLE cycle that `req_i` fired. This forced synthesis to fit the full multiplier path — from the pipeline's `id_ex_q` flops through `mul_product` into `result_q` — into a single clock period. `MUL_BUSY` was a dead stall cycle with no computation, wasting a cycle while the hard constraint sat on the wrong path.

A `set_multicycle_path -setup 2` XDC would have been incorrect: the operands advance out of `id_ex_q` on the next edge, so synthesis would not build a path that actually meets two clock periods of real logic time.

## Fix

- **IDLE on `req_i`**: latch `a_i`, `b_i`, `op_i` into dedicated `mul_a_q`/`mul_b_q`/`mul_op_q` registers; transition to `MUL_BUSY`
- **MUL_BUSY**: compute `mul_product` from the latched operands and register into `result_q`; transition to `DONE`

Synthesis now sees a legitimate single-cycle path: `mul_a/b_q flops → 33×33 multiply → result_q flop`. Vivado can map this directly into pipelined DSP48s at the target frequency with no XDC constraint needed.

DIV is unaffected — its IDLE initialisation is a conditional 32-bit negation (cheap adder path), and the COMPUTE step already operates entirely on registered values.

## Verification

- `make sim-muldiv`: 24/24 MUL/MULH/MULHSU/MULHU/DIV/DIVU/REM/REMU cases pass
- `make sim-compliance` (= `sim-compliance-s2`): 38/38 rv32ui compliance tests pass, 14/14 sw integration programs pass