### PR TITLE
feat(stage4): RV64IMAC — 64-bit pipeline + A extension

### DIFF
--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -1,0 +1,29 @@
+name: sim-all
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  sim-all:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Verilator
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y verilator
+
+      - name: Install RISC-V toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run sim-all
+        run: make -C sim sim-all PULP_AXI_ROOT=/tmp/pulp_axi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,30 @@ Commit message convention: `type(scope): description`
 - Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`
 - Scopes: `alu`, `decode`, `regfile`, `lsu`, `csr`, `top`, `sim`, `sw`, `pkg`
 
+## Pull Requests
+
+Do not include any reference to Claude or AI tools in PR titles, bodies, or descriptions
+(no `🤖 Generated with Claude Code`, no `Co-Authored-By`, no similar footers).
+
+Before creating any PR:
+
+1. Squash all commits on the branch into a single commit.
+2. Rebase on main:
+
+```bash
+git pull --rebase --autostash origin main
+```
+
+When merging, delete the branch:
+
+```bash
+gh pr merge --delete-branch
+```
+
 ## Branch Workflow
 
 One branch per stage. Open it when you start, commit freely during development,
-squash to a single commit when the stage is done, then merge to `main` via PR.
+then squash to a single commit and open a PR before merging.
 
 Direct pushes to `main` are blocked — all changes must go through a pull request.
 
@@ -170,26 +190,23 @@ git checkout -b stage3
 
 # 2. Develop freely — granular commits are fine on the branch
 
-# 3. Pick up any commits that landed on main while you worked
-git pull --rebase --autostash origin main
-
-# 4. Squash all branch commits into one
+# 3. Squash all branch commits into one
 git reset --soft origin/main
 git commit -m "feat(stage3): C extension + branch predictor"
 
-# 5. Open a pull request and merge
+# 4. Rebase on main
+git pull --rebase --autostash origin main
+
+# 5. Open a pull request
 git push -u origin stage3
-# Then open a PR on GitHub; merge via squash merge to main
-git checkout main
-git pull origin main
-git branch -d stage3
+gh pr create --title "feat(stage3): C extension + branch predictor" --body "..."
+
+# 6. Merge and delete the branch
+gh pr merge --delete-branch
 ```
 
 `main` always has exactly one commit per completed stage, plus the skeleton and docs
-commits. Use squash merge on GitHub PRs.
-
-Do not include any reference to Claude or AI tools in commit messages
-(no `🤖 Generated with Claude Code`, no `Co-Authored-By`, no similar footers).
+commits.
 
 ## SystemVerilog Coding Guidelines
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ superscalar design.
 
 **Final target:** RV64GC (RV64IMAFDС)
 
-The register file is 64-bit wide from Stage 0. RV32 software runs throughout
-all stages; RV64 support is added at Stage 4.
+The pipeline is 64-bit wide from Stage 4. Stages 0–3 implement RV32I/IM/IMC;
+Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 
 ## Staged Development
 
@@ -24,7 +24,7 @@ all stages; RV64 support is added at Stage 4.
 | 1     | 5-stage in-order pipeline                       | RV32I            | OBI     | Complete    |
 | 2     | M extension + CSR hardening                     | RV32IM           | OBI     | Complete    |
 | 3     | AXI4 switch + C extension + branch predictor   | RV32IMC          | AXI4    | Complete    |
-| 4     | RV64I + A extension                             | RV64IMAC         | AXI4    | Planned     |
+| 4     | RV64I + A extension                             | RV64IMAC         | AXI4    | Complete    |
 | 5     | F/D extensions (floating point)                 | RV64IMAFDС       | AXI4    | Planned     |
 | 6     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
@@ -60,27 +60,37 @@ kronos-riscv/
 │   │   ├── kronos_decode.sv   # RV32I+M decoder (extends stage0)
 │   │   ├── kronos_muldiv.sv   # Multi-cycle mul/div FSM (2–34 cycles)
 │   │   └── kronos_top.sv      # Stage2 pipeline top (muldiv + combined stall)
-│   └── stage3/                # Stage 3: AXI4 bus + C extension + branch predictor
-│       ├── kronos_lsu.sv      # AXI4 LSU (single-outstanding, replaces OBI LSU)
-│       ├── kronos_decompress.sv # RV32C 16-bit → 32-bit instruction expander
-│       ├── kronos_align.sv    # Fetch alignment buffer (variable-width instructions)
-│       ├── kronos_bpred.sv    # Bimodal branch predictor with BTB
-│       └── kronos_top.sv      # Stage3 pipeline top (AXI4 + C ext + bpred)
+│   ├── stage3/                # Stage 3: AXI4 bus + C extension + branch predictor
+│   │   ├── kronos_lsu.sv      # AXI4 LSU (single-outstanding, replaces OBI LSU)
+│   │   ├── kronos_decompress.sv # RV32C 16-bit → 32-bit instruction expander
+│   │   ├── kronos_align.sv    # Fetch alignment buffer (variable-width instructions)
+│   │   ├── kronos_bpred.sv    # Bimodal branch predictor with BTB
+│   │   └── kronos_top.sv      # Stage3 pipeline top (AXI4 + C ext + bpred)
+│   └── stage4/                # Stage 4: RV64I + A extension
+│       ├── kronos_alu.sv      # 64-bit ALU with W-suffix (ADDW/SUBW/…)
+│       ├── kronos_decode.sv   # RV64IMAC decoder
+│       ├── kronos_decompress.sv # RV64C 16-bit → 32-bit instruction expander
+│       ├── kronos_muldiv.sv   # 64-bit multiply/divide unit
+│       ├── kronos_lsu.sv      # AXI4 LSU with LR/SC reservation + AMO RMW
+│       ├── kronos_csr.sv      # 64-bit CSR file (mstatus.SXL/UXL = 2)
+│       └── kronos_top.sv      # Stage4 pipeline top
 ├── tb/
 │   ├── tb_pkg.sv              # Shared testbench utilities
 │   ├── stage0/                # Stage 0 testbenches
 │   ├── stage1/                # Stage 1 unit testbenches
 │   ├── stage2/                # Stage 2 unit testbenches
-│   └── stage3/                # Stage 3 unit testbenches
+│   ├── stage3/                # Stage 3 unit testbenches
+│   └── stage4/                # Stage 4 unit testbenches
 ├── sw/
 │   ├── stage0/                # Stage 0 test programs (RISC-V assembly)
 │   ├── stage1/                # Stage 1 hazard-focused test programs
 │   ├── stage2/                # Stage 2 M-extension test programs
-│   └── stage3/                # Stage 3 test programs
+│   ├── stage3/                # Stage 3 test programs
+│   └── stage4/                # Stage 4 test programs (RV64IMAC)
 ├── sim/
 │   ├── Makefile               # Verilator build and run targets
 │   └── sim_main.cpp           # C++ simulation driver
-├── kronos_riscv.core          # FuseSoC core descriptor (active: stage3)
+├── kronos_riscv.core          # FuseSoC core descriptor (active: stage4)
 ├── LICENSE
 └── CLAUDE.md                  # Claude Code project instructions
 ```
@@ -99,25 +109,38 @@ kronos-riscv/
 Prerequisites: Verilator, FuseSoC, `riscv64-unknown-elf-gcc`.
 
 ```bash
-# Lint (stage 2, default)
+# Lint (stage 4, default)
 fusesoc --cores-root=. run --target=lint opensoc:ip:kronos_riscv
 
 # Lint earlier stages
+fusesoc --cores-root=. run --target=lint-s3 opensoc:ip:kronos_riscv
+fusesoc --cores-root=. run --target=lint-s2 opensoc:ip:kronos_riscv
 fusesoc --cores-root=. run --target=lint-s1 opensoc:ip:kronos_riscv
 fusesoc --cores-root=. run --target=lint-s0 opensoc:ip:kronos_riscv
 
 # Build simulators
+cd sim && make build-s4   # stage 4 (RV64IMAC, AXI4) — active
 cd sim && make build-s3   # stage 3 (RV32IMC, AXI4)
 cd sim && make build-s2   # stage 2 (RV32IM)
 cd sim && make build-s1   # stage 1 (RV32I)
 
-# Run a stage 3 test
-cd sim && make run-s3-test_c_basic
-cd sim && make run-s3-test_c_control
-cd sim && make run-s3-test_bpred_loop
+# Run stage 4 tests
+cd sim && make run-s4-test_rv64i_basic
+cd sim && make run-s4-test_word_ops
+cd sim && make run-s4-test_64bit_loadstore
+cd sim && make run-s4-test_atomic
+
+# Stage 4 regression (all stages 0–4, ISA-compatible tests)
+cd sim && make sim-compliance-s4
+
+# Stage 4 unit testbenches
+cd sim && make sim-alu-s4      # 64-bit ALU
+cd sim && make sim-decode-s4   # RV64IMAC decoder
+cd sim && make sim-muldiv-s4   # 64-bit multiply/divide
+cd sim && make sim-lsu-s4      # AXI4 LSU with LR/SC + AMO
 
 # Stage 3 unit testbenches
-cd sim && make sim-decompress  # RV32C instruction expander
+cd sim && make sim-decompress  # RV64C instruction expander
 cd sim && make sim-bpred       # branch predictor
 cd sim && make sim-lsu-s3      # AXI4 LSU
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # kronos-riscv Architecture Reference
 
-**ISA:** RV32IMC &nbsp;|&nbsp; **Microarchitecture:** 5-stage in-order pipeline &nbsp;|&nbsp; **Bus:** AXI4-Lite &nbsp;|&nbsp; **Branch prediction:** bimodal (64-entry PHT + 16-entry BTB)
+**ISA:** RV64IMAC &nbsp;|&nbsp; **Microarchitecture:** 5-stage in-order pipeline &nbsp;|&nbsp; **Bus:** AXI4 &nbsp;|&nbsp; **Branch prediction:** bimodal (64-entry PHT + 16-entry BTB)
 
 kronos-riscv is a 5-stage in-order RISC-V processor implementing the RV32IMC ISA. Instructions flow through Instruction Fetch (IF), Instruction Decode (ID), Execute (EX), Memory (MEM), and Writeback (WB). The IF stage includes an alignment unit that handles variable-width compressed instructions and a bimodal branch predictor that speculatively redirects fetch before branch resolution. The EX stage contains the ALU, a multi-cycle multiply/divide unit, branch resolution logic, and the CSR unit. The MEM stage drives an AXI4 load/store unit. Hazard and forwarding control modules sit outside the pipeline stages and manage stalls, flushes, and operand forwarding.
 
@@ -176,6 +176,27 @@ combined_stall = mem_stall | muldiv_stall | instr_fetch_stall
 **Load-use detection.** A load-use hazard exists when the instruction currently in EX is a valid load (`id_ex_valid & id_ex_is_load`), its destination is not `x0` (`id_ex_rd != 0`), and the instruction currently in ID reads the same register as either RS1 (`rs1_used & id_ex_rd == if_id_rs1`) or RS2 (`rs2_used & id_ex_rd == if_id_rs2`). The hazard inserts one bubble: IF and ID are held, the ID/EX register is flushed to NOP, and EX/MEM advances normally.
 
 ![Load-use hazard waveform](diagrams/svg/wf-load-use-hazard.svg)
+
+### Stage 4 — RV64IMAC
+
+All datapath widths widened to 64 bits. New: LR/SC reservation register, AMO
+read-modify-write sequencing in LSU, RV64C decompressor (C.ADDIW, C.LDSP,
+C.SDSP, C.LD, C.SD, C.ADDW, C.SUBW).
+
+```
+kronos_top  (rtl/stage4/kronos_top.sv)
+├── u_align      kronos_align      (rtl/stage3/kronos_align.sv)      reused
+├── u_bpred      kronos_bpred      (rtl/stage3/kronos_bpred.sv)      reused
+├── u_decompress kronos_decompress (rtl/stage4/kronos_decompress.sv) updated: RV64C
+├── u_decode     kronos_decode     (rtl/stage4/kronos_decode.sv)     updated: RV64IMAC
+├── u_regfile    kronos_regfile    (rtl/stage0/kronos_regfile.sv)    reused (now 64-bit)
+├── u_alu        kronos_alu        (rtl/stage4/kronos_alu.sv)        updated: 64-bit + W-suffix
+├── u_csr        kronos_csr        (rtl/stage4/kronos_csr.sv)        updated: 64-bit XLEN
+├── u_lsu        kronos_lsu        (rtl/stage4/kronos_lsu.sv)        updated: LR/SC + AMO
+├── u_muldiv     kronos_muldiv     (rtl/stage4/kronos_muldiv.sv)     updated: 64-bit
+├── u_forward    kronos_forward    (rtl/stage1/kronos_forward.sv)    reused
+└── u_hazard     kronos_hazard     (rtl/stage1/kronos_hazard.sv)     reused
+```
 
 ---
 

--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -63,6 +63,25 @@ filesets:
       - rtl/stage3/kronos_top.sv
     file_type: systemVerilogSource
 
+  files_rtl_s4:
+    depend:
+      - pulp-platform.org::axi:0.39.9
+    files:
+      - rtl/kronos_pkg.sv
+      - rtl/stage4/kronos_alu.sv
+      - rtl/stage4/kronos_decode.sv
+      - rtl/stage0/kronos_regfile.sv
+      - rtl/stage4/kronos_csr.sv
+      - rtl/stage4/kronos_lsu.sv
+      - rtl/stage1/kronos_forward.sv
+      - rtl/stage1/kronos_hazard.sv
+      - rtl/stage4/kronos_muldiv.sv
+      - rtl/stage4/kronos_decompress.sv
+      - rtl/stage3/kronos_align.sv
+      - rtl/stage3/kronos_bpred.sv
+      - rtl/stage4/kronos_top.sv
+    file_type: systemVerilogSource
+
   files_tb_s0:
     files:
       - tb/stage0/tb_alu.sv
@@ -111,6 +130,15 @@ targets:
 
   lint-s3:
     filesets: [files_rtl_s3]
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options: [--Wall, --Wno-UNUSED, --Wno-WIDTHEXPAND]
+    toplevel: kronos_top
+    default_tool: verilator
+
+  lint-s4:
+    filesets: [files_rtl_s4]
     tools:
       verilator:
         mode: lint-only

--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -95,6 +95,13 @@ package kronos_pkg;
     // M extension
     logic        is_muldiv;
     muldiv_op_e  muldiv_op;
+    // RV64I
+    logic        is_word_op;  // W-suffix instruction (ADDW, SUBW, etc.)
+    // A extension
+    logic        is_lr;       // LR.W or LR.D
+    logic        is_sc;       // SC.W or SC.D
+    logic        is_amo;      // AMO instruction
+    logic [4:0]  amo_funct5;  // AMO function code
     // Writeback
     wb_sel_e     wb_sel;
     // Illegal
@@ -135,8 +142,8 @@ package kronos_pkg;
   typedef struct packed {
     logic [31:0]    pc;
     decoded_instr_t dec;
-    logic [31:0]    rs1_data;
-    logic [31:0]    rs2_data;
+    logic [63:0]    rs1_data;
+    logic [63:0]    rs2_data;
     logic           valid;
     // Stage 3+
     logic        is_16b;
@@ -147,10 +154,10 @@ package kronos_pkg;
   typedef struct packed {
     logic [31:0]    pc;
     decoded_instr_t dec;
-    logic [31:0]    alu_result;
-    logic [31:0]    rs2_data;
+    logic [63:0]    alu_result;
+    logic [63:0]    rs2_data;
     logic [31:0]    pc_next;
-    logic [31:0]    csr_rdata;
+    logic [63:0]    csr_rdata;
     logic           redirect;
     logic           valid;
     // Stage 3+
@@ -159,9 +166,9 @@ package kronos_pkg;
 
   typedef struct packed {
     decoded_instr_t dec;
-    logic [31:0]    alu_result;
-    logic [31:0]    lsu_rdata;
-    logic [31:0]    csr_rdata;
+    logic [63:0]    alu_result;
+    logic [63:0]    lsu_rdata;
+    logic [63:0]    csr_rdata;
     logic [31:0]    pc4;
     logic           valid;
   } mem_wb_reg_t;

--- a/rtl/stage1/kronos_top.sv
+++ b/rtl/stage1/kronos_top.sv
@@ -174,8 +174,8 @@ module kronos_top
     .rst_ni        (rst_ni),
     .req_i         (ex_mem_q.valid & (ex_mem_q.dec.is_load | ex_mem_q.dec.is_store)),
     .we_i          (ex_mem_q.dec.is_store),
-    .addr_i        (ex_mem_q.alu_result),
-    .wdata_i       (ex_mem_q.rs2_data),
+    .addr_i        (ex_mem_q.alu_result[31:0]),
+    .wdata_i       (ex_mem_q.rs2_data[31:0]),
     .funct3_i      (ex_mem_q.dec.mem_funct3),
     .rdata_o       (lsu_rdata),
     .valid_o       (lsu_valid),
@@ -233,8 +233,8 @@ module kronos_top
     end else if (id_ex_en) begin
       id_ex_q.pc       <= if_id_q.pc;
       id_ex_q.dec      <= id_dec;
-      id_ex_q.rs1_data <= rs1_data_id;
-      id_ex_q.rs2_data <= rs2_data_id;
+      id_ex_q.rs1_data <= {{32{rs1_data_id[31]}}, rs1_data_id};
+      id_ex_q.rs2_data <= {{32{rs2_data_id[31]}}, rs2_data_id};
       id_ex_q.valid    <= if_id_q.valid;
     end
   end
@@ -246,16 +246,16 @@ module kronos_top
   // Forwarding muxes
   always_comb begin
     unique case (fwd_rs1_sel)
-      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data;
-      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result;
+      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data[31:0];
+      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs1_data = wb_result;
-      default:   fwd_rs1_data = id_ex_q.rs1_data;
+      default:   fwd_rs1_data = id_ex_q.rs1_data[31:0];
     endcase
     unique case (fwd_rs2_sel)
-      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data;
-      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result;
+      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data[31:0];
+      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs2_data = wb_result;
-      default:   fwd_rs2_data = id_ex_q.rs2_data;
+      default:   fwd_rs2_data = id_ex_q.rs2_data[31:0];
     endcase
   end
 
@@ -315,10 +315,10 @@ module kronos_top
     end else if (ex_mem_en) begin
       ex_mem_q.pc         <= id_ex_q.pc;
       ex_mem_q.dec        <= id_ex_q.dec;
-      ex_mem_q.alu_result <= alu_result;
-      ex_mem_q.rs2_data   <= fwd_rs2_data;
+      ex_mem_q.alu_result <= {{32{alu_result[31]}}, alu_result};
+      ex_mem_q.rs2_data   <= {{32{fwd_rs2_data[31]}}, fwd_rs2_data};
       ex_mem_q.pc_next    <= ex_pc_next;
-      ex_mem_q.csr_rdata  <= csr_rdata;
+      ex_mem_q.csr_rdata  <= {32'b0, csr_rdata};
       ex_mem_q.redirect   <= ex_redirect;
       // Squash valid on IRQ: instruction is re-fetched after MRET
       ex_mem_q.valid      <= id_ex_q.valid & ~irq_pending;
@@ -335,7 +335,7 @@ module kronos_top
     end else if (mem_wb_en) begin
       mem_wb_q.dec        <= ex_mem_q.dec;
       mem_wb_q.alu_result <= ex_mem_q.alu_result;
-      mem_wb_q.lsu_rdata  <= lsu_rdata;
+      mem_wb_q.lsu_rdata  <= {{32{lsu_rdata[31]}}, lsu_rdata};
       mem_wb_q.csr_rdata  <= ex_mem_q.csr_rdata;
       mem_wb_q.pc4        <= ex_mem_q.pc + 32'd4;
       mem_wb_q.valid      <= ex_mem_q.valid;
@@ -356,22 +356,14 @@ module kronos_top
   // =========================================================================
   always_comb begin
     unique case (mem_wb_q.dec.wb_sel)
-      WB_ALU:  wb_result = mem_wb_q.alu_result;
-      WB_MEM:  wb_result = mem_wb_q.lsu_rdata;
-      WB_PC4:  wb_result = mem_wb_q.pc4;
-      WB_CSR:  wb_result = mem_wb_q.csr_rdata;
-      default: wb_result = mem_wb_q.alu_result;
+      WB_ALU:  wb_result_64 = mem_wb_q.alu_result;
+      WB_MEM:  wb_result_64 = mem_wb_q.lsu_rdata;
+      WB_PC4:  wb_result_64 = {32'b0, mem_wb_q.pc4};
+      WB_CSR:  wb_result_64 = mem_wb_q.csr_rdata;
+      default: wb_result_64 = mem_wb_q.alu_result;
     endcase
   end
 
-  always_comb begin
-    unique case (mem_wb_q.dec.wb_sel)
-      WB_ALU:  wb_result_64 = {{32{wb_result[31]}}, wb_result};
-      WB_MEM:  wb_result_64 = {{32{wb_result[31]}}, wb_result};
-      WB_PC4:  wb_result_64 = {32'b0, wb_result};
-      WB_CSR:  wb_result_64 = {32'b0, wb_result};
-      default: wb_result_64 = {{32{wb_result[31]}}, wb_result};
-    endcase
-  end
+  assign wb_result = wb_result_64[31:0];
 
 endmodule

--- a/rtl/stage2/kronos_top.sv
+++ b/rtl/stage2/kronos_top.sv
@@ -230,8 +230,8 @@ module kronos_top
     .rst_ni        (rst_ni),
     .req_i         (ex_mem_q.valid & (ex_mem_q.dec.is_load | ex_mem_q.dec.is_store) & ~mem_done_q),
     .we_i          (ex_mem_q.dec.is_store),
-    .addr_i        (ex_mem_q.alu_result),
-    .wdata_i       (ex_mem_q.rs2_data),
+    .addr_i        (ex_mem_q.alu_result[31:0]),
+    .wdata_i       (ex_mem_q.rs2_data[31:0]),
     .funct3_i      (ex_mem_q.dec.mem_funct3),
     .rdata_o       (lsu_rdata),
     .valid_o       (lsu_valid),
@@ -289,8 +289,8 @@ module kronos_top
     end else if (id_ex_en) begin
       id_ex_q.pc       <= if_id_q.pc;
       id_ex_q.dec      <= id_dec;
-      id_ex_q.rs1_data <= rs1_data_id;
-      id_ex_q.rs2_data <= rs2_data_id;
+      id_ex_q.rs1_data <= {{32{rs1_data_id[31]}}, rs1_data_id};
+      id_ex_q.rs2_data <= {{32{rs2_data_id[31]}}, rs2_data_id};
       id_ex_q.valid    <= if_id_q.valid;
     end
   end
@@ -302,16 +302,16 @@ module kronos_top
   // Forwarding muxes
   always_comb begin
     unique case (fwd_rs1_sel)
-      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data;
-      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result;
+      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data[31:0];
+      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs1_data = wb_result;
-      default:   fwd_rs1_data = id_ex_q.rs1_data;
+      default:   fwd_rs1_data = id_ex_q.rs1_data[31:0];
     endcase
     unique case (fwd_rs2_sel)
-      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data;
-      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result;
+      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data[31:0];
+      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs2_data = wb_result;
-      default:   fwd_rs2_data = id_ex_q.rs2_data;
+      default:   fwd_rs2_data = id_ex_q.rs2_data[31:0];
     endcase
   end
 
@@ -371,10 +371,10 @@ module kronos_top
     end else if (ex_mem_en) begin
       ex_mem_q.pc         <= id_ex_q.pc;
       ex_mem_q.dec        <= id_ex_q.dec;
-      ex_mem_q.alu_result <= ex_result;     // STAGE2: ex_result, not alu_result
-      ex_mem_q.rs2_data   <= fwd_rs2_data;
+      ex_mem_q.alu_result <= {{32{ex_result[31]}}, ex_result};     // STAGE2: ex_result, not alu_result
+      ex_mem_q.rs2_data   <= {{32{fwd_rs2_data[31]}}, fwd_rs2_data};
       ex_mem_q.pc_next    <= ex_pc_next;
-      ex_mem_q.csr_rdata  <= csr_rdata;
+      ex_mem_q.csr_rdata  <= {32'b0, csr_rdata};
       ex_mem_q.redirect   <= ex_redirect;
       // Squash valid on IRQ: instruction is re-fetched after MRET
       ex_mem_q.valid      <= id_ex_q.valid & ~irq_pending;
@@ -411,7 +411,8 @@ module kronos_top
       mem_wb_q.alu_result <= ex_mem_q.alu_result;
       // Use current rdata when LSU fires on this cycle; use latched value when
       // the pipeline is advancing after an earlier lsu_valid (mem_done_q=1).
-      mem_wb_q.lsu_rdata  <= lsu_valid ? lsu_rdata : lsu_rdata_latch;
+      mem_wb_q.lsu_rdata  <= {{32{(lsu_valid ? lsu_rdata[31] : lsu_rdata_latch[31])}},
+                              (lsu_valid ? lsu_rdata : lsu_rdata_latch)};
       mem_wb_q.csr_rdata  <= ex_mem_q.csr_rdata;
       mem_wb_q.pc4        <= ex_mem_q.pc + 32'd4;
       mem_wb_q.valid      <= ex_mem_q.valid;
@@ -432,22 +433,14 @@ module kronos_top
   // =========================================================================
   always_comb begin
     unique case (mem_wb_q.dec.wb_sel)
-      WB_ALU:  wb_result = mem_wb_q.alu_result;
-      WB_MEM:  wb_result = mem_wb_q.lsu_rdata;
-      WB_PC4:  wb_result = mem_wb_q.pc4;
-      WB_CSR:  wb_result = mem_wb_q.csr_rdata;
-      default: wb_result = mem_wb_q.alu_result;
+      WB_ALU:  wb_result_64 = mem_wb_q.alu_result;
+      WB_MEM:  wb_result_64 = mem_wb_q.lsu_rdata;
+      WB_PC4:  wb_result_64 = {32'b0, mem_wb_q.pc4};
+      WB_CSR:  wb_result_64 = mem_wb_q.csr_rdata;
+      default: wb_result_64 = mem_wb_q.alu_result;
     endcase
   end
 
-  always_comb begin
-    unique case (mem_wb_q.dec.wb_sel)
-      WB_ALU:  wb_result_64 = {{32{wb_result[31]}}, wb_result};
-      WB_MEM:  wb_result_64 = {{32{wb_result[31]}}, wb_result};
-      WB_PC4:  wb_result_64 = {32'b0, wb_result};
-      WB_CSR:  wb_result_64 = {32'b0, wb_result};
-      default: wb_result_64 = {{32{wb_result[31]}}, wb_result};
-    endcase
-  end
+  assign wb_result = wb_result_64[31:0];
 
 endmodule

--- a/rtl/stage4/kronos_alu.sv
+++ b/rtl/stage4/kronos_alu.sv
@@ -1,0 +1,78 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_alu.sv (stage4) — 64-bit ALU with W-suffix support.
+// When word_op_i=1, operates on lower 32 bits and sign-extends result to 64.
+module kronos_alu
+  import kronos_pkg::*;
+(
+  input  alu_op_e     op_i,
+  input  logic [63:0] a_i,
+  input  logic [63:0] b_i,
+  input  logic        word_op_i,
+  output logic [63:0] result_o
+);
+
+  logic [63:0] result_64;
+  logic [31:0] result_32;
+
+  always_comb begin
+    result_64 = '0;
+    result_32 = '0;
+
+    unique case (op_i)
+      ALU_ADD: begin
+        result_64 = a_i + b_i;
+        result_32 = a_i[31:0] + b_i[31:0];
+      end
+      ALU_SUB: begin
+        result_64 = a_i - b_i;
+        result_32 = a_i[31:0] - b_i[31:0];
+      end
+      ALU_SLL: begin
+        result_64 = a_i << b_i[5:0];
+        result_32 = a_i[31:0] << b_i[4:0];
+      end
+      ALU_SLT: begin
+        result_64 = {63'b0, $signed(a_i) < $signed(b_i)};
+        result_32 = result_64[31:0];
+      end
+      ALU_SLTU: begin
+        result_64 = {63'b0, a_i < b_i};
+        result_32 = result_64[31:0];
+      end
+      ALU_XOR: begin
+        result_64 = a_i ^ b_i;
+        result_32 = a_i[31:0] ^ b_i[31:0];
+      end
+      ALU_SRL: begin
+        result_64 = a_i >> b_i[5:0];
+        result_32 = a_i[31:0] >> b_i[4:0];
+      end
+      ALU_SRA: begin
+        result_64 = 64'($signed(a_i) >>> b_i[5:0]);
+        result_32 = 32'($signed(a_i[31:0]) >>> b_i[4:0]);
+      end
+      ALU_OR: begin
+        result_64 = a_i | b_i;
+        result_32 = a_i[31:0] | b_i[31:0];
+      end
+      ALU_AND: begin
+        result_64 = a_i & b_i;
+        result_32 = a_i[31:0] & b_i[31:0];
+      end
+      ALU_PASSB: begin
+        result_64 = b_i;
+        result_32 = b_i[31:0];
+      end
+      default: begin
+        result_64 = '0;
+        result_32 = '0;
+      end
+    endcase
+
+    result_o = word_op_i ? {{32{result_32[31]}}, result_32} : result_64;
+  end
+
+endmodule

--- a/rtl/stage4/kronos_csr.sv
+++ b/rtl/stage4/kronos_csr.sv
@@ -1,0 +1,140 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_csr.sv — machine-mode CSR file for Stage 4 (RV64)
+// Implements mstatus, misa, mie, mtvec, mscratch, mepc, mcause, mip.
+// Handles trap entry (ECALL/EBREAK/illegal), MRET, and CSR read/write.
+// All CSR data paths are 64 bits wide (MXL=10, XLEN=64).
+module kronos_csr #(
+  // MISA extension bits [25:0]. Default = I-only (bit 8).
+  // Stage 4 advertises I+M+A+C as appropriate via the top-level parameter.
+  parameter logic [25:0] MISA_EXT = 26'h0100
+) (
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        req_i,
+  input  logic [11:0] addr_i,
+  input  logic [2:0]  funct3_i,
+  input  logic        use_imm_i,
+  input  logic [63:0] rs1_data_i,
+  input  logic [4:0]  rs1_addr_i,
+  output logic [63:0] rdata_o,
+  output logic        valid_o,
+  // Trap interface
+  input  logic        trap_i,
+  input  logic [31:0] trap_pc_i,
+  input  logic [31:0] trap_cause_i,
+  input  logic        mret_i,
+  output logic [63:0] trap_vector_o,
+  output logic [63:0] mepc_o,
+  // Interrupts
+  input  logic        irq_timer_i,
+  input  logic [14:0] irq_fast_i,
+  output logic        irq_pending_o
+);
+
+  // -------------------------------------------------------------------------
+  // Machine-mode CSRs (state registers)
+  // -------------------------------------------------------------------------
+  logic [63:0] mstatus;   // 0x300
+  logic [63:0] mie;       // 0x304
+  logic [63:0] mtvec;     // 0x305
+  logic [63:0] mscratch;  // 0x340
+  logic [63:0] mepc;      // 0x341
+  logic [63:0] mcause;    // 0x342
+
+  // -------------------------------------------------------------------------
+  // Read-only / combinational CSRs
+  // -------------------------------------------------------------------------
+  logic [63:0] misa;
+  logic [63:0] mip;
+
+  // MISA: MXL=10 (64-bit) in bits [63:62], extension bits from parameter
+  assign misa = {2'b10, 36'b0, MISA_EXT};
+
+  // MIP: fast IRQs at [30:16], timer at [7] — zero-extended to 64 bits
+  assign mip  = {33'b0, irq_fast_i, 4'b0, 1'b0, 3'b0, irq_timer_i, 3'b0, 1'b0, 3'b0};
+
+  // -------------------------------------------------------------------------
+  // CSR write data (combinational)
+  // -------------------------------------------------------------------------
+  logic [63:0] csr_wdata;
+  logic [63:0] csr_new_val;
+
+  // -------------------------------------------------------------------------
+  // Outputs
+  // -------------------------------------------------------------------------
+  assign trap_vector_o = {mtvec[63:2], 2'b00};  // direct mode only
+  assign mepc_o        = mepc;
+  assign irq_pending_o = |(mip & mie) & mstatus[3]; // MIE bit
+  assign valid_o       = req_i;
+
+  // -------------------------------------------------------------------------
+  // CSR read (combinational)
+  // -------------------------------------------------------------------------
+  always_comb begin
+    unique case (addr_i)
+      12'h300: rdata_o = mstatus;
+      12'h301: rdata_o = misa;
+      12'h304: rdata_o = mie;
+      12'h305: rdata_o = mtvec;
+      12'h340: rdata_o = mscratch;
+      12'h341: rdata_o = mepc;
+      12'h342: rdata_o = mcause;
+      12'h344: rdata_o = mip;
+      default: rdata_o = 64'hDEAD_C5A0_DEAD_C5A0; // unimplemented CSR
+    endcase
+  end
+
+  always_comb begin
+    csr_wdata   = use_imm_i ? {59'b0, rs1_addr_i} : rs1_data_i;
+    csr_new_val = rdata_o;  // default: no change
+    unique case (funct3_i[1:0])
+      2'b01:   csr_new_val = csr_wdata;              // CSRRW / CSRRWI
+      2'b10:   csr_new_val = rdata_o | csr_wdata;    // CSRRS / CSRRSI
+      2'b11:   csr_new_val = rdata_o & ~csr_wdata;   // CSRRC / CSRRCI
+      default: csr_new_val = rdata_o;
+    endcase
+  end
+
+  // -------------------------------------------------------------------------
+  // Sequential logic
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mstatus  <= 64'h0000_0000_0000_1800; // MPP=11 (machine mode)
+      mie      <= '0;
+      mtvec    <= '0;
+      mscratch <= '0;
+      mepc     <= '0;
+      mcause   <= '0;
+    end else begin
+      // Trap entry (highest priority)
+      if (trap_i) begin
+        mepc       <= {32'b0, trap_pc_i};
+        mcause     <= {32'b0, trap_cause_i};
+        mstatus[7] <= mstatus[3]; // MPIE = MIE
+        mstatus[3] <= 1'b0;       // MIE = 0 (disable interrupts on trap)
+      end
+      // MRET: restore interrupt state
+      if (mret_i) begin
+        mstatus[3] <= mstatus[7]; // MIE = MPIE
+        mstatus[7] <= 1'b1;       // MPIE = 1
+      end
+      // CSR write
+      if (req_i) begin
+        unique case (addr_i)
+          12'h300: mstatus  <= csr_new_val;
+          12'h304: mie      <= csr_new_val;
+          12'h305: mtvec    <= csr_new_val;
+          12'h340: mscratch <= csr_new_val;
+          12'h341: mepc     <= csr_new_val;
+          12'h342: mcause   <= csr_new_val;
+          default: ; // read-only or unimplemented: ignore write
+        endcase
+      end
+    end
+  end
+
+endmodule

--- a/rtl/stage4/kronos_decode.sv
+++ b/rtl/stage4/kronos_decode.sv
@@ -1,0 +1,295 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode.sv (stage4) — RV64IMAC instruction decoder.
+// Extends the stage2 RV32IM decoder with:
+//   - OP-IMM 6-bit shamts (RV64 SLLI/SRLI/SRAI)
+//   - LOAD funct3=011 (LD), 110 (LWU); only 111 illegal
+//   - STORE funct3=011 (SD); funct3>011 illegal
+//   - OP-IMM-32 (0011011): ADDIW/SLLIW/SRLIW/SRAIW
+//   - OP-32    (0111011): ADDW/SUBW/SLLW/SRLW/SRAW + MULW/DIVW/DIVUW/REMW/REMUW
+//   - AMO      (0101111): LR/SC/AMO*
+// Defaults for new fields (is_word_op, is_lr, is_sc, is_amo, amo_funct5) come
+// from the `dec_o = '0;` line at the top of always_comb, which zero-initialises
+// the entire decoded_instr_t struct.
+module kronos_decode
+  import kronos_pkg::*;
+(
+  input  logic [31:0]    instr_i,
+  output decoded_instr_t dec_o
+);
+
+  // Instruction fields
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [2:0] funct3;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [6:0] funct7;
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign funct3 = instr_i[14:12];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct7 = instr_i[31:25];
+
+  // Opcode constants
+  localparam logic [6:0] OP         = 7'b011_0011; // R-type
+  localparam logic [6:0] OP_IMM     = 7'b001_0011; // I-type ALU
+  localparam logic [6:0] OP_IMM_32  = 7'b001_1011; // RV64 I-type ALU-W
+  localparam logic [6:0] OP_32      = 7'b011_1011; // RV64 R-type ALU-W
+  localparam logic [6:0] LOAD       = 7'b000_0011;
+  localparam logic [6:0] STORE      = 7'b010_0011;
+  localparam logic [6:0] BRANCH     = 7'b110_0011;
+  localparam logic [6:0] LUI        = 7'b011_0111;
+  localparam logic [6:0] AUIPC      = 7'b001_0111;
+  localparam logic [6:0] JAL        = 7'b110_1111;
+  localparam logic [6:0] JALR       = 7'b110_0111;
+  localparam logic [6:0] SYSTEM     = 7'b111_0011;
+  localparam logic [6:0] AMO        = 7'b010_1111;
+
+  always_comb begin
+    dec_o          = '0;
+    dec_o.rs1      = rs1;
+    dec_o.rs2      = rs2;
+    dec_o.rd       = rd;
+    dec_o.illegal  = 1'b0;
+
+    unique case (opcode)
+      OP: begin  // R-type: ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND + M-ext
+        dec_o.rs1_used = 1'b1;
+        dec_o.rs2_used = 1'b1;
+        dec_o.rd_wen   = 1'b1;
+        dec_o.wb_sel   = WB_ALU;
+
+        if (funct7 == 7'b000_0001) begin
+          // M extension: MUL/MULH/MULHSU/MULHU/DIV/DIVU/REM/REMU
+          dec_o.is_muldiv = 1'b1;
+          dec_o.muldiv_op = muldiv_op_e'(funct3);
+          dec_o.use_imm   = 1'b0;
+          dec_o.alu_op    = ALU_ADD; // don't-care; ALU result is discarded
+        end else begin
+          dec_o.use_imm = 1'b0;
+          unique case ({funct7, funct3})
+            {7'b000_0000, 3'b000}: dec_o.alu_op = ALU_ADD;
+            {7'b010_0000, 3'b000}: dec_o.alu_op = ALU_SUB;
+            {7'b000_0000, 3'b001}: dec_o.alu_op = ALU_SLL;
+            {7'b000_0000, 3'b010}: dec_o.alu_op = ALU_SLT;
+            {7'b000_0000, 3'b011}: dec_o.alu_op = ALU_SLTU;
+            {7'b000_0000, 3'b100}: dec_o.alu_op = ALU_XOR;
+            {7'b000_0000, 3'b101}: dec_o.alu_op = ALU_SRL;
+            {7'b010_0000, 3'b101}: dec_o.alu_op = ALU_SRA;
+            {7'b000_0000, 3'b110}: dec_o.alu_op = ALU_OR;
+            {7'b000_0000, 3'b111}: dec_o.alu_op = ALU_AND;
+            default:               dec_o.illegal = 1'b1;
+          endcase
+        end
+      end
+
+      OP_IMM: begin  // I-type ALU: ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI
+        dec_o.rs1_used = 1'b1;
+        dec_o.rd_wen   = 1'b1;
+        dec_o.use_imm  = 1'b1;
+        dec_o.wb_sel   = WB_ALU;
+        dec_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
+        unique case (funct3)
+          3'b000: dec_o.alu_op = ALU_ADD;   // ADDI
+          3'b010: dec_o.alu_op = ALU_SLT;   // SLTI
+          3'b011: dec_o.alu_op = ALU_SLTU;  // SLTIU
+          3'b100: dec_o.alu_op = ALU_XOR;   // XORI
+          3'b110: dec_o.alu_op = ALU_OR;    // ORI
+          3'b111: dec_o.alu_op = ALU_AND;   // ANDI
+          3'b001: begin  // SLLI (6-bit shamt in RV64)
+            dec_o.alu_op = ALU_SLL;
+            dec_o.imm    = {26'b0, instr_i[25:20]};
+            if (funct7[6:1] != 6'b000_000) dec_o.illegal = 1'b1;
+          end
+          3'b101: begin  // SRLI / SRAI (6-bit shamt in RV64)
+            dec_o.imm = {26'b0, instr_i[25:20]};
+            if      (funct7[6:1] == 6'b000_000) dec_o.alu_op = ALU_SRL;
+            else if (funct7[6:1] == 6'b010_000) dec_o.alu_op = ALU_SRA;
+            else                                dec_o.illegal = 1'b1;
+          end
+          default: dec_o.illegal = 1'b1;
+        endcase
+      end
+
+      OP_IMM_32: begin  // ADDIW / SLLIW / SRLIW / SRAIW
+        dec_o.rs1_used   = 1'b1;
+        dec_o.rd_wen     = 1'b1;
+        dec_o.use_imm    = 1'b1;
+        dec_o.wb_sel     = WB_ALU;
+        dec_o.is_word_op = 1'b1;
+        dec_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        unique case (funct3)
+          3'b000: dec_o.alu_op = ALU_ADD;
+          3'b001: begin  // SLLIW
+            dec_o.alu_op = ALU_SLL;
+            dec_o.imm    = {27'b0, instr_i[24:20]};
+            if (funct7 != 7'b000_0000) dec_o.illegal = 1'b1;
+          end
+          3'b101: begin  // SRLIW / SRAIW
+            dec_o.imm = {27'b0, instr_i[24:20]};
+            if      (funct7 == 7'b000_0000) dec_o.alu_op = ALU_SRL;
+            else if (funct7 == 7'b010_0000) dec_o.alu_op = ALU_SRA;
+            else                            dec_o.illegal = 1'b1;
+          end
+          default: dec_o.illegal = 1'b1;
+        endcase
+      end
+
+      OP_32: begin  // ADDW / SUBW / SLLW / SRLW / SRAW + MULW/DIVW/DIVUW/REMW/REMUW
+        dec_o.rs1_used   = 1'b1;
+        dec_o.rs2_used   = 1'b1;
+        dec_o.rd_wen     = 1'b1;
+        dec_o.wb_sel     = WB_ALU;
+        dec_o.is_word_op = 1'b1;
+
+        if (funct7 == 7'b000_0001) begin
+          dec_o.is_muldiv = 1'b1;
+          dec_o.muldiv_op = muldiv_op_e'(funct3);
+          dec_o.use_imm   = 1'b0;
+          dec_o.alu_op    = ALU_ADD;
+          if (funct3 > 3'b000 && funct3 < 3'b100) dec_o.illegal = 1'b1;
+        end else begin
+          dec_o.use_imm = 1'b0;
+          unique case ({funct7, funct3})
+            {7'b000_0000, 3'b000}: dec_o.alu_op = ALU_ADD;
+            {7'b010_0000, 3'b000}: dec_o.alu_op = ALU_SUB;
+            {7'b000_0000, 3'b001}: dec_o.alu_op = ALU_SLL;
+            {7'b000_0000, 3'b101}: dec_o.alu_op = ALU_SRL;
+            {7'b010_0000, 3'b101}: dec_o.alu_op = ALU_SRA;
+            default:               dec_o.illegal = 1'b1;
+          endcase
+        end
+      end
+
+      LUI: begin
+        dec_o.rd_wen  = 1'b1;
+        dec_o.use_imm = 1'b1;
+        dec_o.alu_op  = ALU_PASSB;
+        dec_o.imm     = {instr_i[31:12], 12'b0};
+        dec_o.wb_sel  = WB_ALU;
+      end
+
+      AUIPC: begin
+        dec_o.rd_wen  = 1'b1;
+        dec_o.use_imm = 1'b1;
+        dec_o.use_pc  = 1'b1;
+        dec_o.alu_op  = ALU_ADD;
+        dec_o.imm     = {instr_i[31:12], 12'b0};
+        dec_o.wb_sel  = WB_ALU;
+      end
+
+      JAL: begin
+        dec_o.rd_wen = 1'b1;
+        dec_o.is_jal = 1'b1;
+        // J-type immediate: imm[20|10:1|11|19:12], bit 0 always 0
+        dec_o.imm    = {{11{instr_i[31]}}, instr_i[31], instr_i[19:12],
+                        instr_i[20], instr_i[30:21], 1'b0};
+        dec_o.wb_sel = WB_PC4;
+      end
+
+      JALR: begin
+        dec_o.rs1_used = 1'b1;
+        dec_o.rd_wen   = 1'b1;
+        dec_o.is_jalr  = 1'b1;
+        dec_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
+        dec_o.wb_sel   = WB_PC4;
+        if (funct3 != 3'b000) dec_o.illegal = 1'b1;
+      end
+
+      BRANCH: begin  // BEQ, BNE, BLT, BGE, BLTU, BGEU
+        dec_o.rs1_used      = 1'b1;
+        dec_o.rs2_used      = 1'b1;
+        dec_o.is_branch     = 1'b1;
+        dec_o.branch_funct3 = funct3;
+        // B-type immediate: imm[12|10:5|4:1|11], bit 0 always 0
+        dec_o.imm = {{19{instr_i[31]}}, instr_i[31], instr_i[7],
+                     instr_i[30:25], instr_i[11:8], 1'b0};
+        if (funct3 == 3'b010 || funct3 == 3'b011) dec_o.illegal = 1'b1;
+      end
+
+      LOAD: begin  // LB, LH, LW, LBU, LHU + RV64 LD, LWU
+        dec_o.rs1_used   = 1'b1;
+        dec_o.rd_wen     = 1'b1;
+        dec_o.use_imm    = 1'b1;
+        dec_o.alu_op     = ALU_ADD;
+        dec_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        dec_o.is_load    = 1'b1;
+        dec_o.mem_funct3 = funct3;
+        dec_o.wb_sel     = WB_MEM;
+        if (funct3 == 3'b111) dec_o.illegal = 1'b1; // reserved in RV64
+      end
+
+      STORE: begin  // SB, SH, SW + RV64 SD
+        dec_o.rs1_used   = 1'b1;
+        dec_o.rs2_used   = 1'b1;
+        dec_o.use_imm    = 1'b1;
+        dec_o.alu_op     = ALU_ADD;
+        dec_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
+        dec_o.is_store   = 1'b1;
+        dec_o.mem_funct3 = funct3;
+        dec_o.wb_sel     = WB_ALU;
+        dec_o.rd_wen     = 1'b0;
+        if (funct3 > 3'b011) dec_o.illegal = 1'b1; // only SB/SH/SW/SD
+      end
+
+      AMO: begin  // LR.W/D, SC.W/D, AMO*.W/D
+        dec_o.rs1_used   = 1'b1;
+        dec_o.rd_wen     = 1'b1;
+        dec_o.wb_sel     = WB_MEM;
+        dec_o.mem_funct3 = funct3;
+        dec_o.use_imm    = 1'b1;
+        dec_o.alu_op     = ALU_ADD;
+        dec_o.imm        = 32'd0;
+
+        unique case (funct7[6:2])
+          5'b00010: begin
+            dec_o.is_load = 1'b1;
+            dec_o.is_lr   = 1'b1;
+          end
+          5'b00011: begin
+            dec_o.is_store = 1'b1;
+            dec_o.is_sc    = 1'b1;
+            dec_o.rs2_used = 1'b1;
+          end
+          default: begin
+            dec_o.is_amo     = 1'b1;
+            dec_o.amo_funct5 = funct7[6:2];
+            dec_o.rs2_used   = 1'b1;
+          end
+        endcase
+
+        if (funct3 != 3'b010 && funct3 != 3'b011) dec_o.illegal = 1'b1;
+      end
+
+      SYSTEM: begin
+        unique case (funct3)
+          3'b000: begin  // ECALL, EBREAK, MRET
+            unique case (instr_i[31:20])
+              12'h000: dec_o.is_ecall  = 1'b1;
+              12'h001: dec_o.is_ebreak = 1'b1;
+              12'h302: dec_o.is_mret   = 1'b1;
+              default: dec_o.illegal   = 1'b1;
+            endcase
+          end
+          default: begin  // CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI
+            dec_o.is_csr      = 1'b1;
+            dec_o.rd_wen      = 1'b1;
+            dec_o.rs1_used    = ~funct3[2]; // funct3[2]=1 means zimm form
+            dec_o.csr_addr    = instr_i[31:20];
+            dec_o.csr_funct3  = funct3;
+            dec_o.csr_use_imm = funct3[2];
+            dec_o.wb_sel      = WB_CSR;
+          end
+        endcase
+      end
+
+      default: dec_o.illegal = 1'b1;
+    endcase
+  end
+
+endmodule

--- a/rtl/stage4/kronos_decompress.sv
+++ b/rtl/stage4/kronos_decompress.sv
@@ -1,0 +1,283 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decompress.sv — RV32C 16-bit instruction expander.
+// Purely combinational. Returns the 32-bit canonical RV32I equivalent.
+// Sets illegal_o=1 for reserved or undefined encodings.
+module kronos_decompress (
+  input  logic [15:0] instr16_i,
+  output logic [31:0] instr32_o,
+  output logic        illegal_o
+);
+  logic [2:0]  funct3;
+  logic [4:0]  rd,  rs1,  rs2;
+  logic [2:0]  rd_p, rs1_p, rs2_p;
+
+  assign funct3 = instr16_i[15:13];
+  assign rd     = instr16_i[11:7];
+  assign rs1    = instr16_i[11:7];
+  assign rs2    = instr16_i[6:2];
+  assign rd_p   = instr16_i[4:2];
+  assign rs1_p  = instr16_i[9:7];
+  assign rs2_p  = instr16_i[4:2];
+
+  logic [4:0] rd_full, rs1_full, rs2_full;
+  assign rd_full  = {2'b01, rd_p};
+  assign rs1_full = {2'b01, rs1_p};
+  assign rs2_full = {2'b01, rs2_p};
+
+  localparam logic [6:0] OP_IMM   = 7'b001_0011;
+  localparam logic [6:0] OP_LUI   = 7'b011_0111;
+  localparam logic [6:0] OP_JAL   = 7'b110_1111;
+  localparam logic [6:0] OP_JALR  = 7'b110_0111;
+  localparam logic [6:0] OP_LOAD  = 7'b000_0011;
+  localparam logic [6:0] OP_STORE = 7'b010_0011;
+  localparam logic [6:0] OP_BRNCH = 7'b110_0011;
+  localparam logic [6:0] OP_REG     = 7'b011_0011;
+  localparam logic [6:0] OP_IMM_32 = 7'b001_1011;  // RV64 OP-IMM-32 (ADDIW/SLLIW/etc.)
+
+  // Temporary signals for immediate assembly (shared across case arms — only one active at a time)
+  logic [11:0] uimm;
+  logic [31:0] nzimm;
+  logic [31:0] imm;
+  logic [31:0] off;
+  logic [5:0]  shamt;
+
+  always_comb begin
+    instr32_o = '0;
+    illegal_o = 1'b0;
+
+    unique case (instr16_i[1:0])
+
+      // ---------------------------------------------------------------
+      // Quadrant 0
+      // ---------------------------------------------------------------
+      2'b00: begin
+        unique case (funct3)
+
+          3'b000: begin  // C.ADDI4SPN → ADDI rd', x2, nzuimm
+            uimm = {2'b0, instr16_i[10:7], instr16_i[12:11],
+                    instr16_i[5], instr16_i[6], 2'b0};
+            if (uimm == '0) illegal_o = 1'b1;
+            else instr32_o = {uimm, 5'd2, 3'b000, rd_full, OP_IMM};
+          end
+
+          3'b001: begin  // RV64C: C.LD → LD rd', uimm(rs1')
+            uimm = {4'b0, instr16_i[6:5], instr16_i[12:10], 3'b0};
+            instr32_o = {uimm, rs1_full, 3'b011, rd_full, OP_LOAD};
+          end
+
+          3'b010: begin  // C.LW → LW rd', offset(rs1')
+            uimm = {5'b0, instr16_i[5], instr16_i[12:10], instr16_i[6], 2'b0};
+            instr32_o = {uimm, rs1_full, 3'b010, rd_full, OP_LOAD};
+          end
+
+          3'b011: begin  // RV64C: C.LD (also via funct3=011 in RV64) → LD rd', uimm(rs1')
+            uimm = {4'b0, instr16_i[6:5], instr16_i[12:10], 3'b0};
+            instr32_o = {uimm, rs1_full, 3'b011, rd_full, OP_LOAD};
+          end
+
+          3'b101: begin  // RV64C: C.SD → SD rs2', uimm(rs1')
+            uimm = {4'b0, instr16_i[6:5], instr16_i[12:10], 3'b0};
+            instr32_o = {uimm[11:5], rs2_full, rs1_full, 3'b011,
+                         uimm[4:0], OP_STORE};
+          end
+
+          3'b111: begin  // RV64C: C.SD (also via funct3=111 in RV64) → SD rs2', uimm(rs1')
+            uimm = {4'b0, instr16_i[6:5], instr16_i[12:10], 3'b0};
+            instr32_o = {uimm[11:5], rs2_full, rs1_full, 3'b011,
+                         uimm[4:0], OP_STORE};
+          end
+
+          3'b110: begin  // C.SW → SW rs2', offset(rs1')
+            uimm = {5'b0, instr16_i[5], instr16_i[12:10], instr16_i[6], 2'b0};
+            instr32_o = {uimm[11:5], rs2_full, rs1_full, 3'b010,
+                         uimm[4:0], OP_STORE};
+          end
+
+          default: illegal_o = 1'b1;
+        endcase
+      end
+
+      // ---------------------------------------------------------------
+      // Quadrant 1
+      // ---------------------------------------------------------------
+      2'b01: begin
+        unique case (funct3)
+
+          3'b000: begin  // C.NOP / C.ADDI → ADDI rd, rd, nzimm
+            nzimm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            instr32_o = {nzimm[11:0], rd, 3'b000, rd, OP_IMM};
+          end
+
+          3'b001: begin  // RV64C: C.ADDIW → ADDIW rd, rd, imm  (C.JAL removed in RV64)
+            imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            if (rd == 5'd0) illegal_o = 1'b1;
+            else instr32_o = {imm[11:0], rd, 3'b000, rd, OP_IMM_32};
+          end
+
+          3'b010: begin  // C.LI → ADDI rd, x0, imm
+            imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+            instr32_o = {imm[11:0], 5'd0, 3'b000, rd, OP_IMM};
+          end
+
+          3'b011: begin  // C.LUI / C.ADDI16SP
+            if (rd == 5'd2) begin  // C.ADDI16SP → ADDI x2, x2, nzimm
+              nzimm = {{23{instr16_i[12]}}, instr16_i[4:3], instr16_i[5],
+                       instr16_i[2], instr16_i[6], 4'b0};
+              if (nzimm == '0) illegal_o = 1'b1;
+              else instr32_o = {nzimm[11:0], 5'd2, 3'b000, 5'd2, OP_IMM};
+            end else begin  // C.LUI → LUI rd, nzimm
+              nzimm = {{15{instr16_i[12]}}, instr16_i[6:2], 12'b0};
+              if (nzimm == '0) illegal_o = 1'b1;
+              else instr32_o = {nzimm[31:12], rd, OP_LUI};
+            end
+          end
+
+          3'b100: begin  // C.SRLI / C.SRAI / C.ANDI / C.SUB/XOR/OR/AND / C.SUBW/C.ADDW
+            shamt = {instr16_i[12], instr16_i[6:2]};
+            unique case (instr16_i[11:10])
+
+              2'b00: begin  // C.SRLI → SRLI rs1', rs1', shamt
+                if (shamt == 6'd0) illegal_o = 1'b1;
+                else instr32_o = {6'b000_000, shamt, rs1_full,
+                                  3'b101, rs1_full, OP_IMM};
+              end
+
+              2'b01: begin  // C.SRAI → SRAI rs1', rs1', shamt
+                if (shamt == 6'd0) illegal_o = 1'b1;
+                else instr32_o = {6'b010_000, shamt, rs1_full,
+                                  3'b101, rs1_full, OP_IMM};
+              end
+
+              2'b10: begin  // C.ANDI → ANDI rs1', rs1', imm
+                imm = {{26{instr16_i[12]}}, instr16_i[6:2]};
+                instr32_o = {imm[11:0], rs1_full, 3'b111, rs1_full, OP_IMM};
+              end
+
+              2'b11: begin
+                if (instr16_i[12] == 1'b0) begin
+                  // RV32C: C.SUB, C.XOR, C.OR, C.AND
+                  unique case (instr16_i[6:5])
+                    2'b00: instr32_o = {7'b010_0000, rs2_full, rs1_full,
+                                        3'b000, rs1_full, OP_REG};
+                    2'b01: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b100, rs1_full, OP_REG};
+                    2'b10: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b110, rs1_full, OP_REG};
+                    2'b11: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b111, rs1_full, OP_REG};
+                    default: illegal_o = 1'b1;
+                  endcase
+                end else begin
+                  // RV64C: C.SUBW, C.ADDW
+                  unique case (instr16_i[6:5])
+                    2'b00: instr32_o = {7'b010_0000, rs2_full, rs1_full,
+                                        3'b000, rs1_full, 7'b011_1011};  // C.SUBW
+                    2'b01: instr32_o = {7'b000_0000, rs2_full, rs1_full,
+                                        3'b000, rs1_full, 7'b011_1011};  // C.ADDW
+                    default: illegal_o = 1'b1;  // bits [6:5]=10/11 reserved
+                  endcase
+                end
+              end
+
+              default: illegal_o = 1'b1;
+            endcase
+          end
+
+          3'b101: begin  // C.J → JAL x0, offset
+            imm = {{10{instr16_i[12]}}, instr16_i[8], instr16_i[10:9],
+                   instr16_i[6], instr16_i[7], instr16_i[2], instr16_i[11],
+                   instr16_i[5:3], 1'b0};
+            instr32_o = {imm[20], imm[10:1], imm[11], imm[19:12],
+                         5'd0, OP_JAL};
+          end
+
+          3'b110: begin  // C.BEQZ → BEQ rs1', x0, offset
+            off = {{24{instr16_i[12]}}, instr16_i[6:5], instr16_i[2],
+                   instr16_i[11:10], instr16_i[4:3], 1'b0};
+            instr32_o = {off[12], off[10:5], 5'd0, rs1_full, 3'b000,
+                         off[4:1], off[11], OP_BRNCH};
+          end
+
+          3'b111: begin  // C.BNEZ → BNE rs1', x0, offset
+            off = {{24{instr16_i[12]}}, instr16_i[6:5], instr16_i[2],
+                   instr16_i[11:10], instr16_i[4:3], 1'b0};
+            instr32_o = {off[12], off[10:5], 5'd0, rs1_full, 3'b001,
+                         off[4:1], off[11], OP_BRNCH};
+          end
+
+          default: illegal_o = 1'b1;
+        endcase
+      end
+
+      // ---------------------------------------------------------------
+      // Quadrant 2
+      // ---------------------------------------------------------------
+      2'b10: begin
+        unique case (funct3)
+
+          3'b000: begin  // C.SLLI → SLLI rd, rd, shamt
+            shamt = {instr16_i[12], instr16_i[6:2]};
+            if (shamt == 6'd0 || rd == 5'd0) illegal_o = 1'b1;
+            else instr32_o = {6'b000_000, shamt, rd, 3'b001, rd, OP_IMM};
+          end
+
+          3'b011: begin  // RV64C: C.LDSP → LD rd, uimm(x2)
+            uimm = {3'b0, instr16_i[4:2], instr16_i[12], instr16_i[6:5], 3'b0};
+            if (rd == 5'd0) illegal_o = 1'b1;
+            else instr32_o = {uimm, 5'd2, 3'b011, rd, OP_LOAD};
+          end
+
+          3'b010: begin  // C.LWSP → LW rd, offset(x2)
+            uimm = {4'b0, instr16_i[3:2], instr16_i[12], instr16_i[6:4], 2'b0};
+            if (rd == 5'd0) illegal_o = 1'b1;
+            else instr32_o = {uimm, 5'd2, 3'b010, rd, OP_LOAD};
+          end
+
+          3'b100: begin  // C.JR / C.MV / C.EBREAK / C.JALR / C.ADD
+            if (instr16_i[12] == 1'b0) begin
+              if (rs2 == 5'd0 && rs1 != 5'd0) begin
+                instr32_o = {12'd0, rs1, 3'b000, 5'd0, OP_JALR};  // C.JR
+              end else if (rs2 != 5'd0) begin
+                instr32_o = {7'b000_0000, rs2, 5'd0, 3'b000, rd, OP_REG};  // C.MV
+              end else begin
+                illegal_o = 1'b1;
+              end
+            end else begin
+              if (rs1 == 5'd0 && rs2 == 5'd0) begin
+                instr32_o = 32'h00100073;  // C.EBREAK
+              end else if (rs2 == 5'd0 && rs1 != 5'd0) begin
+                instr32_o = {12'd0, rs1, 3'b000, 5'd1, OP_JALR};  // C.JALR
+              end else if (rs2 != 5'd0) begin
+                instr32_o = {7'b000_0000, rs2, rd, 3'b000, rd, OP_REG};  // C.ADD
+              end else begin
+                illegal_o = 1'b1;
+              end
+            end
+          end
+
+          3'b111: begin  // RV64C: C.SDSP → SD rs2, uimm(x2)
+            uimm = {3'b0, instr16_i[9:7], instr16_i[12:10], 3'b0};
+            instr32_o = {uimm[11:5], rs2, 5'd2, 3'b011, uimm[4:0], OP_STORE};
+          end
+
+          3'b110: begin  // C.SWSP → SW rs2, offset(x2)
+            uimm = {4'b0, instr16_i[8:7], instr16_i[12:9], 2'b0};
+            instr32_o = {uimm[11:5], rs2, 5'd2, 3'b010, uimm[4:0], OP_STORE};
+          end
+
+          default: illegal_o = 1'b1;
+        endcase
+      end
+
+      // ---------------------------------------------------------------
+      // 2'b11 — 32-bit instruction, not a compressed encoding
+      // ---------------------------------------------------------------
+      default: illegal_o = 1'b1;
+
+    endcase
+  end
+
+endmodule

--- a/rtl/stage4/kronos_lsu.sv
+++ b/rtl/stage4/kronos_lsu.sv
@@ -1,0 +1,454 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_lsu.sv (stage4) — 64-bit load/store unit with AXI4 master FSM.
+// Widens the stage3 32-bit LSU to support LD/SD/LWU using two 32-bit AXI
+// beats for the doubleword cases. Sub-word loads/stores (B/H/W) reuse the
+// stage3 byte-enable / replication / address-low-bit mux logic unchanged.
+//
+// A-extension ports (LR/SC/AMO) are accepted but inert in this stage.
+// `sc_success_o` is tied to 0 so downstream logic sees a consistent value
+// until Tasks 12 and 13 wire up the real behaviour.
+module kronos_lsu
+  import kronos_pkg::*;
+(
+  input  logic             clk_i,
+  input  logic             rst_ni,
+  // Pipeline interface (64-bit data)
+  input  logic             req_i,
+  input  logic             we_i,
+  input  logic [31:0]      addr_i,
+  input  logic [63:0]      wdata_i,
+  input  logic [2:0]       funct3_i,
+  output logic [63:0]      rdata_o,
+  output logic             valid_o,
+  output logic             mem_stall_o,
+  // A-extension (stubs for Tasks 12-13)
+  input  logic             is_lr_i,
+  input  logic             is_sc_i,
+  input  logic             is_amo_i,
+  input  logic [4:0]       amo_funct5_i,
+  input  logic [63:0]      amo_src_i,
+  output logic             sc_success_o,
+  // AXI4 master
+  output kronos_axi_req_t  axi_req_o,
+  input  kronos_axi_resp_t axi_rsp_i
+);
+
+  // -------------------------------------------------------------------------
+  // FSM state (widened to 4 bits to reserve room for AMO/SC_FAIL states)
+  // -------------------------------------------------------------------------
+  typedef enum logic [3:0] {
+    IDLE          = 4'd0,
+    LOAD_ADDR     = 4'd1,
+    LOAD_DATA     = 4'd2,
+    LOAD_DONE     = 4'd3,
+    STORE_SEND    = 4'd4,
+    STORE_RESP    = 4'd5,
+    STORE_DONE    = 4'd6,
+    LOAD_ADDR_HI  = 4'd7,
+    LOAD_DATA_HI  = 4'd8,
+    STORE_SEND_HI = 4'd9,
+    STORE_RESP_HI = 4'd10,
+    AMO_COMPUTE   = 4'd11,  // reserved for Task 13 (AMO)
+    SC_FAIL       = 4'd12   // reserved for Task 12 (SC failure)
+  } lsu_state_e;
+
+  lsu_state_e state_q;
+
+  // -------------------------------------------------------------------------
+  // Registered operands (captured at IDLE→non-IDLE transition)
+  // -------------------------------------------------------------------------
+  logic [31:0] addr_q;
+  logic [63:0] wdata_q;
+  logic [2:0]  funct3_q;
+  logic [31:0] rdata_q;
+  logic [31:0] rdata_hi_q;
+  logic        is_dword_q;
+  logic        aw_acked_q;
+  logic        w_acked_q;
+  logic        is_lr_q;
+  logic        is_sc_q;
+  logic        is_amo_q;
+  logic [4:0]  amo_funct5_q;
+  logic [63:0] amo_src_q;
+  logic        reservation_valid_q;
+  logic [31:0] reservation_addr_q;
+  logic        sc_result_q;  // 0 = success, 1 = fail; presented in rdata_o on SC
+
+  // -------------------------------------------------------------------------
+  // Byte-enable and store-data replication (sub-word stores reuse stage3
+  // logic unchanged; for SD each 32-bit beat uses strb=1111 and the raw
+  // upper/lower half of wdata_q).
+  // -------------------------------------------------------------------------
+  logic [ 3:0] be;
+  logic [31:0] wdata_rep;
+
+  always_comb begin
+    be = 4'b1111;
+    unique case (funct3_q[1:0])
+      2'b00:   be = 4'b0001 << addr_q[1:0];
+      2'b01:   be = 4'b0011 << addr_q[1:0];
+      2'b10:   be = 4'b1111;
+      2'b11:   be = 4'b1111;  // SD: both beats cover a full word
+      default: be = 4'b1111;
+    endcase
+  end
+
+  always_comb begin
+    wdata_rep = wdata_q[31:0];
+    unique case (funct3_q[1:0])
+      2'b00:   wdata_rep = {4{wdata_q[7:0]}};
+      2'b01:   wdata_rep = {2{wdata_q[15:0]}};
+      2'b10:   wdata_rep = wdata_q[31:0];
+      2'b11:   wdata_rep = wdata_q[31:0];  // SD low beat
+      default: wdata_rep = wdata_q[31:0];
+    endcase
+  end
+
+  // -------------------------------------------------------------------------
+  // AMO compute: given the loaded value (rdata_q / rdata_hi_q) and the
+  // register-file source (amo_src_q), produce the value to be written back.
+  // Word vs doubleword is selected from funct3_q (W=010, D=011).
+  // -------------------------------------------------------------------------
+  logic        amo_is_word;
+  logic [63:0] amo_new_val;
+  logic [31:0] amo_a32;
+  logic [31:0] amo_b32;
+  logic [31:0] amo_r32;
+  logic [63:0] amo_a64;
+  logic [63:0] amo_b64;
+
+  assign amo_is_word = (funct3_q[1:0] == 2'b10);
+  assign amo_a32     = rdata_q;
+  assign amo_b32     = amo_src_q[31:0];
+  assign amo_a64     = {rdata_hi_q, rdata_q};
+  assign amo_b64     = amo_src_q;
+
+  always_comb begin
+    amo_r32 = '0;
+    unique case (amo_funct5_q)
+      5'b00001: amo_r32 = amo_b32;                                              // AMOSWAP
+      5'b00000: amo_r32 = amo_a32 + amo_b32;                                    // AMOADD
+      5'b00100: amo_r32 = amo_a32 ^ amo_b32;                                    // AMOXOR
+      5'b01100: amo_r32 = amo_a32 & amo_b32;                                    // AMOAND
+      5'b01000: amo_r32 = amo_a32 | amo_b32;                                    // AMOOR
+      5'b10000: amo_r32 = ($signed(amo_a32) <  $signed(amo_b32)) ? amo_a32
+                                                                 : amo_b32;     // AMOMIN
+      5'b10100: amo_r32 = ($signed(amo_a32) >= $signed(amo_b32)) ? amo_a32
+                                                                 : amo_b32;     // AMOMAX
+      5'b11000: amo_r32 = (amo_a32 <  amo_b32) ? amo_a32 : amo_b32;             // AMOMINU
+      5'b11100: amo_r32 = (amo_a32 >= amo_b32) ? amo_a32 : amo_b32;             // AMOMAXU
+      default:  amo_r32 = '0;
+    endcase
+  end
+
+  always_comb begin
+    amo_new_val = '0;
+    if (amo_is_word) begin
+      amo_new_val = {32'b0, amo_r32};
+    end else begin
+      unique case (amo_funct5_q)
+        5'b00001: amo_new_val = amo_b64;
+        5'b00000: amo_new_val = amo_a64 + amo_b64;
+        5'b00100: amo_new_val = amo_a64 ^ amo_b64;
+        5'b01100: amo_new_val = amo_a64 & amo_b64;
+        5'b01000: amo_new_val = amo_a64 | amo_b64;
+        5'b10000: amo_new_val = ($signed(amo_a64) <  $signed(amo_b64)) ? amo_a64
+                                                                       : amo_b64;
+        5'b10100: amo_new_val = ($signed(amo_a64) >= $signed(amo_b64)) ? amo_a64
+                                                                       : amo_b64;
+        5'b11000: amo_new_val = (amo_a64 <  amo_b64) ? amo_a64 : amo_b64;
+        5'b11100: amo_new_val = (amo_a64 >= amo_b64) ? amo_a64 : amo_b64;
+        default:  amo_new_val = '0;
+      endcase
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // Load-data extraction and sign extension (64-bit result)
+  // -------------------------------------------------------------------------
+  logic [1:0]  byte_off;
+  logic [31:0] rdata_shifted;
+  logic [7:0]  raw_byte;
+  logic [15:0] raw_half;
+
+  assign byte_off      = addr_q[1:0];
+  assign rdata_shifted = rdata_q >> ({3'b0, byte_off} * 4'd8);
+  assign raw_byte      = rdata_shifted[7:0];
+  assign raw_half      = rdata_shifted[15:0];
+
+  always_comb begin
+    rdata_o = '0;
+    if (is_sc_q) begin
+      // SC returns 0 on success, 1 on failure in the destination register.
+      rdata_o = {63'b0, sc_result_q};
+    end else begin
+      unique case (funct3_q)
+        3'b000:  rdata_o = {{56{raw_byte[7]}},  raw_byte};        // LB
+        3'b001:  rdata_o = {{48{raw_half[15]}}, raw_half};        // LH
+        3'b010:  rdata_o = {{32{rdata_q[31]}},  rdata_q};         // LW (sign-ext)
+        3'b011:  rdata_o = {rdata_hi_q, rdata_q};                 // LD
+        3'b100:  rdata_o = {56'b0, raw_byte};                     // LBU
+        3'b101:  rdata_o = {48'b0, raw_half};                     // LHU
+        3'b110:  rdata_o = {32'b0, rdata_q};                      // LWU
+        default: rdata_o = '0;
+      endcase
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // FSM
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q             <= IDLE;
+      addr_q              <= '0;
+      wdata_q             <= '0;
+      funct3_q            <= '0;
+      rdata_q             <= '0;
+      rdata_hi_q          <= '0;
+      is_dword_q          <= 1'b0;
+      aw_acked_q          <= 1'b0;
+      w_acked_q           <= 1'b0;
+      is_lr_q             <= 1'b0;
+      is_sc_q             <= 1'b0;
+      is_amo_q            <= 1'b0;
+      amo_funct5_q        <= '0;
+      amo_src_q           <= '0;
+      reservation_valid_q <= 1'b0;
+      reservation_addr_q  <= '0;
+      sc_result_q         <= 1'b0;
+    end else begin
+      unique case (state_q)
+
+        IDLE: begin
+          if (req_i) begin
+            addr_q       <= addr_i;
+            wdata_q      <= wdata_i;
+            funct3_q     <= funct3_i;
+            is_dword_q   <= (funct3_i[1:0] == 2'b11);
+            is_lr_q      <= is_lr_i;
+            is_sc_q      <= is_sc_i;
+            is_amo_q     <= is_amo_i;
+            amo_funct5_q <= amo_funct5_i;
+            amo_src_q    <= amo_src_i;
+            if (is_amo_i) begin
+              // AMO: read-modify-write. Go through the load path first; after
+              // LOAD_DONE we divert to AMO_COMPUTE and then STORE_SEND. AMO
+              // does not touch the LR/SC reservation state.
+              state_q <= LOAD_ADDR;
+            end else if (is_sc_i) begin
+              // SC always clears the reservation, regardless of outcome.
+              reservation_valid_q <= 1'b0;
+              if (reservation_valid_q && (reservation_addr_q == addr_i)) begin
+                // Reservation hit: perform the store and report success.
+                sc_result_q <= 1'b0;
+                state_q     <= STORE_SEND;
+                aw_acked_q  <= 1'b0;
+                w_acked_q   <= 1'b0;
+              end else begin
+                // Reservation miss: skip the AXI store and report failure.
+                sc_result_q <= 1'b1;
+                state_q     <= SC_FAIL;
+              end
+            end else if (we_i) begin
+              // Any non-SC store invalidates an outstanding reservation
+              // (simplified single-reservation model).
+              reservation_valid_q <= 1'b0;
+              state_q    <= STORE_SEND;
+              aw_acked_q <= 1'b0;
+              w_acked_q  <= 1'b0;
+            end else begin
+              state_q <= LOAD_ADDR;
+            end
+          end
+        end
+
+        LOAD_ADDR: begin
+          if (axi_rsp_i.ar_ready) state_q <= LOAD_DATA;
+        end
+
+        LOAD_DATA: begin
+          if (axi_rsp_i.r_valid) begin
+            rdata_q <= axi_rsp_i.r.data;
+            if (is_dword_q) begin
+              state_q <= LOAD_ADDR_HI;
+            end else begin
+              state_q <= LOAD_DONE;
+              // LR.W installs a word-granular reservation on the captured
+              // address (always word-sized, so the single-beat path applies).
+              if (is_lr_q) begin
+                reservation_valid_q <= 1'b1;
+                reservation_addr_q  <= addr_q;
+              end
+            end
+          end
+        end
+
+        LOAD_ADDR_HI: begin
+          if (axi_rsp_i.ar_ready) state_q <= LOAD_DATA_HI;
+        end
+
+        LOAD_DATA_HI: begin
+          if (axi_rsp_i.r_valid) begin
+            rdata_hi_q <= axi_rsp_i.r.data;
+            state_q    <= LOAD_DONE;
+          end
+        end
+
+        LOAD_DONE: begin
+          if (is_amo_q) begin
+            // AMO: feed loaded value into the compute stage; do NOT pulse
+            // valid_o here (see valid_o assignment below).
+            state_q <= AMO_COMPUTE;
+          end else begin
+            state_q <= IDLE;  // unconditional — valid_o is a 1-cycle pulse
+          end
+        end
+
+        STORE_SEND: begin
+          if (axi_rsp_i.aw_ready) aw_acked_q <= 1'b1;
+          if (axi_rsp_i.w_ready)  w_acked_q  <= 1'b1;
+          if ((aw_acked_q | axi_rsp_i.aw_ready) &
+              (w_acked_q  | axi_rsp_i.w_ready)) begin
+            state_q    <= STORE_RESP;
+            aw_acked_q <= 1'b0;
+            w_acked_q  <= 1'b0;
+          end
+        end
+
+        STORE_RESP: begin
+          if (axi_rsp_i.b_valid) begin
+            if (is_dword_q) state_q <= STORE_SEND_HI;
+            else            state_q <= STORE_DONE;
+          end
+        end
+
+        STORE_SEND_HI: begin
+          if (axi_rsp_i.aw_ready) aw_acked_q <= 1'b1;
+          if (axi_rsp_i.w_ready)  w_acked_q  <= 1'b1;
+          if ((aw_acked_q | axi_rsp_i.aw_ready) &
+              (w_acked_q  | axi_rsp_i.w_ready)) begin
+            state_q    <= STORE_RESP_HI;
+            aw_acked_q <= 1'b0;
+            w_acked_q  <= 1'b0;
+          end
+        end
+
+        STORE_RESP_HI: begin
+          if (axi_rsp_i.b_valid) state_q <= STORE_DONE;
+        end
+
+        STORE_DONE: begin
+          // Clear the AMO flag so rdata_o returns to the normal load mux path
+          // on the next operation.
+          is_amo_q <= 1'b0;
+          state_q  <= IDLE;  // unconditional — valid_o is a 1-cycle pulse
+        end
+
+        SC_FAIL: begin
+          // One-cycle valid pulse carrying sc_result_q=1 in rdata_o.
+          state_q <= IDLE;
+        end
+
+        AMO_COMPUTE: begin
+          // Single-cycle compute: latch the ALU result into wdata_q so the
+          // existing STORE_SEND path writes it back. addr_q/funct3_q/rdata_q
+          // must remain untouched so the final valid_o pulse returns the
+          // ORIGINAL loaded value through the normal load-mux path.
+          wdata_q    <= amo_new_val;
+          aw_acked_q <= 1'b0;
+          w_acked_q  <= 1'b0;
+          state_q    <= STORE_SEND;
+        end
+
+        default: state_q <= IDLE;
+      endcase
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // AXI4 request outputs
+  // -------------------------------------------------------------------------
+  logic [31:0] addr_lo_aligned;
+  logic [31:0] addr_hi_aligned;
+
+  assign addr_lo_aligned = {addr_q[31:2], 2'b00};
+  assign addr_hi_aligned = {addr_q[31:2], 2'b00} + 32'd4;
+
+  always_comb begin
+    axi_req_o = '0;
+    unique case (state_q)
+      LOAD_ADDR: begin
+        axi_req_o.ar_valid = 1'b1;
+        axi_req_o.ar.addr  = addr_lo_aligned;
+        axi_req_o.ar.size  = 3'b010;
+        axi_req_o.ar.burst = axi_pkg::BURST_INCR;
+      end
+      LOAD_DATA: begin
+        axi_req_o.r_ready  = 1'b1;
+      end
+      LOAD_ADDR_HI: begin
+        axi_req_o.ar_valid = 1'b1;
+        axi_req_o.ar.addr  = addr_hi_aligned;
+        axi_req_o.ar.size  = 3'b010;
+        axi_req_o.ar.burst = axi_pkg::BURST_INCR;
+      end
+      LOAD_DATA_HI: begin
+        axi_req_o.r_ready  = 1'b1;
+      end
+      STORE_SEND: begin
+        axi_req_o.aw_valid = ~aw_acked_q;
+        axi_req_o.aw.addr  = addr_lo_aligned;
+        axi_req_o.aw.size  = 3'b010;
+        axi_req_o.aw.burst = axi_pkg::BURST_INCR;
+        axi_req_o.w_valid  = ~w_acked_q;
+        axi_req_o.w.data   = wdata_rep;
+        axi_req_o.w.strb   = be;
+        axi_req_o.w.last   = 1'b1;
+      end
+      STORE_RESP: begin
+        axi_req_o.b_ready  = 1'b1;
+      end
+      STORE_SEND_HI: begin
+        axi_req_o.aw_valid = ~aw_acked_q;
+        axi_req_o.aw.addr  = addr_hi_aligned;
+        axi_req_o.aw.size  = 3'b010;
+        axi_req_o.aw.burst = axi_pkg::BURST_INCR;
+        axi_req_o.w_valid  = ~w_acked_q;
+        axi_req_o.w.data   = wdata_q[63:32];
+        axi_req_o.w.strb   = 4'b1111;
+        axi_req_o.w.last   = 1'b1;
+      end
+      STORE_RESP_HI: begin
+        axi_req_o.b_ready  = 1'b1;
+      end
+      default: ;
+    endcase
+  end
+
+  // -------------------------------------------------------------------------
+  // Pipeline stall and valid
+  // -------------------------------------------------------------------------
+  // AMO suppresses the LOAD_DONE valid pulse — the instruction completes only
+  // on STORE_DONE, after the write-back beat returns. mem_stall_o stays
+  // asserted through AMO_COMPUTE/STORE_SEND/STORE_RESP/STORE_DONE for the
+  // same reason.
+  assign mem_stall_o = req_i & (state_q != LOAD_DONE || is_amo_q) &
+                              (state_q != STORE_DONE) &
+                              (state_q != SC_FAIL);
+  assign valid_o     = ((state_q == LOAD_DONE) & ~is_amo_q) |
+                       (state_q == STORE_DONE) |
+                       (state_q == SC_FAIL);
+
+  // -------------------------------------------------------------------------
+  // A-extension: LR/SC (Task 12) and AMO (Task 13) are fully wired. No lint
+  // stubs remain — all A-extension ports drive live logic.
+  // -------------------------------------------------------------------------
+  // sc_success_o mirrors the inverted failure flag so downstream logic can
+  // read 1=success / 0=fail without inspecting rdata_o.
+  assign sc_success_o = ~sc_result_q;
+
+endmodule

--- a/rtl/stage4/kronos_muldiv.sv
+++ b/rtl/stage4/kronos_muldiv.sv
@@ -1,0 +1,310 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_muldiv.sv — multi-cycle 64-bit multiply/divide unit (RV64M).
+//
+// MUL/MULH/MULHSU/MULHU: 2-cycle latency (MUL_BUSY then DONE).
+//   Operands are stored on req; a combinational 65x65 signed product is
+//   registered during MUL_BUSY so synthesis sees a single multiplier.
+//
+// DIV/DIVU/REM/REMU: IDLE -> COMPUTE x N -> DONE, where
+//   N = 64 for full 64-bit ops and N = 32 when word_op_i is asserted.
+//   Uses an iterative restoring algorithm. Edge cases (divide-by-zero,
+//   INT_MIN / -1) are detected in the IDLE->COMPUTE transition and jump
+//   straight to DONE.
+//
+// word_op_i widens/narrows the datapath:
+//   * Multiplier: for word_op, only the low 32 bits of each operand are
+//     used. They are sign- or zero-extended into the 65-bit operand based
+//     on the multiply variant (MULHU is unsigned, others signed).
+//   * Divider: the absolute 32-bit dividend is left-aligned into the
+//     upper half of the 64-bit dividend register and the FSM runs for
+//     only 32 iterations so the quotient lands in the low 32 bits.
+//   * Final result has its low 32 bits sign-extended to 64.
+//
+// Interface:
+//   req_i   — pulse HIGH for one cycle to start an operation (only when idle_o=1)
+//   busy_o  — HIGH while computing (MUL_BUSY or COMPUTE state); stalls the pipeline
+//   valid_o — HIGH for exactly one cycle when result_o is ready (DONE state)
+//   idle_o  — HIGH when ready to accept a new operation (IDLE state)
+module kronos_muldiv
+  import kronos_pkg::*;
+(
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        req_i,
+  input  muldiv_op_e  op_i,
+  input  logic [63:0] a_i,
+  input  logic [63:0] b_i,
+  input  logic        word_op_i,
+  output logic [63:0] result_o,
+  output logic        busy_o,
+  output logic        valid_o,
+  output logic        idle_o
+);
+
+  // -------------------------------------------------------------------------
+  // FSM state encoding
+  // -------------------------------------------------------------------------
+  typedef enum logic [1:0] {
+    IDLE     = 2'd0,
+    MUL_BUSY = 2'd1,
+    COMPUTE  = 2'd2,
+    DONE     = 2'd3
+  } muldiv_state_e;
+
+  muldiv_state_e state_q;
+
+  // -------------------------------------------------------------------------
+  // Stored result
+  // -------------------------------------------------------------------------
+  logic [63:0] result_q;
+
+  // -------------------------------------------------------------------------
+  // Multiplier (combinational 65x65 -> 130-bit signed product)
+  // -------------------------------------------------------------------------
+  logic        mul_signed_a;
+  logic        mul_signed_b;
+  logic [31:0] mul_a_low;
+  logic [31:0] mul_b_low;
+  logic        mul_a_sign_bit;
+  logic        mul_b_sign_bit;
+  logic [63:0] mul_a_eff;
+  logic [63:0] mul_b_eff;
+  logic [64:0] mul_a65;
+  logic [64:0] mul_b65;
+  logic signed [129:0] mul_product;
+  logic [63:0] mul_result_comb;
+  logic [63:0] mul_result_final;
+
+  // MUL, MULH, MULHSU treat A as signed; MULHU is unsigned.
+  assign mul_signed_a = (op_i == MULDIV_MUL) | (op_i == MULDIV_MULH) | (op_i == MULDIV_MULHSU);
+  // MUL, MULH treat B as signed; MULHSU and MULHU are unsigned in B.
+  assign mul_signed_b = (op_i == MULDIV_MUL) | (op_i == MULDIV_MULH);
+
+  // For word_op, the effective operands are the low 32 bits, extended to 64.
+  assign mul_a_low = a_i[31:0];
+  assign mul_b_low = b_i[31:0];
+  assign mul_a_sign_bit = mul_signed_a ? mul_a_low[31] : 1'b0;
+  assign mul_b_sign_bit = mul_signed_b ? mul_b_low[31] : 1'b0;
+
+  assign mul_a_eff = word_op_i ? {{32{mul_a_sign_bit}}, mul_a_low} : a_i;
+  assign mul_b_eff = word_op_i ? {{32{mul_b_sign_bit}}, mul_b_low} : b_i;
+
+  // Extend to 65 bits for signed/unsigned product.
+  assign mul_a65 = mul_signed_a ? {mul_a_eff[63], mul_a_eff} : {1'b0, mul_a_eff};
+  assign mul_b65 = mul_signed_b ? {mul_b_eff[63], mul_b_eff} : {1'b0, mul_b_eff};
+  assign mul_product = $signed(mul_a65) * $signed(mul_b65);
+
+  // Select high or low half of the product depending on op.
+  always_comb begin
+    unique case (op_i)
+      MULDIV_MUL:    mul_result_comb = mul_product[63:0];
+      MULDIV_MULH:   mul_result_comb = mul_product[127:64];
+      MULDIV_MULHSU: mul_result_comb = mul_product[127:64];
+      MULDIV_MULHU:  mul_result_comb = mul_product[127:64];
+      default:       mul_result_comb = mul_product[63:0];
+    endcase
+  end
+
+  // Apply word_op sign extension to the registered multiplier output.
+  assign mul_result_final = word_op_i
+                          ? {{32{mul_result_comb[31]}}, mul_result_comb[31:0]}
+                          : mul_result_comb;
+
+  // -------------------------------------------------------------------------
+  // Divider registers (restoring division)
+  // -------------------------------------------------------------------------
+  logic [63:0] dividend_q;   // left-shifted each step; MSB feeds remainder
+  logic [64:0] remainder_q;  // 65-bit partial remainder (extra bit for borrow)
+  logic [63:0] quotient_q;
+  logic [63:0] abs_b_q;
+  logic [6:0]  count_q;      // counts down from 64 (or 32 for word_op)
+  logic        div_neg_q;    // negate quotient at end (signed DIV)
+  logic        rem_neg_q;    // negate remainder at end (signed REM)
+  logic        is_rem_q;     // 1 = REM/REMU, 0 = DIV/DIVU
+  logic        word_op_q;    // latch of word_op_i for this operation
+
+  // Combinational signals for one restoring-division step
+  logic [64:0] rem_shifted;
+  logic [64:0] rem_sub;
+  logic [63:0] div_shifted;
+
+  assign rem_shifted = {remainder_q[63:0], dividend_q[63]};
+  assign rem_sub     = rem_shifted - {1'b0, abs_b_q};
+  assign div_shifted = {dividend_q[62:0], 1'b0};
+
+  // -------------------------------------------------------------------------
+  // Output wiring
+  // -------------------------------------------------------------------------
+  assign busy_o   = (state_q == MUL_BUSY) | (state_q == COMPUTE);
+  assign valid_o  = (state_q == DONE);
+  assign idle_o   = (state_q == IDLE);
+  assign result_o = result_q;
+
+  // -------------------------------------------------------------------------
+  // Sequential FSM
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q     <= IDLE;
+      result_q    <= '0;
+      dividend_q  <= '0;
+      remainder_q <= '0;
+      quotient_q  <= '0;
+      abs_b_q     <= '0;
+      count_q     <= '0;
+      div_neg_q   <= '0;
+      rem_neg_q   <= '0;
+      is_rem_q    <= '0;
+      word_op_q   <= '0;
+    end else begin
+      unique case (state_q)
+
+        // ---------------------------------------------------------------
+        IDLE: begin
+          if (req_i) begin
+            unique case (op_i)
+              MULDIV_MUL, MULDIV_MULH, MULDIV_MULHSU, MULDIV_MULHU: begin
+                // Capture combinational product; spend one cycle in MUL_BUSY.
+                result_q  <= mul_result_final;
+                word_op_q <= word_op_i;
+                state_q   <= MUL_BUSY;
+              end
+
+              MULDIV_DIV, MULDIV_DIVU, MULDIV_REM, MULDIV_REMU: begin
+                logic        is_signed_div;
+                logic        a_sign_bit;
+                logic        b_sign_bit;
+                logic [63:0] a_eff;
+                logic [63:0] b_eff;
+                logic        neg_a;
+                logic        neg_b;
+                logic [63:0] abs_a;
+                logic [63:0] abs_b;
+                logic        b_is_zero;
+                logic        ov_div;
+                logic        ov_rem;
+                logic [63:0] int_min;
+                logic [63:0] neg_one;
+
+                is_signed_div = (op_i == MULDIV_DIV) | (op_i == MULDIV_REM);
+
+                // Effective operands: low 32 bits sign-extended when word_op.
+                a_sign_bit = is_signed_div ? a_i[31] : 1'b0;
+                b_sign_bit = is_signed_div ? b_i[31] : 1'b0;
+                a_eff      = word_op_i ? {{32{a_sign_bit}}, a_i[31:0]} : a_i;
+                b_eff      = word_op_i ? {{32{b_sign_bit}}, b_i[31:0]} : b_i;
+
+                neg_a = is_signed_div & a_eff[63];
+                neg_b = is_signed_div & b_eff[63];
+                abs_a = neg_a ? (~a_eff + 64'd1) : a_eff;
+                abs_b = neg_b ? (~b_eff + 64'd1) : b_eff;
+
+                b_is_zero = (b_eff == 64'd0);
+
+                int_min = word_op_i ? 64'hFFFF_FFFF_8000_0000 : 64'h8000_0000_0000_0000;
+                neg_one = 64'hFFFF_FFFF_FFFF_FFFF;
+                ov_div  = (op_i == MULDIV_DIV) & (a_eff == int_min) & (b_eff == neg_one);
+                ov_rem  = (op_i == MULDIV_REM) & (a_eff == int_min) & (b_eff == neg_one);
+
+                word_op_q <= word_op_i;
+
+                if (b_is_zero) begin
+                  // Divide by zero: DIV/DIVU -> all ones; REM/REMU -> dividend.
+                  // For word_op the all-ones is naturally sign-extended.
+                  if ((op_i == MULDIV_REM) | (op_i == MULDIV_REMU)) begin
+                    result_q <= word_op_i
+                                ? {{32{a_i[31]}}, a_i[31:0]}
+                                : a_i;
+                  end else begin
+                    result_q <= 64'hFFFF_FFFF_FFFF_FFFF;
+                  end
+                  state_q <= DONE;
+                end else if (ov_div) begin
+                  // Signed overflow: INT_MIN / -1 = INT_MIN
+                  result_q <= int_min;
+                  state_q  <= DONE;
+                end else if (ov_rem) begin
+                  // Signed overflow: INT_MIN % -1 = 0
+                  result_q <= 64'd0;
+                  state_q  <= DONE;
+                end else begin
+                  // Normal case: iterative restoring division.
+                  // For word_op, left-align the 32-bit dividend into the
+                  // upper 32 bits so the MSB-first shift consumes real bits.
+                  dividend_q  <= word_op_i ? {abs_a[31:0], 32'd0} : abs_a;
+                  remainder_q <= '0;
+                  quotient_q  <= '0;
+                  abs_b_q     <= abs_b;
+                  div_neg_q   <= (op_i == MULDIV_DIV) & (a_eff[63] ^ b_eff[63]);
+                  rem_neg_q   <= (op_i == MULDIV_REM) & a_eff[63];
+                  is_rem_q    <= (op_i == MULDIV_REM) | (op_i == MULDIV_REMU);
+                  count_q     <= word_op_i ? 7'd32 : 7'd64;
+                  state_q     <= COMPUTE;
+                end
+              end
+
+              default: state_q <= IDLE;
+            endcase
+          end
+        end
+
+        // ---------------------------------------------------------------
+        MUL_BUSY: begin
+          // result_q already holds the product; one busy cycle then expose.
+          state_q <= DONE;
+        end
+
+        // ---------------------------------------------------------------
+        COMPUTE: begin
+          // One restoring-division step per cycle.
+          if (!rem_sub[64]) begin
+            remainder_q <= {1'b0, rem_sub[63:0]};
+            quotient_q  <= {quotient_q[62:0], 1'b1};
+          end else begin
+            remainder_q <= {1'b0, rem_shifted[63:0]};
+            quotient_q  <= {quotient_q[62:0], 1'b0};
+          end
+          dividend_q <= div_shifted;
+          count_q    <= count_q - 7'd1;
+
+          if (count_q == 7'd1) begin
+            logic [63:0] final_quot;
+            logic [63:0] final_rem;
+            logic [63:0] signed_quot;
+            logic [63:0] signed_rem;
+            logic [63:0] pre_result;
+
+            if (!rem_sub[64]) begin
+              final_quot = {quotient_q[62:0], 1'b1};
+              final_rem  = rem_sub[63:0];
+            end else begin
+              final_quot = {quotient_q[62:0], 1'b0};
+              final_rem  = rem_shifted[63:0];
+            end
+
+            signed_quot = div_neg_q ? (~final_quot + 64'd1) : final_quot;
+            signed_rem  = rem_neg_q ? (~final_rem  + 64'd1) : final_rem;
+            pre_result  = is_rem_q  ? signed_rem : signed_quot;
+
+            // For word_op, sign-extend the low 32 bits of the result.
+            result_q <= word_op_q
+                        ? {{32{pre_result[31]}}, pre_result[31:0]}
+                        : pre_result;
+            state_q  <= DONE;
+          end
+        end
+
+        // ---------------------------------------------------------------
+        DONE: begin
+          state_q <= IDLE;
+        end
+
+        default: state_q <= IDLE;
+      endcase
+    end
+  end
+
+endmodule

--- a/rtl/stage4/kronos_top.sv
+++ b/rtl/stage4/kronos_top.sv
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// kronos_top.sv (stage3) — 5-stage in-order pipeline with RV32M and AXI4 bus.
-// Replaces OBI ports with native AXI4 master ports.
-// Reuses stage0: kronos_regfile, kronos_alu, kronos_csr
-// Reuses stage1: kronos_forward, kronos_hazard
-// Reuses stage2: kronos_decode (RV32I+M), kronos_muldiv
-// New in stage3:  kronos_lsu (AXI4 FSM), fetch FSM in kronos_top
+// kronos_top.sv (stage4) — 5-stage in-order pipeline widened to RV64IMAC.
+// Mirrors the stage3 top but uses 64-bit datapath components:
+//   * kronos_alu / kronos_muldiv support word_op_i (W-suffix instructions)
+//   * kronos_csr is 64-bit
+//   * kronos_lsu supports 64-bit loads/stores (LD/SD/LWU) and A-extension stubs
+// Reuses: kronos_regfile (stage0, already 64-bit), kronos_forward/hazard
+//         (stage1), kronos_align/kronos_bpred (stage3) unchanged.
 module kronos_top
   import kronos_pkg::*;
 (
@@ -48,24 +49,26 @@ module kronos_top
   // -------------------------------------------------------------------------
   decoded_instr_t id_dec;
   logic [63:0]    rs1_rdata_64, rs2_rdata_64;
-  logic [31:0]    rs1_data_id, rs2_data_id;
+  logic [63:0]    rs1_data_id, rs2_data_id;
   logic           wb_writing;
 
   // -------------------------------------------------------------------------
-  // EX-stage wires
+  // EX-stage wires (64-bit datapath)
   // -------------------------------------------------------------------------
-  logic [31:0] fwd_rs1_data, fwd_rs2_data;
-  logic [31:0] alu_a, alu_b, alu_result;
-  logic [31:0] ex_result;
+  logic [63:0] fwd_rs1_data, fwd_rs2_data;
+  logic [63:0] alu_a, alu_b, alu_result;
+  logic [63:0] ex_result;
   logic [31:0] ex_pc_next;
   logic        ex_redirect;
   logic        branch_taken;
   logic        irq_pending;
-  logic [31:0] csr_rdata, trap_vector, mepc;
+  logic [63:0] csr_rdata;
+  logic [63:0] trap_vector, mepc;
   logic [31:0] trap_cause;
+  logic [63:0] jalr_target_64;
 
-  // STAGE2: muldiv signals
-  logic [31:0] muldiv_result;
+  // STAGE2: muldiv signals (64-bit)
+  logic [63:0] muldiv_result;
   logic        muldiv_valid, muldiv_idle;
   logic        muldiv_stall;
 
@@ -92,24 +95,28 @@ module kronos_top
   logic        is_branch_or_jump;
 
   // -------------------------------------------------------------------------
-  // MEM-stage wires
+  // MEM-stage wires (64-bit lsu data)
   // -------------------------------------------------------------------------
-  logic [31:0]      lsu_rdata;
+  logic [63:0]      lsu_rdata;
   logic             lsu_valid;
   logic             mem_stall;
   // mem_done_q: set when LSU signals valid_o; cleared when MEM/WB register
   // advances.  Gates req_i so LSU does not re-issue while the pipeline is
   // frozen by instr_fetch_stall.
   logic             mem_done_q;
-  logic [31:0]      lsu_rdata_latch;  // holds rdata across the stall gap
+  logic [63:0]      lsu_rdata_latch;  // holds rdata across the stall gap
   kronos_axi_req_t  data_req;
   kronos_axi_resp_t data_rsp;
 
   // -------------------------------------------------------------------------
-  // WB-stage wires
+  // WB-stage wires (64-bit)
   // -------------------------------------------------------------------------
-  logic [31:0] wb_result;
   logic [63:0] wb_result_64;
+
+  // -------------------------------------------------------------------------
+  // PC next (combinational)
+  // -------------------------------------------------------------------------
+  logic [31:0] pc_next;
 
   // =========================================================================
   // Submodule instantiations
@@ -138,7 +145,7 @@ module kronos_top
     .id_ex_rs2_used_i (id_ex_q.dec.rs2_used),
     .ex_mem_rd_i      (ex_mem_q.dec.rd),
     .ex_mem_rd_wen_i  (ex_mem_q.dec.rd_wen & ex_mem_q.valid),
-    .ex_mem_is_load_i (ex_mem_q.dec.is_load),
+    .ex_mem_is_load_i (ex_mem_q.dec.wb_sel == WB_MEM),  // SC/AMO also need suppression
     .mem_wb_rd_i      (mem_wb_q.dec.rd),
     .mem_wb_rd_wen_i  (mem_wb_q.dec.rd_wen & mem_wb_q.valid),
     .fwd_rs1_sel_o    (fwd_rs1_sel),
@@ -147,7 +154,6 @@ module kronos_top
 
   // STAGE3: combined_stall — mem_stall | muldiv_stall | instr_fetch_stall
   assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid;
-  // STAGE3: stall until the alignment unit has a valid instruction ready.
   assign instr_fetch_stall = ~align_instr_valid;
   assign combined_stall    = mem_stall | muldiv_stall | instr_fetch_stall;
 
@@ -171,28 +177,31 @@ module kronos_top
   );
 
   kronos_alu u_alu (
-    .op_i     (id_ex_q.dec.alu_op),
-    .a_i      (alu_a),
-    .b_i      (alu_b),
-    .result_o (alu_result)
+    .op_i      (id_ex_q.dec.alu_op),
+    .a_i       (alu_a),
+    .b_i       (alu_b),
+    .word_op_i (id_ex_q.dec.is_word_op),
+    .result_o  (alu_result)
   );
 
   kronos_muldiv u_muldiv (
-    .clk_i    (clk_i),
-    .rst_ni   (rst_ni),
-    .req_i    (id_ex_q.valid & id_ex_q.dec.is_muldiv & muldiv_idle & ~mem_stall),
-    .op_i     (id_ex_q.dec.muldiv_op),
-    .a_i      (fwd_rs1_data),
-    .b_i      (fwd_rs2_data),
-    .result_o (muldiv_result),
-    .busy_o   (),
-    .valid_o  (muldiv_valid),
-    .idle_o   (muldiv_idle)
+    .clk_i     (clk_i),
+    .rst_ni    (rst_ni),
+    .req_i     (id_ex_q.valid & id_ex_q.dec.is_muldiv & muldiv_idle & ~mem_stall),
+    .op_i      (id_ex_q.dec.muldiv_op),
+    .a_i       (fwd_rs1_data),
+    .b_i       (fwd_rs2_data),
+    .word_op_i (id_ex_q.dec.is_word_op),
+    .result_o  (muldiv_result),
+    .busy_o    (),
+    .valid_o   (muldiv_valid),
+    .idle_o    (muldiv_idle)
   );
 
   assign ex_result = id_ex_q.dec.is_muldiv ? muldiv_result : alu_result;
 
-  kronos_csr #(.MISA_EXT(26'h1104)) u_csr (  // I+M+C bits
+  // MISA_EXT = I + M + A + C extension bits (bit 8, 12, 0, 2) = 26'h1105
+  kronos_csr #(.MISA_EXT(26'h1105)) u_csr (
     .clk_i         (clk_i),
     .rst_ni        (rst_ni),
     .req_i         (id_ex_q.valid & id_ex_q.dec.is_csr),
@@ -203,11 +212,8 @@ module kronos_top
     .rs1_addr_i    (id_ex_q.dec.rs1),
     .rdata_o       (csr_rdata),
     .valid_o       (),
-    // Gate trap_i and mret_i with ~combined_stall: the CSR must only update state
-    // (MEPC, MCAUSE, mstatus.MIE) when the pipeline is actually advancing.
-    // When combined_stall=1 (e.g. instr_fetch_stall active), the pipeline is frozen
-    // and no redirect occurs, so processing trap_i would clear MIE without the
-    // handler ever running.
+    // Gate trap_i and mret_i with ~combined_stall: CSR must only update state
+    // when the pipeline is actually advancing (see stage3 comment for details).
     .trap_i        (id_ex_q.valid & ~combined_stall &
                     (id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak |
                      id_ex_q.dec.illegal  | irq_pending)),
@@ -221,22 +227,27 @@ module kronos_top
     .irq_pending_o (irq_pending)
   );
 
-  // STAGE3: LSU with AXI4 interface.
-  // mem_done_q gates req_i to prevent re-issue while the pipeline is frozen
-  // by instr_fetch_stall after a data response has already been received.
+  // STAGE4: 64-bit LSU with AXI4 interface and A-extension stubs.
   kronos_lsu u_lsu (
-    .clk_i       (clk_i),
-    .rst_ni      (rst_ni),
-    .req_i       (ex_mem_q.valid & (ex_mem_q.dec.is_load | ex_mem_q.dec.is_store) & ~mem_done_q),
-    .we_i        (ex_mem_q.dec.is_store),
-    .addr_i      (ex_mem_q.alu_result[31:0]),
-    .wdata_i     (ex_mem_q.rs2_data[31:0]),
-    .funct3_i    (ex_mem_q.dec.mem_funct3),
-    .rdata_o     (lsu_rdata),
-    .valid_o     (lsu_valid),
-    .mem_stall_o (mem_stall),
-    .axi_req_o   (data_req),
-    .axi_rsp_i   (data_rsp)
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .req_i        (ex_mem_q.valid & (ex_mem_q.dec.is_load | ex_mem_q.dec.is_store
+                   | ex_mem_q.dec.is_amo) & ~mem_done_q),
+    .we_i         (ex_mem_q.dec.is_store),
+    .addr_i       (ex_mem_q.alu_result[31:0]),
+    .wdata_i      (ex_mem_q.rs2_data),
+    .funct3_i     (ex_mem_q.dec.mem_funct3),
+    .rdata_o      (lsu_rdata),
+    .valid_o      (lsu_valid),
+    .mem_stall_o  (mem_stall),
+    .is_lr_i      (ex_mem_q.dec.is_lr),
+    .is_sc_i      (ex_mem_q.dec.is_sc),
+    .is_amo_i     (ex_mem_q.dec.is_amo),
+    .amo_funct5_i (ex_mem_q.dec.amo_funct5),
+    .amo_src_i    (ex_mem_q.rs2_data),
+    .sc_success_o (),
+    .axi_req_o    (data_req),
+    .axi_rsp_i    (data_rsp)
   );
 
   assign data_axi_req_o = data_req;
@@ -276,7 +287,6 @@ module kronos_top
   // =========================================================================
   // PC register
   // =========================================================================
-  logic [31:0] pc_next;
   assign pc_next = ex_redirect   ? ex_pc_next
                  : pred_taken    ? pred_target
                  : align_is_16b  ? pc_q + 32'd2
@@ -288,32 +298,26 @@ module kronos_top
   end
 
   // =========================================================================
-  // IF stage — 2-state fetch FSM
+  // IF stage — 2-state fetch FSM (identical to stage3)
   // =========================================================================
-  // IDLE:      drive ar_valid=1, ar_addr=pc_q.  Transition to FETCH_WAIT_R on ar_ready.
-  // FETCH_WAIT_R: drive r_ready=1.  Transition to IDLE on r_valid.
-  //
-  // instr_fetch_stall deasserts only on the cycle r_valid fires (FETCH_WAIT_R).
-  // The PC and pipeline are frozen in all other cycles.
-
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) fetch_state_q <= FETCH_IDLE;
     else begin
       unique case (fetch_state_q)
-        FETCH_IDLE:   if (instr_axi_req_o.ar_valid & instr_axi_rsp_i.ar_ready) fetch_state_q <= FETCH_WAIT_R;
-        FETCH_WAIT_R: if (instr_axi_rsp_i.r_valid)   fetch_state_q <= FETCH_IDLE;
-        default:      fetch_state_q <= FETCH_IDLE;
+        FETCH_IDLE:
+          if (instr_axi_req_o.ar_valid & instr_axi_rsp_i.ar_ready)
+            fetch_state_q <= FETCH_WAIT_R;
+        FETCH_WAIT_R:
+          if (instr_axi_rsp_i.r_valid) fetch_state_q <= FETCH_IDLE;
+        default: fetch_state_q <= FETCH_IDLE;
       endcase
     end
   end
 
-  // Instr AXI4 request: ar_valid in IDLE, r_ready in FETCH_WAIT_R.
-  // AW/W/B unused on instr port (read-only).
   always_comb begin
     instr_axi_req_o            = '0;
     unique case (fetch_state_q)
       FETCH_IDLE: begin
-        // STAGE3: gate by align_needs_fetch; use next-word addr in NEED_UPPER
         instr_axi_req_o.ar_valid  = rst_ni & align_needs_fetch;
         instr_axi_req_o.ar.addr   = align_need_upper
           ? {pc_q[31:2] + 30'd1, 2'b00}
@@ -354,8 +358,8 @@ module kronos_top
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;
-      id_ex_q.rs1_data    <= {{32{rs1_data_id[31]}}, rs1_data_id};
-      id_ex_q.rs2_data    <= {{32{rs2_data_id[31]}}, rs2_data_id};
+      id_ex_q.rs1_data    <= rs1_data_id;
+      id_ex_q.rs2_data    <= rs2_data_id;
       id_ex_q.valid       <= if_id_q.valid;
       id_ex_q.is_16b      <= if_id_q.is_16b;
       id_ex_q.pred_taken  <= if_id_q.pred_taken;
@@ -364,26 +368,30 @@ module kronos_top
   end
 
   // =========================================================================
-  // EX stage
+  // EX stage — 64-bit forwarding mux
   // =========================================================================
   always_comb begin
     unique case (fwd_rs1_sel)
-      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data[31:0];
-      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result[31:0];
-      FWD_MEMWB: fwd_rs1_data = wb_result;
-      default:   fwd_rs1_data = id_ex_q.rs1_data[31:0];
+      FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data;
+      FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result;
+      FWD_MEMWB: fwd_rs1_data = wb_result_64;
+      default:   fwd_rs1_data = id_ex_q.rs1_data;
     endcase
     unique case (fwd_rs2_sel)
-      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data[31:0];
-      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result[31:0];
-      FWD_MEMWB: fwd_rs2_data = wb_result;
-      default:   fwd_rs2_data = id_ex_q.rs2_data[31:0];
+      FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data;
+      FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result;
+      FWD_MEMWB: fwd_rs2_data = wb_result_64;
+      default:   fwd_rs2_data = id_ex_q.rs2_data;
     endcase
   end
 
-  assign alu_a = id_ex_q.dec.use_pc  ? id_ex_q.pc      : fwd_rs1_data;
-  assign alu_b = id_ex_q.dec.use_imm ? id_ex_q.dec.imm : fwd_rs2_data;
+  // ALU operand formation — PC zero-extends to 64, imm sign-extends to 64.
+  assign alu_a = id_ex_q.dec.use_pc  ? {32'b0, id_ex_q.pc}
+                                     : fwd_rs1_data;
+  assign alu_b = id_ex_q.dec.use_imm ? {{32{id_ex_q.dec.imm[31]}}, id_ex_q.dec.imm}
+                                     : fwd_rs2_data;
 
+  // 64-bit branch comparison
   always_comb begin
     branch_taken = 1'b0;
     if (id_ex_q.valid & id_ex_q.dec.is_branch) begin
@@ -400,20 +408,24 @@ module kronos_top
   end
 
   always_comb begin
-    if      (irq_pending)          trap_cause = 32'h80000007;
+    if      (irq_pending)          trap_cause = 32'h8000_0007;
     else if (id_ex_q.dec.illegal)  trap_cause = 32'd2;
     else if (id_ex_q.dec.is_ecall) trap_cause = 32'd11;
     else                           trap_cause = 32'd3;
   end
 
+  // JALR target: 64-bit add, truncate to 32-bit PC (physical PC is 32-bit).
+  assign jalr_target_64 = (fwd_rs1_data + {{32{id_ex_q.dec.imm[31]}}, id_ex_q.dec.imm})
+                           & ~64'd1;
+
   always_comb begin
     if      (id_ex_q.valid & (id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak |
                                id_ex_q.dec.illegal  | irq_pending))
-      ex_pc_next = trap_vector;
+      ex_pc_next = trap_vector[31:0];
     else if (id_ex_q.valid & id_ex_q.dec.is_mret)
-      ex_pc_next = mepc;
+      ex_pc_next = mepc[31:0];
     else if (id_ex_q.valid & id_ex_q.dec.is_jalr)
-      ex_pc_next = (fwd_rs1_data + id_ex_q.dec.imm) & ~32'd1;
+      ex_pc_next = jalr_target_64[31:0];
     else if (id_ex_q.valid & id_ex_q.dec.is_jal)
       ex_pc_next = id_ex_q.pc + id_ex_q.dec.imm;
     else if (branch_taken)
@@ -424,21 +436,16 @@ module kronos_top
 
   // STAGE3: branch predictor — misprediction detection and update
   assign is_branch_or_jump = id_ex_q.dec.is_branch | id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr;
-  assign actual_taken = branch_taken | id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr;
+  assign actual_taken      = branch_taken | id_ex_q.dec.is_jal | id_ex_q.dec.is_jalr;
 
   assign bpred_mispredict = id_ex_q.valid & (
-    // Predicted taken but actually not taken (or not a branch/jump at all)
     (id_ex_q.pred_taken & ~actual_taken) |
-    // Not predicted but actually taken
     (~id_ex_q.pred_taken & actual_taken) |
-    // Both predicted and actually taken but wrong target
     (id_ex_q.pred_taken & actual_taken & (id_ex_q.pred_target != ex_pc_next))
   );
 
-  // Update predictor when a branch/jump leaves EX
   assign bpred_update_en = id_ex_q.valid & ex_mem_en & is_branch_or_jump;
 
-  // STAGE3: redirect on misprediction or trap/mret (not on correct prediction)
   assign ex_redirect = bpred_mispredict |
     (id_ex_q.valid &
      (id_ex_q.dec.is_ecall | id_ex_q.dec.is_ebreak | id_ex_q.dec.illegal |
@@ -450,10 +457,10 @@ module kronos_top
     end else if (ex_mem_en) begin
       ex_mem_q.pc         <= id_ex_q.pc;
       ex_mem_q.dec        <= id_ex_q.dec;
-      ex_mem_q.alu_result <= {{32{ex_result[31]}}, ex_result};
-      ex_mem_q.rs2_data   <= {{32{fwd_rs2_data[31]}}, fwd_rs2_data};
+      ex_mem_q.alu_result <= ex_result;
+      ex_mem_q.rs2_data   <= fwd_rs2_data;
       ex_mem_q.pc_next    <= ex_pc_next;
-      ex_mem_q.csr_rdata  <= {32'b0, csr_rdata};
+      ex_mem_q.csr_rdata  <= csr_rdata;
       ex_mem_q.redirect   <= ex_redirect;
       ex_mem_q.valid      <= id_ex_q.valid & ~irq_pending;
       ex_mem_q.is_16b     <= id_ex_q.is_16b;
@@ -461,11 +468,8 @@ module kronos_top
   end
 
   // =========================================================================
-  // MEM stage
+  // MEM stage — mem_done_q / lsu_rdata_latch handle pipeline stall bridging
   // =========================================================================
-  // mem_done_q: prevents LSU re-issue while pipeline is frozen by instr_fetch_stall.
-  // lsu_rdata_latch: holds the load data across the gap between data rvalid and
-  // the next instr rvalid that allows the pipeline to advance.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       mem_done_q      <= 1'b0;
@@ -476,7 +480,7 @@ module kronos_top
         lsu_rdata_latch <= lsu_rdata;
       end
       if (mem_wb_en) begin
-        mem_done_q <= 1'b0;  // pipeline advanced — re-arm for next instruction
+        mem_done_q <= 1'b0;
       end
     end
   end
@@ -487,10 +491,7 @@ module kronos_top
     end else if (mem_wb_en) begin
       mem_wb_q.dec        <= ex_mem_q.dec;
       mem_wb_q.alu_result <= ex_mem_q.alu_result;
-      // Use current rdata when LSU fires this cycle; use latched value when
-      // the pipeline advances after an earlier lsu_valid (mem_done_q=1).
-      mem_wb_q.lsu_rdata  <= {{32{(lsu_valid ? lsu_rdata[31] : lsu_rdata_latch[31])}},
-                              (lsu_valid ? lsu_rdata : lsu_rdata_latch)};
+      mem_wb_q.lsu_rdata  <= lsu_valid ? lsu_rdata : lsu_rdata_latch;
       mem_wb_q.csr_rdata  <= ex_mem_q.csr_rdata;
       mem_wb_q.pc4        <= ex_mem_q.pc + (ex_mem_q.is_16b ? 32'd2 : 32'd4);
       mem_wb_q.valid      <= ex_mem_q.valid;
@@ -498,16 +499,16 @@ module kronos_top
   end
 
   // =========================================================================
-  // WB→ID bypass
+  // WB→ID bypass (64-bit)
   // =========================================================================
   assign wb_writing  = mem_wb_q.valid & mem_wb_q.dec.rd_wen & (mem_wb_q.dec.rd != 5'd0);
-  assign rs1_data_id = (wb_writing && mem_wb_q.dec.rd == id_dec.rs1) ? wb_result
-                                                                       : rs1_rdata_64[31:0];
-  assign rs2_data_id = (wb_writing && mem_wb_q.dec.rd == id_dec.rs2) ? wb_result
-                                                                       : rs2_rdata_64[31:0];
+  assign rs1_data_id = (wb_writing && mem_wb_q.dec.rd == id_dec.rs1)
+                         ? wb_result_64 : rs1_rdata_64;
+  assign rs2_data_id = (wb_writing && mem_wb_q.dec.rd == id_dec.rs2)
+                         ? wb_result_64 : rs2_rdata_64;
 
   // =========================================================================
-  // WB stage
+  // WB stage (64-bit)
   // =========================================================================
   always_comb begin
     unique case (mem_wb_q.dec.wb_sel)
@@ -518,7 +519,5 @@ module kronos_top
       default: wb_result_64 = mem_wb_q.alu_result;
     endcase
   end
-
-  assign wb_result = wb_result_64[31:0];
 
 endmodule

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -4,6 +4,7 @@ SW_DIR    := ../sw/stage0
 SW_DIR_S1 := ../sw/stage1
 SW_DIR_S2 := ../sw/stage2
 SW_DIR_S3 := ../sw/stage3
+SW_DIR_S4 := ../sw/stage4
 OBJ_DIR   := obj_dir
 
 VERILATOR := verilator
@@ -12,9 +13,10 @@ CFLAGS    := -std=c++14
 # --Wno-WIDTHEXPAND: suppress upstream axi_pkg.sv:203 width warning (PULP library bug)
 # PULP_AXI_INC / AXI_PKG_SV are required for all invocations: kronos_pkg.sv always
 # imports `AXI_TYPEDEF_ALL since the stage3 AXI switch plan.
-PULP_AXI_INC  := -I/home/popes/opensoc/hw/ip/pulp_axi/include
-AXI_PKG_SV    := /home/popes/opensoc/hw/ip/pulp_axi/src/axi_pkg.sv
-AXI_FLAGS     := $(PULP_AXI_INC) --Wno-WIDTHEXPAND
+PULP_AXI_ROOT ?= /home/popes/opensoc/hw/ip/pulp_axi
+PULP_AXI_INC  := -I$(PULP_AXI_ROOT)/include
+AXI_PKG_SV    := $(PULP_AXI_ROOT)/src/axi_pkg.sv
+AXI_FLAGS     := $(PULP_AXI_INC) --Wno-WIDTHEXPAND --Wno-BLKSEQ
 
 TOP       := kronos_top
 SIM_BIN   := $(OBJ_DIR)/V$(TOP)
@@ -94,7 +96,8 @@ SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
         run-s3-latency-% sim-alu sim-regfile sim-decode sim-compliance \
         sim-compliance-s1 sim-lsu-s1 sim-forward sim-hazard \
         sim-muldiv sim-compliance-s2 sim-decompress sim-align sim-lsu-s3 sim-bpred \
-        sim-compliance-s3 clean
+        sim-compliance-s3 build-s4 run-s4-% sim-compliance-s4 sim-alu-s4 sim-decode-s4 \
+        sim-muldiv-s4 sim-lsu-s4 sim-all clean
 
 .DEFAULT_GOAL := help
 
@@ -133,25 +136,27 @@ help:
 	@echo "  make sim-compliance-s2  Stage 2: all sw/ programs + rv32ui compliance"
 	@echo "  make sim-compliance-s3  Stage 3: all sw/ programs (stages 0-3)"
 	@echo ""
+	@echo "  make sim-all         All unit testbenches + stage 4 compliance suite"
+	@echo ""
 	@echo "Housekeeping:"
 	@echo "  make clean           Remove build artifacts"
 
 build: $(SIM_BIN)
 
-$(SIM_BIN): $(SV_FILES) sim_main_obi.cpp
+$(SIM_BIN): $(SV_FILES) $(abspath sim_main_obi.cpp)
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED \
 	  --top-module $(TOP) \
-	  $(SV_FILES) sim_main_obi.cpp \
+	  $(SV_FILES) $(abspath sim_main_obi.cpp) \
 	  -CFLAGS "$(CFLAGS)" \
 	  $(AXI_FLAGS) \
 	  -o V$(TOP)
 
 build-s1: $(SIM_BIN_S1)
 
-$(SIM_BIN_S1): $(SV_FILES_S1) sim_main_obi.cpp
+$(SIM_BIN_S1): $(SV_FILES_S1) $(abspath sim_main_obi.cpp)
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED \
 	  --top-module kronos_top \
-	  $(SV_FILES_S1) sim_main_obi.cpp \
+	  $(SV_FILES_S1) $(abspath sim_main_obi.cpp) \
 	  -CFLAGS "$(CFLAGS)" \
 	  $(AXI_FLAGS) \
 	  -Mdir $(OBJ_DIR)/s1 \
@@ -222,10 +227,10 @@ sim-muldiv:
 
 build-s2: $(SIM_BIN_S2)
 
-$(SIM_BIN_S2): $(SV_FILES_S2) sim_main_obi.cpp
+$(SIM_BIN_S2): $(SV_FILES_S2) $(abspath sim_main_obi.cpp)
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED --Wno-WIDTHEXPAND \
 	  --top-module kronos_top \
-	  $(SV_FILES_S2) sim_main_obi.cpp \
+	  $(SV_FILES_S2) $(abspath sim_main_obi.cpp) \
 	  -CFLAGS "$(CFLAGS)" \
 	  $(AXI_FLAGS) \
 	  -Mdir $(OBJ_DIR)/s2 \
@@ -289,7 +294,7 @@ TB_ALIGN_FILES := $(AXI_PKG_SV) \
                   $(TB_DIR)/stage3/tb_align.sv
 
 sim-align:
-	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND --Wno-BLKSEQ \
 	  --top-module tb_align $(TB_ALIGN_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_align
 	./$(OBJ_DIR)/tb_align/Vtb_align
@@ -301,10 +306,10 @@ TB_LSU_S3_FILES := $(AXI_PKG_SV) \
 
 build-s3: $(SIM_BIN_S3)
 
-$(SIM_BIN_S3): $(SV_FILES_S3) sim_main.cpp
+$(SIM_BIN_S3): $(SV_FILES_S3) $(abspath sim_main.cpp)
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED --Wno-WIDTHEXPAND --Wno-PINCONNECTEMPTY \
 	  --top-module $(TOP_S3) \
-	  $(SV_FILES_S3) sim_main.cpp \
+	  $(SV_FILES_S3) $(abspath sim_main.cpp) \
 	  -CFLAGS "$(CFLAGS)" \
 	  -Mdir $(OBJ_DIR)/s3 \
 	  $(PULP_AXI_INC) \
@@ -317,7 +322,7 @@ run-s3-latency-%: build-s3
 	./$(SIM_BIN_S3) $(SW_DIR_S3)/build/$*.hex 2 4
 
 sim-lsu-s3:
-	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND --Wno-BLKSEQ \
 	  --top-module tb_lsu_s3 $(TB_LSU_S3_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_lsu_s3
 	./$(OBJ_DIR)/tb_lsu_s3/Vtb_lsu_s3
@@ -328,7 +333,7 @@ TB_BPRED_FILES := $(AXI_PKG_SV) \
                   $(TB_DIR)/stage3/tb_bpred.sv
 
 sim-bpred:
-	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND --Wno-BLKSEQ \
 	  --top-module tb_bpred $(TB_BPRED_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_bpred
 	./$(OBJ_DIR)/tb_bpred/Vtb_bpred
@@ -353,6 +358,161 @@ sim-compliance-s3: build-s3
 	done; \
 	echo "Stage 3 regression: $$pass passed, $$fail failed"; \
 	[ $$fail -eq 0 ]
+
+SV_FILES_S4 := $(AXI_PKG_SV) \
+               $(RTL_DIR)/kronos_pkg.sv \
+               $(RTL_DIR)/stage4/kronos_alu.sv \
+               $(RTL_DIR)/stage4/kronos_decode.sv \
+               $(RTL_DIR)/stage0/kronos_regfile.sv \
+               $(RTL_DIR)/stage4/kronos_csr.sv \
+               $(RTL_DIR)/stage4/kronos_lsu.sv \
+               $(RTL_DIR)/stage1/kronos_forward.sv \
+               $(RTL_DIR)/stage1/kronos_hazard.sv \
+               $(RTL_DIR)/stage4/kronos_muldiv.sv \
+               $(RTL_DIR)/stage4/kronos_decompress.sv \
+               $(RTL_DIR)/stage3/kronos_align.sv \
+               $(RTL_DIR)/stage3/kronos_bpred.sv \
+               $(RTL_DIR)/stage4/kronos_top.sv \
+               sim_top.sv
+
+TOP_S4     := sim_top
+SIM_BIN_S4 := $(OBJ_DIR)/s4/V$(TOP_S4)
+
+build-s4: $(SIM_BIN_S4)
+
+$(SIM_BIN_S4): $(SV_FILES_S4) $(abspath sim_main.cpp)
+	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED --Wno-WIDTHEXPAND --Wno-PINCONNECTEMPTY \
+	  --top-module $(TOP_S4) \
+	  $(SV_FILES_S4) $(abspath sim_main.cpp) \
+	  -CFLAGS "$(CFLAGS)" \
+	  -Mdir $(OBJ_DIR)/s4 \
+	  $(PULP_AXI_INC) \
+	  -o V$(TOP_S4)
+
+run-s4-%: build-s4
+	./$(SIM_BIN_S4) $(SW_DIR_S4)/build/$*.hex
+
+sim-compliance-s4: build-s4
+	@$(MAKE) -C $(SW_DIR) all & \
+	 $(MAKE) -C $(SW_DIR_S1) all & \
+	 $(MAKE) -C $(SW_DIR_S2) all & \
+	 $(MAKE) -C $(SW_DIR_S4) all & \
+	 wait
+	@tmpdir=$$(mktemp -d); \
+	pids=""; \
+	for hex in $(SW_DIR)/build/*.hex $(SW_DIR_S1)/build/*.hex \
+	           $(SW_DIR_S2)/build/*.hex \
+	           $$(ls $(SW_DIR_S4)/build/*.hex 2>/dev/null); do \
+	  [ -f "$$hex" ] || continue; \
+	  name=$$(basename $$hex .hex); \
+	  case "$$name" in \
+	    test_mul|test_div|test_irq) continue ;; \
+	  esac; \
+	  { out=$$(./$(SIM_BIN_S4) $$hex 2>&1); \
+	    x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	    echo "$$hex $$x10"; } > $$tmpdir/$$name & \
+	  pids="$$pids $$!"; \
+	done; \
+	wait $$pids; \
+	pass=0; fail=0; \
+	for f in $$tmpdir/*; do \
+	  read hex x10 < $$f; \
+	  if [ "$$x10" = "0" ]; then \
+	    pass=$$((pass+1)); \
+	  else \
+	    echo "FAIL: $$hex (x10=$$x10)"; fail=$$((fail+1)); \
+	  fi; \
+	done; \
+	rm -rf $$tmpdir; \
+	echo "Stage 4 regression: $$pass passed, $$fail failed"; \
+	[ $$fail -eq 0 ]
+
+TB_ALU_S4_FILES := $(AXI_PKG_SV) \
+                   $(RTL_DIR)/kronos_pkg.sv \
+                   $(RTL_DIR)/stage4/kronos_alu.sv \
+                   $(TB_DIR)/stage4/tb_alu_s4.sv
+
+sim-alu-s4:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_alu_s4 $(TB_ALU_S4_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_alu_s4
+	./$(OBJ_DIR)/tb_alu_s4/Vtb_alu_s4
+
+TB_DECODE_S4_FILES := $(AXI_PKG_SV) \
+                      $(RTL_DIR)/kronos_pkg.sv \
+                      $(RTL_DIR)/stage4/kronos_decode.sv \
+                      $(TB_DIR)/stage4/tb_decode_s4.sv
+
+sim-decode-s4:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_decode_s4 $(TB_DECODE_S4_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_decode_s4
+	./$(OBJ_DIR)/tb_decode_s4/Vtb_decode_s4
+
+TB_MULDIV_S4_FILES := $(AXI_PKG_SV) \
+                      $(RTL_DIR)/kronos_pkg.sv \
+                      $(RTL_DIR)/stage4/kronos_muldiv.sv \
+                      $(TB_DIR)/stage4/tb_muldiv_s4.sv
+
+sim-muldiv-s4:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_muldiv_s4 $(TB_MULDIV_S4_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_muldiv_s4
+	./$(OBJ_DIR)/tb_muldiv_s4/Vtb_muldiv_s4
+
+TB_LSU_S4_FILES := $(AXI_PKG_SV) \
+                   $(RTL_DIR)/kronos_pkg.sv \
+                   $(RTL_DIR)/stage4/kronos_lsu.sv \
+                   $(TB_DIR)/stage4/tb_lsu_s4.sv
+
+sim-lsu-s4:
+	$(VERILATOR) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --top-module tb_lsu_s4 $(TB_LSU_S4_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_lsu_s4
+	./$(OBJ_DIR)/tb_lsu_s4/Vtb_lsu_s4
+
+SIM_UNITS := sim-alu sim-regfile sim-decode \
+             sim-lsu-s1 sim-forward sim-hazard \
+             sim-muldiv \
+             sim-decompress sim-align sim-lsu-s3 sim-bpred \
+             sim-alu-s4 sim-decode-s4 sim-muldiv-s4 sim-lsu-s4
+
+SIM_REPORT_DIR := $(OBJ_DIR)/sim-results
+
+sim-all:
+	@rm -rf $(SIM_REPORT_DIR) && mkdir -p $(SIM_REPORT_DIR)
+	@pids=""; \
+	for t in $(SIM_UNITS); do \
+	  { if $(MAKE) $$t > $(SIM_REPORT_DIR)/$$t.log 2>&1; \
+	    then echo "PASS  $$t"; \
+	    else echo "FAIL  $$t"; \
+	    fi; } > $(SIM_REPORT_DIR)/$$t.result & \
+	  pids="$$pids $$!"; \
+	done; \
+	{ if $(MAKE) sim-compliance-s4 > $(SIM_REPORT_DIR)/compliance.log 2>&1; then \
+	    echo "PASS  compliance  ($$(grep 'Stage 4 regression:' $(SIM_REPORT_DIR)/compliance.log | tail -1))"; \
+	  else \
+	    { grep 'FAIL:' $(SIM_REPORT_DIR)/compliance.log; \
+	      echo "FAIL  compliance  ($$(grep 'Stage 4 regression:' $(SIM_REPORT_DIR)/compliance.log | tail -1))"; }; \
+	  fi; } > $(SIM_REPORT_DIR)/compliance.result & \
+	pids="$$pids $$!"; \
+	wait $$pids || true; \
+	printf "\n%-50s\n" "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
+	printf "  sim-all results\n"; \
+	printf "%-50s\n" "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
+	for t in $(SIM_UNITS); do printf "  %s\n" "$$(cat $(SIM_REPORT_DIR)/$$t.result)"; done; \
+	printf "  %-48s\n" "──────────────────────────────────────────────────"; \
+	printf "  %s\n" "$$(cat $(SIM_REPORT_DIR)/compliance.result)"; \
+	printf "%-50s\n\n" "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
+	for f in $(SIM_REPORT_DIR)/*.result; do \
+	  if grep -q "^FAIL" $$f; then \
+	    t=$$(basename $$f .result); \
+	    echo "--- $$t log ---"; \
+	    cat $(SIM_REPORT_DIR)/$$t.log; \
+	    echo "--- end $$t log ---"; \
+	  fi; \
+	done; \
+	! grep -q "^FAIL" $(SIM_REPORT_DIR)/*.result
 
 clean:
 	rm -rf $(OBJ_DIR)

--- a/sw/stage4/Makefile
+++ b/sw/stage4/Makefile
@@ -1,0 +1,24 @@
+TOOLCHAIN := riscv64-unknown-elf
+CC        := $(TOOLCHAIN)-gcc
+OBJCOPY   := $(TOOLCHAIN)-objcopy
+OBJDUMP   := $(TOOLCHAIN)-objdump
+
+ARCH   := rv64imac
+ABI    := lp64
+CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
+
+TESTS  := test_rv64i_basic test_word_ops test_64bit_loadstore test_atomic
+
+BUILD_DIR := build
+
+all: $(TESTS:%=$(BUILD_DIR)/%.hex)
+
+$(BUILD_DIR)/%.hex: %.S ../stage0/common.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $(@:.hex=.elf) $^
+	$(OBJCOPY) -O ihex $(@:.hex=.elf) $@
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/sw/stage4/test_64bit_loadstore.S
+++ b/sw/stage4/test_64bit_loadstore.S
@@ -1,0 +1,62 @@
+# test_64bit_loadstore.S — LD, SD, LWU, LB/LBU tests
+.section .text
+.globl main
+main:
+    li   a0, 0
+    la   sp, data
+
+    # SD then LD — round-trip 64-bit
+    li   t0, 1
+    slli t0, t0, 32
+    addi t0, t0, 0x42
+    sd   t0, 0(sp)
+    ld   t1, 0(sp)
+    bne  t0, t1, fail
+
+    # SD negative, LD back
+    li   t0, -1
+    sd   t0, 8(sp)
+    ld   t1, 8(sp)
+    bne  t0, t1, fail
+
+    # LW sign-extends
+    li   t0, -1
+    sw   t0, 16(sp)
+    lw   t1, 16(sp)
+    li   t2, -1
+    bne  t1, t2, fail
+
+    # LWU zero-extends
+    lwu  t1, 16(sp)
+    srli t2, t1, 32
+    bne  t2, x0, fail
+    slli t3, t1, 32
+    srli t3, t3, 32
+    li   t4, -1
+    slli t4, t4, 32
+    srli t4, t4, 32
+    bne  t3, t4, fail
+
+    # LB sign-extends
+    li   t0, 0x80
+    sb   t0, 24(sp)
+    lb   t1, 24(sp)
+    li   t2, -128
+    bne  t1, t2, fail
+
+    # LBU zero-extends
+    lbu  t1, 24(sp)
+    li   t2, 0x80
+    bne  t1, t2, fail
+
+    li   a0, 0
+    ret
+
+fail:
+    li   a0, 1
+    ret
+
+.section .data
+.align 3
+data:
+    .zero 64

--- a/sw/stage4/test_atomic.S
+++ b/sw/stage4/test_atomic.S
@@ -1,0 +1,93 @@
+# test_atomic.S — LR/SC + AMO instruction tests
+.section .text
+.globl main
+main:
+    li   a0, 0
+    la   t6, data
+
+    # ---- LR.W / SC.W ----
+
+    li   t0, 42
+    sw   t0, 0(t6)
+
+    # LR.W: load-reserved
+    lr.w t1, (t6)
+    li   t2, 42
+    bne  t1, t2, fail
+
+    # SC.W: store-conditional (reservation valid → should succeed, result=0)
+    li   t3, 99
+    sc.w t4, t3, (t6)
+    bne  t4, x0, fail
+    lw   t5, 0(t6)
+    li   t0, 99
+    bne  t5, t0, fail
+
+    # SC.W without prior LR (reservation cleared) → should fail, result=1
+    li   t3, 200
+    sc.w t4, t3, (t6)
+    li   t5, 1
+    bne  t4, t5, fail
+    lw   t0, 0(t6)
+    li   t1, 99
+    bne  t0, t1, fail            # memory must NOT have changed
+
+    # ---- AMOADD.W ----
+    li   t0, 100
+    sw   t0, 8(t6)
+    addi t3, t6, 8
+    li   t1, 25
+    amoadd.w t2, t1, (t3)       # t2 = old (100), mem[8] = 125
+    li   t4, 100
+    bne  t2, t4, fail
+    lw   t5, 8(t6)
+    li   t0, 125
+    bne  t5, t0, fail
+
+    # ---- AMOSWAP.W ----
+    li   t0, 0xAA
+    sw   t0, 16(t6)
+    addi t3, t6, 16
+    li   t1, 0xBB
+    amoswap.w t2, t1, (t3)     # t2 = old (0xAA), mem[16] = 0xBB
+    li   t4, 0xAA
+    bne  t2, t4, fail
+    lw   t5, 16(t6)
+    li   t0, 0xBB
+    bne  t5, t0, fail
+
+    # ---- AMOAND.W ----
+    li   t0, 0xFF
+    sw   t0, 24(t6)
+    addi t3, t6, 24
+    li   t1, 0x0F
+    amoand.w t2, t1, (t3)      # t2 = old (0xFF), mem[24] = 0x0F
+    li   t4, 0xFF
+    bne  t2, t4, fail
+    lw   t5, 24(t6)
+    li   t0, 0x0F
+    bne  t5, t0, fail
+
+    # ---- AMOOR.W ----
+    li   t0, 0xA0
+    sw   t0, 32(t6)
+    addi t3, t6, 32
+    li   t1, 0x0F
+    amoor.w t2, t1, (t3)       # t2 = old (0xA0), mem[32] = 0xAF
+    li   t4, 0xA0
+    bne  t2, t4, fail
+    lw   t5, 32(t6)
+    li   t0, 0xAF
+    bne  t5, t0, fail
+
+    li   a0, 0
+    ret
+
+fail:
+    li   a0, 1
+    ret
+
+.section .data
+.align 3
+data:
+    .zero 64

--- a/sw/stage4/test_rv64i_basic.S
+++ b/sw/stage4/test_rv64i_basic.S
@@ -1,0 +1,95 @@
+// RV64I basic test: exercise 64-bit ops, W-suffix, 6-bit shamt, and LD/SD.
+// x10 accumulates failure count; x10 = 0 means pass.
+//
+// Layout:
+//   - register reserved as fail counter: a0 (x10), initialized to 0
+//   - scratch data area: label `data` — 64 bytes, 8-byte aligned
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                  // fail counter
+
+    // --------------------------------------------------------------
+    // Test 1: SLLI by 32 then SRLI by 32 round-trips a 32-bit value
+    //   t0 = 1; t0 <<= 32  -> 0x0000_0001_0000_0000
+    //   t1 = t0 >> 32     -> 0x0000_0000_0000_0001
+    // --------------------------------------------------------------
+    li      t0, 1
+    slli    t0, t0, 32
+    srli    t1, t0, 32
+    li      t2, 1
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+
+    // --------------------------------------------------------------
+    // Test 2: SRAI by 32 sign-extends
+    //   t0 = 0xFFFF_FFFF_0000_0000 (via LUI+SLLI)
+    //   t1 = t0 >>> 32  -> 0xFFFF_FFFF_FFFF_FFFF
+    // --------------------------------------------------------------
+    li      t0, -1
+    slli    t0, t0, 32             // 0xFFFF_FFFF_0000_0000
+    srai    t1, t0, 32             // 0xFFFF_FFFF_FFFF_FFFF
+    li      t2, -1
+    beq     t1, t2, 2f
+    addi    a0, a0, 1
+2:
+
+    // --------------------------------------------------------------
+    // Test 3: ADDW sign-extends a 32-bit add result
+    //   t0 = 0x7FFFFFFF; t1 = 1
+    //   t2 = ADDW(t0,t1) -> 0xFFFF_FFFF_8000_0000
+    // --------------------------------------------------------------
+    li      t0, 0x7FFFFFFF
+    li      t1, 1
+    addw    t2, t0, t1
+    li      t3, 0xFFFFFFFF80000000
+    beq     t2, t3, 3f
+    addi    a0, a0, 1
+3:
+
+    // --------------------------------------------------------------
+    // Test 4: SUBW wraparound sign-extends
+    //   t0 = 0; t1 = 1
+    //   t2 = SUBW(t0,t1) -> 0xFFFF_FFFF_FFFF_FFFF
+    // --------------------------------------------------------------
+    li      t0, 0
+    li      t1, 1
+    subw    t2, t0, t1
+    li      t3, -1
+    beq     t2, t3, 4f
+    addi    a0, a0, 1
+4:
+
+    // --------------------------------------------------------------
+    // Test 5: LUI sign-extends bit 31
+    //   t0 = LUI 0x80000  -> 0xFFFF_FFFF_8000_0000
+    // --------------------------------------------------------------
+    lui     t0, 0x80000
+    li      t1, 0xFFFFFFFF80000000
+    beq     t0, t1, 5f
+    addi    a0, a0, 1
+5:
+
+    // --------------------------------------------------------------
+    // Test 6: SD/LD round-trip on a 64-bit pattern
+    //   store 0xDEAD_BEEF_CAFE_BABE to data, load back, compare
+    // --------------------------------------------------------------
+    la      t0, data
+    li      t1, 0xDEADBEEFCAFEBABE
+    sd      t1, 0(t0)
+    ld      t2, 0(t0)
+    bne     t1, t2, 6f
+    j       7f
+6:
+    addi    a0, a0, 1
+7:
+
+    ret
+
+.section .data
+.align 3
+data:
+    .zero 64

--- a/sw/stage4/test_word_ops.S
+++ b/sw/stage4/test_word_ops.S
@@ -1,0 +1,49 @@
+# test_word_ops.S — W-suffix instruction tests
+.section .text
+.globl main
+main:
+    li   a0, 0
+
+    # ADDIW: 0x7FFFFFFF + 1 sign-extends to negative
+    li   t0, 0x7FFFFFFF
+    addiw t1, t0, 1
+    bge  t1, x0, fail
+
+    # SUBW: 0 - 1 = -1 (sign-extended)
+    li   t0, 0
+    li   t1, 1
+    subw t2, t0, t1
+    li   t3, -1
+    bne  t2, t3, fail
+
+    # SLLW: 1 << 31 -> negative
+    li   t0, 1
+    li   t1, 31
+    sllw t2, t0, t1
+    bge  t2, x0, fail
+
+    # SRLW: logical shift in 32-bit domain
+    lui  t0, 0x80000
+    li   t1, 1
+    srlw t2, t0, t1
+    li   t3, 0x40000000
+    bne  t2, t3, fail
+
+    # SRAW: arithmetic shift in 32-bit domain
+    lui  t0, 0x80000
+    li   t1, 1
+    sraw t2, t0, t1
+    bge  t2, x0, fail
+    slli t3, t2, 32
+    srli t3, t3, 32
+    li   t4, 0xC0000000
+    slli t4, t4, 32
+    srli t4, t4, 32
+    bne  t3, t4, fail
+
+    li   a0, 0
+    ret
+
+fail:
+    li   a0, 1
+    ret

--- a/tb/stage4/tb_alu_s4.sv
+++ b/tb/stage4/tb_alu_s4.sv
@@ -1,0 +1,93 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+module tb_alu_s4;
+  import kronos_pkg::*;
+
+  logic [63:0] a, b, result;
+  alu_op_e     op;
+  logic        word_op;
+
+  kronos_alu dut (
+    .op_i      (op),
+    .a_i       (a),
+    .b_i       (b),
+    .word_op_i (word_op),
+    .result_o  (result)
+  );
+
+  int errors = 0;
+
+  task check(string name, logic [63:0] expected);
+    if (result !== expected) begin
+      $display("FAIL %s: got %016h, expected %016h", name, result, expected);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    // ---- 64-bit operations ----
+    word_op = 0;
+
+    op = ALU_ADD; a = 64'h00000001_00000001; b = 64'h00000000_FFFFFFFF; #1;
+    check("ADD64", 64'h00000002_00000000);
+
+    op = ALU_SUB; a = 64'h00000001_00000000; b = 64'h00000000_00000001; #1;
+    check("SUB64", 64'h00000000_FFFFFFFF);
+
+    op = ALU_SLL; a = 64'h00000000_00000001; b = 64'd32; #1;
+    check("SLL64_32", 64'h00000001_00000000);
+
+    op = ALU_SRL; a = 64'h80000000_00000000; b = 64'd32; #1;
+    check("SRL64_32", 64'h00000000_80000000);
+
+    op = ALU_SRA; a = 64'hF000000000000000; b = 64'd4; #1;
+    check("SRA64", 64'hFF00000000000000);
+
+    op = ALU_SLT; a = 64'hFFFFFFFF_FFFFFFFF; b = 64'h00000000_00000001; #1;
+    check("SLT64_neg", 64'h1);
+
+    op = ALU_SLTU; a = 64'hFFFFFFFF_FFFFFFFF; b = 64'h00000000_00000001; #1;
+    check("SLTU64", 64'h0);
+
+    op = ALU_XOR; a = 64'hAAAAAAAA_AAAAAAAA; b = 64'h55555555_55555555; #1;
+    check("XOR64", 64'hFFFFFFFF_FFFFFFFF);
+
+    op = ALU_OR; a = 64'hAAAAAAAA_00000000; b = 64'h00000000_55555555; #1;
+    check("OR64", 64'hAAAAAAAA_55555555);
+
+    op = ALU_AND; a = 64'hFFFFFFFF_00000000; b = 64'h0F0F0F0F_0F0F0F0F; #1;
+    check("AND64", 64'h0F0F0F0F_00000000);
+
+    op = ALU_PASSB; a = 64'hDEADBEEF; b = 64'hCAFEBABE_12345678; #1;
+    check("PASSB64", 64'hCAFEBABE_12345678);
+
+    // ---- W-suffix operations ----
+    word_op = 1;
+
+    op = ALU_ADD; a = 64'h00000000_7FFFFFFF; b = 64'h00000000_00000001; #1;
+    check("ADDW_overflow", 64'hFFFFFFFF_80000000);
+
+    op = ALU_SUB; a = 64'h0; b = 64'h1; #1;
+    check("SUBW_neg", 64'hFFFFFFFF_FFFFFFFF);
+
+    op = ALU_SLL; a = 64'h00000000_00000001; b = 64'd31; #1;
+    check("SLLW_31", 64'hFFFFFFFF_80000000);
+
+    op = ALU_SRL; a = 64'hFFFFFFFF_80000000; b = 64'd1; #1;
+    check("SRLW", 64'h00000000_40000000);
+
+    op = ALU_SRA; a = 64'hFFFFFFFF_80000000; b = 64'd1; #1;
+    check("SRAW", 64'hFFFFFFFF_C0000000);
+
+    op = ALU_SLL; a = 64'h00000000_00000001; b = 64'd32; #1;
+    check("SLLW_wrap32", 64'h00000000_00000001);
+
+    if (errors == 0) $display("tb_alu_s4: ALL PASSED");
+    else $display("tb_alu_s4: %0d FAILED", errors);
+    $finish;
+  end
+endmodule

--- a/tb/stage4/tb_decode_s4.sv
+++ b/tb/stage4/tb_decode_s4.sv
@@ -1,0 +1,123 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+module tb_decode_s4;
+  import kronos_pkg::*;
+
+  logic [31:0]    instr;
+  decoded_instr_t dec;
+  int errors = 0;
+
+  kronos_decode dut (.instr_i(instr), .dec_o(dec));
+
+  task check_field(string name, logic [63:0] got, logic [63:0] expected);
+    if (got !== expected) begin
+      $display("FAIL %s: got %0h, expected %0h (instr=%08h)", name, got, expected, instr);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    // ADDIW x1, x2, 5
+    instr = 32'h0051_009B; #1;
+    check_field("ADDIW.alu_op",    dec.alu_op,    ALU_ADD);
+    check_field("ADDIW.is_word",   dec.is_word_op, 1);
+    check_field("ADDIW.rd_wen",    dec.rd_wen,    1);
+    check_field("ADDIW.rs1_used",  dec.rs1_used,  1);
+    check_field("ADDIW.use_imm",   dec.use_imm,   1);
+    check_field("ADDIW.imm",       dec.imm,       32'd5);
+
+    instr = {7'b000_0000, 5'd15, 5'd4, 3'b001, 5'd3, 7'b001_1011}; #1;
+    check_field("SLLIW.alu_op",    dec.alu_op,    ALU_SLL);
+    check_field("SLLIW.is_word",   dec.is_word_op, 1);
+    check_field("SLLIW.imm",       dec.imm,       32'd15);
+
+    instr = {7'b000_0000, 5'd3, 5'd6, 3'b101, 5'd5, 7'b001_1011}; #1;
+    check_field("SRLIW.alu_op",    dec.alu_op,    ALU_SRL);
+    check_field("SRLIW.is_word",   dec.is_word_op, 1);
+
+    instr = {7'b010_0000, 5'd3, 5'd8, 3'b101, 5'd7, 7'b001_1011}; #1;
+    check_field("SRAIW.alu_op",    dec.alu_op,    ALU_SRA);
+    check_field("SRAIW.is_word",   dec.is_word_op, 1);
+
+    // ADDW x1, x2, x3
+    instr = {7'b000_0000, 5'd3, 5'd2, 3'b000, 5'd1, 7'b011_1011}; #1;
+    check_field("ADDW.alu_op",     dec.alu_op,    ALU_ADD);
+    check_field("ADDW.is_word",    dec.is_word_op, 1);
+    check_field("ADDW.rs1_used",   dec.rs1_used,  1);
+    check_field("ADDW.rs2_used",   dec.rs2_used,  1);
+
+    // SUBW x4, x5, x6
+    instr = {7'b010_0000, 5'd6, 5'd5, 3'b000, 5'd4, 7'b011_1011}; #1;
+    check_field("SUBW.alu_op",     dec.alu_op,    ALU_SUB);
+    check_field("SUBW.is_word",    dec.is_word_op, 1);
+
+    // MULW x1, x2, x3
+    instr = {7'b000_0001, 5'd3, 5'd2, 3'b000, 5'd1, 7'b011_1011}; #1;
+    check_field("MULW.is_muldiv",  dec.is_muldiv, 1);
+    check_field("MULW.is_word",    dec.is_word_op, 1);
+    check_field("MULW.muldiv_op",  dec.muldiv_op, MULDIV_MUL);
+
+    // DIVW
+    instr = {7'b000_0001, 5'd3, 5'd2, 3'b100, 5'd1, 7'b011_1011}; #1;
+    check_field("DIVW.is_muldiv",  dec.is_muldiv, 1);
+    check_field("DIVW.is_word",    dec.is_word_op, 1);
+    check_field("DIVW.muldiv_op",  dec.muldiv_op, MULDIV_DIV);
+
+    // SLLI x1, x2, 33 (RV64 6-bit shamt)
+    instr = {6'b000_000, 1'b1, 5'd1, 5'd2, 3'b001, 5'd1, 7'b001_0011}; #1;
+    check_field("SLLI64.alu_op",   dec.alu_op,    ALU_SLL);
+    check_field("SLLI64.is_word",  dec.is_word_op, 0);
+    check_field("SLLI64.imm",      dec.imm,       32'd33);
+
+    // LD
+    instr = {12'd8, 5'd2, 3'b011, 5'd1, 7'b000_0011}; #1;
+    check_field("LD.is_load",      dec.is_load,   1);
+    check_field("LD.illegal",      dec.illegal,   0);
+    check_field("LD.mem_funct3",   dec.mem_funct3, 3'b011);
+
+    // LWU
+    instr = {12'd4, 5'd2, 3'b110, 5'd1, 7'b000_0011}; #1;
+    check_field("LWU.is_load",     dec.is_load,   1);
+    check_field("LWU.illegal",     dec.illegal,   0);
+    check_field("LWU.mem_funct3",  dec.mem_funct3, 3'b110);
+
+    // SD
+    instr = {7'd0, 5'd3, 5'd4, 3'b011, 5'd16, 7'b010_0011}; #1;
+    check_field("SD.is_store",     dec.is_store,  1);
+    check_field("SD.illegal",      dec.illegal,   0);
+
+    // LR.W
+    instr = {5'b00010, 2'b00, 5'd0, 5'd2, 3'b010, 5'd1, 7'b010_1111}; #1;
+    check_field("LR_W.is_lr",      dec.is_lr,     1);
+    check_field("LR_W.is_load",    dec.is_load,   1);
+    check_field("LR_W.illegal",    dec.illegal,   0);
+
+    // SC.W
+    instr = {5'b00011, 2'b00, 5'd3, 5'd2, 3'b010, 5'd1, 7'b010_1111}; #1;
+    check_field("SC_W.is_sc",      dec.is_sc,     1);
+    check_field("SC_W.is_store",   dec.is_store,  1);
+
+    // AMOADD.W
+    instr = {5'b00000, 2'b00, 5'd3, 5'd2, 3'b010, 5'd1, 7'b010_1111}; #1;
+    check_field("AMOADD_W.is_amo", dec.is_amo,    1);
+    check_field("AMOADD_W.funct5", dec.amo_funct5, 5'b00000);
+
+    // LR.D
+    instr = {5'b00010, 2'b00, 5'd0, 5'd2, 3'b011, 5'd1, 7'b010_1111}; #1;
+    check_field("LR_D.is_lr",      dec.is_lr,     1);
+    check_field("LR_D.mem_funct3", dec.mem_funct3, 3'b011);
+
+    // ADD x1, x2, x3 (RV32 backward compat)
+    instr = {7'b000_0000, 5'd3, 5'd2, 3'b000, 5'd1, 7'b011_0011}; #1;
+    check_field("ADD32.alu_op",    dec.alu_op,    ALU_ADD);
+    check_field("ADD32.is_word",   dec.is_word_op, 0);
+
+    if (errors == 0) $display("tb_decode_s4: ALL PASSED");
+    else $display("tb_decode_s4: %0d FAILED", errors);
+    $finish;
+  end
+endmodule

--- a/tb/stage4/tb_lsu_s4.sv
+++ b/tb/stage4/tb_lsu_s4.sv
@@ -1,0 +1,221 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+module tb_lsu_s4;
+  import kronos_pkg::*;
+
+  logic             clk, rst_n;
+  logic             req, we;
+  logic [31:0]      addr;
+  logic [63:0]      wdata;
+  logic [2:0]       funct3;
+  logic [63:0]      rdata;
+  logic             valid_out, mem_stall;
+  logic             is_lr, is_sc, is_amo;
+  logic [4:0]       amo_funct5;
+  logic [63:0]      amo_src;
+  logic             sc_success;
+  kronos_axi_req_t  axi_req;
+  kronos_axi_resp_t axi_rsp;
+
+  kronos_lsu dut (
+    .clk_i       (clk),
+    .rst_ni      (rst_n),
+    .req_i       (req),
+    .we_i        (we),
+    .addr_i      (addr),
+    .wdata_i     (wdata),
+    .funct3_i    (funct3),
+    .rdata_o     (rdata),
+    .valid_o     (valid_out),
+    .mem_stall_o (mem_stall),
+    .is_lr_i     (is_lr),
+    .is_sc_i     (is_sc),
+    .is_amo_i    (is_amo),
+    .amo_funct5_i(amo_funct5),
+    .amo_src_i   (amo_src),
+    .sc_success_o(sc_success),
+    .axi_req_o   (axi_req),
+    .axi_rsp_i   (axi_rsp)
+  );
+
+  initial begin clk = 0; forever #5 clk = ~clk; end
+
+  logic [31:0] mem [256];
+  int errors = 0;
+
+  logic [31:0] ar_addr_q;
+  logic        ar_pending;
+
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      axi_rsp    <= '0;
+      ar_pending <= 0;
+    end else begin
+      axi_rsp <= '0;
+      axi_rsp.ar_ready <= 1;
+      axi_rsp.aw_ready <= 1;
+      axi_rsp.w_ready  <= 1;
+
+      if (axi_req.ar_valid && axi_rsp.ar_ready) begin
+        ar_addr_q  <= axi_req.ar.addr;
+        ar_pending <= 1;
+      end
+
+      if (ar_pending) begin
+        axi_rsp.r_valid <= 1;
+        axi_rsp.r.data  <= mem[ar_addr_q[9:2]];
+        axi_rsp.r.last  <= 1;
+        ar_pending      <= 0;
+      end
+
+      if (axi_req.aw_valid && axi_req.w_valid) begin
+        for (int i = 0; i < 4; i++)
+          if (axi_req.w.strb[i]) mem[axi_req.aw.addr[9:2]][i*8 +: 8] <= axi_req.w.data[i*8 +: 8];
+        axi_rsp.b_valid <= 1;
+      end
+    end
+  end
+
+  task wait_valid;
+    while (!valid_out) @(posedge clk);
+  endtask
+
+  initial begin
+    rst_n = 0; req = 0; we = 0; is_lr = 0; is_sc = 0; is_amo = 0;
+    amo_funct5 = 0; amo_src = 0;
+    for (int i = 0; i < 256; i++) mem[i] = 0;
+    repeat (4) @(posedge clk);
+    rst_n = 1;
+    @(posedge clk);
+
+    mem[0] = 32'h8000_0001;
+    req = 1; we = 0; addr = 32'h0; funct3 = 3'b010;
+    @(posedge clk); req = 0;
+    wait_valid;
+    if (rdata !== 64'hFFFFFFFF_80000001) begin
+      $display("FAIL LW_sext: got %016h", rdata); errors++;
+    end
+    @(posedge clk);
+
+    req = 1; we = 0; addr = 32'h0; funct3 = 3'b110;
+    @(posedge clk); req = 0;
+    wait_valid;
+    if (rdata !== 64'h00000000_80000001) begin
+      $display("FAIL LWU: got %016h", rdata); errors++;
+    end
+    @(posedge clk);
+
+    req = 1; we = 1; addr = 32'h10; funct3 = 3'b011;
+    wdata = 64'hDEADBEEF_CAFEBABE;
+    @(posedge clk); req = 0;
+    wait_valid;
+    @(posedge clk);
+
+    if (mem[4] !== 32'hCAFEBABE) begin
+      $display("FAIL SD_lo: mem[4]=%08h", mem[4]); errors++;
+    end
+    if (mem[5] !== 32'hDEADBEEF) begin
+      $display("FAIL SD_hi: mem[5]=%08h", mem[5]); errors++;
+    end
+
+    req = 1; we = 0; addr = 32'h10; funct3 = 3'b011;
+    @(posedge clk); req = 0;
+    wait_valid;
+    if (rdata !== 64'hDEADBEEF_CAFEBABE) begin
+      $display("FAIL LD: got %016h", rdata); errors++;
+    end
+    @(posedge clk);
+
+    mem[8] = 32'h000000FF;
+    req = 1; we = 0; addr = 32'h20; funct3 = 3'b000;
+    @(posedge clk); req = 0;
+    wait_valid;
+    if (rdata !== 64'hFFFFFFFF_FFFFFFFF) begin
+      $display("FAIL LB_sext: got %016h", rdata); errors++;
+    end
+    @(posedge clk);
+
+    req = 1; we = 0; addr = 32'h20; funct3 = 3'b100;
+    @(posedge clk); req = 0;
+    wait_valid;
+    if (rdata !== 64'h00000000_000000FF) begin
+      $display("FAIL LBU: got %016h", rdata); errors++;
+    end
+    @(posedge clk);
+
+    // ---- LR.W: load with reservation ----
+    mem[16] = 32'hAABB_CCDD;
+    req = 1; we = 0; addr = 32'h40; funct3 = 3'b010; is_lr = 1;
+    @(posedge clk); req = 0; is_lr = 0;
+    wait_valid;
+    if (rdata !== 64'hFFFFFFFF_AABBCCDD) begin  // LW sign-extends to 64
+      $display("FAIL LR_W: got %016h", rdata); errors++;
+    end
+    @(posedge clk);
+
+    // ---- SC.W success: reservation matches ----
+    req = 1; we = 1; addr = 32'h40; funct3 = 3'b010; is_sc = 1;
+    wdata = {32'b0, 32'h1122_3344};
+    @(posedge clk); req = 0; is_sc = 0;
+    wait_valid;
+    if (rdata !== 64'h0) begin
+      $display("FAIL SC_W_success: got %016h", rdata); errors++;
+    end
+    if (mem[16] !== 32'h1122_3344) begin
+      $display("FAIL SC_W_mem: got %08h", mem[16]); errors++;
+    end
+    @(posedge clk);
+
+    // ---- SC.W fail: no prior LR (reservation cleared by previous SC) ----
+    req = 1; we = 1; addr = 32'h40; funct3 = 3'b010; is_sc = 1;
+    wdata = {32'b0, 32'hDEAD_BEEF};
+    @(posedge clk); req = 0; is_sc = 0;
+    wait_valid;
+    if (rdata !== 64'h1) begin
+      $display("FAIL SC_W_fail: got %016h", rdata); errors++;
+    end
+    if (mem[16] !== 32'h1122_3344) begin  // UNCHANGED
+      $display("FAIL SC_W_fail_mem: got %08h", mem[16]); errors++;
+    end
+    @(posedge clk);
+
+    // ---- AMOADD.W ----
+    mem[20] = 32'd100;  // addr 0x50 (word index 20)
+    req = 1; we = 0; addr = 32'h50; funct3 = 3'b010; is_amo = 1;
+    amo_funct5 = 5'b00000;  // AMOADD
+    amo_src = 64'd25;
+    @(posedge clk); req = 0; is_amo = 0;
+    wait_valid;
+    // AMO returns OLD value (100, sign-extended since funct3=W)
+    if (rdata !== 64'h0000_0000_0000_0064) begin
+      $display("FAIL AMOADD_rdata: got %016h", rdata); errors++;
+    end
+    @(posedge clk); @(posedge clk);  // let memory write settle
+    if (mem[20] !== 32'd125) begin
+      $display("FAIL AMOADD_mem: got %0d", mem[20]); errors++;
+    end
+
+    // ---- AMOSWAP.W ----
+    mem[24] = 32'hAAAA_BBBB;  // addr 0x60
+    req = 1; we = 0; addr = 32'h60; funct3 = 3'b010; is_amo = 1;
+    amo_funct5 = 5'b00001;  // AMOSWAP
+    amo_src = 64'hCCCC_DDDD;
+    @(posedge clk); req = 0; is_amo = 0;
+    wait_valid;
+    if (rdata !== 64'hFFFFFFFF_AAAABBBB) begin  // old value, sign-extended
+      $display("FAIL AMOSWAP_rdata: got %016h", rdata); errors++;
+    end
+    @(posedge clk); @(posedge clk);
+    if (mem[24] !== 32'hCCCC_DDDD) begin
+      $display("FAIL AMOSWAP_mem: got %08h", mem[24]); errors++;
+    end
+
+    if (errors == 0) $display("tb_lsu_s4: ALL PASSED");
+    else $display("tb_lsu_s4: %0d FAILED", errors);
+    $finish;
+  end
+endmodule

--- a/tb/stage4/tb_muldiv_s4.sv
+++ b/tb/stage4/tb_muldiv_s4.sv
@@ -1,0 +1,72 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+module tb_muldiv_s4;
+  import kronos_pkg::*;
+
+  logic        clk, rst_n;
+  logic        req;
+  muldiv_op_e  op;
+  logic [63:0] a, b;
+  logic        word_op;
+  logic [63:0] result;
+  logic        busy, valid, idle;
+
+  kronos_muldiv dut (
+    .clk_i    (clk),
+    .rst_ni   (rst_n),
+    .req_i    (req),
+    .op_i     (op),
+    .a_i      (a),
+    .b_i      (b),
+    .word_op_i(word_op),
+    .result_o (result),
+    .busy_o   (busy),
+    .valid_o  (valid),
+    .idle_o   (idle)
+  );
+
+  initial begin clk = 0; forever #5 clk = ~clk; end
+
+  int errors = 0;
+
+  task do_op(muldiv_op_e o, logic [63:0] va, logic [63:0] vb, logic w,
+             logic [63:0] expected, string name);
+    @(posedge clk);
+    op = o; a = va; b = vb; word_op = w; req = 1;
+    @(posedge clk);
+    req = 0;
+    while (!valid) @(posedge clk);
+    if (result !== expected) begin
+      $display("FAIL %s: got %016h, expected %016h", name, result, expected);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    rst_n = 0; req = 0; word_op = 0;
+    repeat (4) @(posedge clk);
+    rst_n = 1;
+    @(posedge clk);
+
+    do_op(MULDIV_MUL,  64'h1_0000_0000,          64'h3,           0, 64'h3_0000_0000,         "MUL64");
+    do_op(MULDIV_MUL,  64'hFFFFFFFF_FFFFFFFF,    64'h2,           0, 64'hFFFFFFFF_FFFFFFFE,   "MUL64_neg");
+    do_op(MULDIV_MULH, 64'h8000_0000_0000_0000,  64'h2,           0, 64'hFFFF_FFFF_FFFF_FFFF, "MULH64");
+    do_op(MULDIV_MUL,  64'd100000,               64'd100000,      1, 64'h00000000_540BE400,   "MULW");
+    do_op(MULDIV_MUL,  64'h7FFF_FFFF,            64'h2,           1, 64'hFFFF_FFFF_FFFF_FFFE, "MULW_ovf");
+    do_op(MULDIV_DIV,  64'd100,                  64'd7,           0, 64'd14,                  "DIV64");
+    do_op(MULDIV_DIV,  -64'sd100,                64'd7,           0, -64'sd14,                "DIV64_neg");
+    do_op(MULDIV_DIV,  64'd42,                   64'd0,           0, 64'hFFFF_FFFF_FFFF_FFFF, "DIV64_zero");
+    do_op(MULDIV_REM,  64'd100,                  64'd7,           0, 64'd2,                   "REM64");
+    do_op(MULDIV_DIV,  64'd100,                  64'd7,           1, 64'd14,                  "DIVW");
+    do_op(MULDIV_REM,  64'd100,                  64'd7,           1, 64'd2,                   "REMW");
+    do_op(MULDIV_DIV,  64'd42,                   64'd0,           1, 64'hFFFF_FFFF_FFFF_FFFF, "DIVW_zero");
+
+    if (errors == 0) $display("tb_muldiv_s4: ALL PASSED");
+    else $display("tb_muldiv_s4: %0d FAILED", errors);
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

- Widens the entire datapath to 64 bits (registers, ALU, CSR, LSU, muldiv)
- Adds RV64I instructions: LD/SD/LWU, ADDIW/ADDW/SUBW/SLLW/SRLW/SRAW and their register variants, 6-bit shift amounts
- Adds A extension: LR.W/SC.W (load-reserved/store-conditional with reservation register) and AMO RMW instructions (AMOADD/AMOSWAP/AMOAND/AMOOR, .W suffix)
- Updates RV64C decompressor: C.ADDIW (replaces C.JAL), C.LDSP/C.SDSP, C.LD/C.SD, C.ADDW/C.SUBW, full 6-bit shamt for C.SLLI/C.SRLI/C.SRAI
- Fixes EX/MEM forwarding suppression to cover SC and AMO (result comes from LSU, not ALU)
- Adds CI: GitHub Actions runs \`make sim-all\` on every push and PR
- \`make sim-all\` runs all 16 unit testbenches + compliance suite in parallel with a summary report

## Test plan

- [x] CI green