### PR TITLE
perf(forward): pre-register forward select to cut EX critical path

### DIFF
--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -144,6 +144,9 @@ package kronos_pkg;
     decoded_instr_t dec;
     logic [63:0]    rs1_data;
     logic [63:0]    rs2_data;
+    logic [63:0]    rs3_data;       // Stage 5a: FMA third source (from FP regfile)
+    fwd_sel_e       fwd_rs1_sel;    // pre-computed EX bypass select for rs1
+    fwd_sel_e       fwd_rs2_sel;    // pre-computed EX bypass select for rs2
     logic           valid;
     // Stage 3+
     logic        is_16b;

--- a/rtl/stage1/kronos_forward.sv
+++ b/rtl/stage1/kronos_forward.sv
@@ -2,51 +2,55 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// kronos_forward.sv — data hazard forwarding mux select logic
-// Computes fwd_rs1_sel and fwd_rs2_sel for the EX stage.
-// EX/MEM takes priority over MEM/WB. Load-in-MEM suppresses EX/MEM forward.
+// kronos_forward.sv — pre-registered data-hazard forward select
+// Computes fwd_rs1_sel and fwd_rs2_sel for the instruction currently
+// entering ID/EX (consumer) based on the instructions in EX (will be in
+// MEM next cycle) and MEM (will be in WB next cycle).
+// The outputs are stored in id_ex_reg_t and used in the EX bypass mux,
+// removing any combinational comparison from the EX critical path.
+// EX path has priority over MEM path. A load in EX suppresses EX forward.
 // x0 is never forwarded.
 module kronos_forward
   import kronos_pkg::*;
 (
-  // Consumer: instruction currently in EX (from ID/EX register)
-  input  logic [4:0] id_ex_rs1_i,
-  input  logic       id_ex_rs1_used_i,
-  input  logic [4:0] id_ex_rs2_i,
-  input  logic       id_ex_rs2_used_i,
-  // Producer in MEM (from EX/MEM register)
+  // Consumer: instruction being captured into ID/EX (currently in ID stage)
+  input  logic [4:0] if_id_rs1_i,
+  input  logic       if_id_rs1_used_i,
+  input  logic [4:0] if_id_rs2_i,
+  input  logic       if_id_rs2_used_i,
+  // Producer in EX (will be in MEM next cycle — EX/MEM forward)
+  input  logic [4:0] id_ex_rd_i,
+  input  logic       id_ex_rd_wen_i,
+  input  logic       id_ex_is_load_i,   // suppresses EX forward (data not ready)
+  // Producer in MEM (will be in WB next cycle — MEM/WB forward)
   input  logic [4:0] ex_mem_rd_i,
   input  logic       ex_mem_rd_wen_i,
-  input  logic       ex_mem_is_load_i,   // result not yet available — stall instead
-  // Producer in WB (from MEM/WB register)
-  input  logic [4:0] mem_wb_rd_i,
-  input  logic       mem_wb_rd_wen_i,
-  // Outputs
+  // Outputs: stored into id_ex_q.fwd_rs1_sel / id_ex_q.fwd_rs2_sel
   output fwd_sel_e   fwd_rs1_sel_o,
   output fwd_sel_e   fwd_rs2_sel_o
 );
 
-  logic ex_mem_can_fwd;
-  assign ex_mem_can_fwd = ex_mem_rd_wen_i && !ex_mem_is_load_i && (ex_mem_rd_i != 5'd0);
+  logic ex_can_fwd;
+  assign ex_can_fwd = id_ex_rd_wen_i && !id_ex_is_load_i && (id_ex_rd_i != 5'd0);
 
-  logic mem_wb_can_fwd;
-  assign mem_wb_can_fwd = mem_wb_rd_wen_i && (mem_wb_rd_i != 5'd0);
+  logic mem_can_fwd;
+  assign mem_can_fwd = ex_mem_rd_wen_i && (ex_mem_rd_i != 5'd0);
 
   always_comb begin
     fwd_rs1_sel_o = FWD_NONE;
     fwd_rs2_sel_o = FWD_NONE;
 
-    // EX/MEM has priority
-    if (ex_mem_can_fwd) begin
-      if (id_ex_rs1_used_i && id_ex_rs1_i == ex_mem_rd_i) fwd_rs1_sel_o = FWD_EXMEM;
-      if (id_ex_rs2_used_i && id_ex_rs2_i == ex_mem_rd_i) fwd_rs2_sel_o = FWD_EXMEM;
+    // EX path has priority
+    if (ex_can_fwd) begin
+      if (if_id_rs1_used_i && if_id_rs1_i == id_ex_rd_i) fwd_rs1_sel_o = FWD_EXMEM;
+      if (if_id_rs2_used_i && if_id_rs2_i == id_ex_rd_i) fwd_rs2_sel_o = FWD_EXMEM;
     end
 
-    // MEM/WB — only if EX/MEM did not already forward for that operand
-    if (mem_wb_can_fwd) begin
-      if (id_ex_rs1_used_i && id_ex_rs1_i == mem_wb_rd_i && fwd_rs1_sel_o == FWD_NONE)
+    // MEM path — only if EX path did not already forward that operand
+    if (mem_can_fwd) begin
+      if (if_id_rs1_used_i && if_id_rs1_i == ex_mem_rd_i && fwd_rs1_sel_o == FWD_NONE)
         fwd_rs1_sel_o = FWD_MEMWB;
-      if (id_ex_rs2_used_i && id_ex_rs2_i == mem_wb_rd_i && fwd_rs2_sel_o == FWD_NONE)
+      if (if_id_rs2_used_i && if_id_rs2_i == ex_mem_rd_i && fwd_rs2_sel_o == FWD_NONE)
         fwd_rs2_sel_o = FWD_MEMWB;
     end
   end

--- a/rtl/stage1/kronos_top.sv
+++ b/rtl/stage1/kronos_top.sv
@@ -107,15 +107,15 @@ module kronos_top
   );
 
   kronos_forward u_forward (
-    .id_ex_rs1_i      (id_ex_q.dec.rs1),
-    .id_ex_rs1_used_i (id_ex_q.dec.rs1_used),
-    .id_ex_rs2_i      (id_ex_q.dec.rs2),
-    .id_ex_rs2_used_i (id_ex_q.dec.rs2_used),
+    .if_id_rs1_i      (id_dec.rs1),
+    .if_id_rs1_used_i (id_dec.rs1_used),
+    .if_id_rs2_i      (id_dec.rs2),
+    .if_id_rs2_used_i (id_dec.rs2_used),
+    .id_ex_rd_i       (id_ex_q.dec.rd),
+    .id_ex_rd_wen_i   (id_ex_q.dec.rd_wen & id_ex_q.valid),
+    .id_ex_is_load_i  (id_ex_q.dec.is_load),
     .ex_mem_rd_i      (ex_mem_q.dec.rd),
     .ex_mem_rd_wen_i  (ex_mem_q.dec.rd_wen & ex_mem_q.valid),
-    .ex_mem_is_load_i (ex_mem_q.dec.is_load),
-    .mem_wb_rd_i      (mem_wb_q.dec.rd),
-    .mem_wb_rd_wen_i  (mem_wb_q.dec.rd_wen & mem_wb_q.valid),
     .fwd_rs1_sel_o    (fwd_rs1_sel),
     .fwd_rs2_sel_o    (fwd_rs2_sel)
   );
@@ -231,11 +231,13 @@ module kronos_top
     end else if (id_ex_flush) begin
       id_ex_q <= '0;
     end else if (id_ex_en) begin
-      id_ex_q.pc       <= if_id_q.pc;
-      id_ex_q.dec      <= id_dec;
-      id_ex_q.rs1_data <= {{32{rs1_data_id[31]}}, rs1_data_id};
-      id_ex_q.rs2_data <= {{32{rs2_data_id[31]}}, rs2_data_id};
-      id_ex_q.valid    <= if_id_q.valid;
+      id_ex_q.pc          <= if_id_q.pc;
+      id_ex_q.dec         <= id_dec;
+      id_ex_q.rs1_data    <= {{32{rs1_data_id[31]}}, rs1_data_id};
+      id_ex_q.rs2_data    <= {{32{rs2_data_id[31]}}, rs2_data_id};
+      id_ex_q.valid       <= if_id_q.valid;
+      id_ex_q.fwd_rs1_sel <= fwd_rs1_sel;
+      id_ex_q.fwd_rs2_sel <= fwd_rs2_sel;
     end
   end
 
@@ -245,13 +247,13 @@ module kronos_top
 
   // Forwarding muxes
   always_comb begin
-    unique case (fwd_rs1_sel)
+    unique case (id_ex_q.fwd_rs1_sel)
       FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data[31:0];
       FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs1_data = wb_result;
       default:   fwd_rs1_data = id_ex_q.rs1_data[31:0];
     endcase
-    unique case (fwd_rs2_sel)
+    unique case (id_ex_q.fwd_rs2_sel)
       FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data[31:0];
       FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs2_data = wb_result;

--- a/rtl/stage2/kronos_top.sv
+++ b/rtl/stage2/kronos_top.sv
@@ -126,15 +126,15 @@ module kronos_top
   );
 
   kronos_forward u_forward (
-    .id_ex_rs1_i      (id_ex_q.dec.rs1),
-    .id_ex_rs1_used_i (id_ex_q.dec.rs1_used),
-    .id_ex_rs2_i      (id_ex_q.dec.rs2),
-    .id_ex_rs2_used_i (id_ex_q.dec.rs2_used),
+    .if_id_rs1_i      (id_dec.rs1),
+    .if_id_rs1_used_i (id_dec.rs1_used),
+    .if_id_rs2_i      (id_dec.rs2),
+    .if_id_rs2_used_i (id_dec.rs2_used),
+    .id_ex_rd_i       (id_ex_q.dec.rd),
+    .id_ex_rd_wen_i   (id_ex_q.dec.rd_wen & id_ex_q.valid),
+    .id_ex_is_load_i  (id_ex_q.dec.is_load),
     .ex_mem_rd_i      (ex_mem_q.dec.rd),
     .ex_mem_rd_wen_i  (ex_mem_q.dec.rd_wen & ex_mem_q.valid),
-    .ex_mem_is_load_i (ex_mem_q.dec.is_load),
-    .mem_wb_rd_i      (mem_wb_q.dec.rd),
-    .mem_wb_rd_wen_i  (mem_wb_q.dec.rd_wen & mem_wb_q.valid),
     .fwd_rs1_sel_o    (fwd_rs1_sel),
     .fwd_rs2_sel_o    (fwd_rs2_sel)
   );
@@ -287,11 +287,13 @@ module kronos_top
     end else if (id_ex_flush) begin
       id_ex_q <= '0;
     end else if (id_ex_en) begin
-      id_ex_q.pc       <= if_id_q.pc;
-      id_ex_q.dec      <= id_dec;
-      id_ex_q.rs1_data <= {{32{rs1_data_id[31]}}, rs1_data_id};
-      id_ex_q.rs2_data <= {{32{rs2_data_id[31]}}, rs2_data_id};
-      id_ex_q.valid    <= if_id_q.valid;
+      id_ex_q.pc          <= if_id_q.pc;
+      id_ex_q.dec         <= id_dec;
+      id_ex_q.rs1_data    <= {{32{rs1_data_id[31]}}, rs1_data_id};
+      id_ex_q.rs2_data    <= {{32{rs2_data_id[31]}}, rs2_data_id};
+      id_ex_q.valid       <= if_id_q.valid;
+      id_ex_q.fwd_rs1_sel <= fwd_rs1_sel;
+      id_ex_q.fwd_rs2_sel <= fwd_rs2_sel;
     end
   end
 
@@ -301,13 +303,13 @@ module kronos_top
 
   // Forwarding muxes
   always_comb begin
-    unique case (fwd_rs1_sel)
+    unique case (id_ex_q.fwd_rs1_sel)
       FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data[31:0];
       FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs1_data = wb_result;
       default:   fwd_rs1_data = id_ex_q.rs1_data[31:0];
     endcase
-    unique case (fwd_rs2_sel)
+    unique case (id_ex_q.fwd_rs2_sel)
       FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data[31:0];
       FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs2_data = wb_result;

--- a/rtl/stage3/kronos_top.sv
+++ b/rtl/stage3/kronos_top.sv
@@ -132,15 +132,15 @@ module kronos_top
   );
 
   kronos_forward u_forward (
-    .id_ex_rs1_i      (id_ex_q.dec.rs1),
-    .id_ex_rs1_used_i (id_ex_q.dec.rs1_used),
-    .id_ex_rs2_i      (id_ex_q.dec.rs2),
-    .id_ex_rs2_used_i (id_ex_q.dec.rs2_used),
+    .if_id_rs1_i      (id_dec.rs1),
+    .if_id_rs1_used_i (id_dec.rs1_used),
+    .if_id_rs2_i      (id_dec.rs2),
+    .if_id_rs2_used_i (id_dec.rs2_used),
+    .id_ex_rd_i       (id_ex_q.dec.rd),
+    .id_ex_rd_wen_i   (id_ex_q.dec.rd_wen & id_ex_q.valid),
+    .id_ex_is_load_i  (id_ex_q.dec.is_load),
     .ex_mem_rd_i      (ex_mem_q.dec.rd),
     .ex_mem_rd_wen_i  (ex_mem_q.dec.rd_wen & ex_mem_q.valid),
-    .ex_mem_is_load_i (ex_mem_q.dec.is_load),
-    .mem_wb_rd_i      (mem_wb_q.dec.rd),
-    .mem_wb_rd_wen_i  (mem_wb_q.dec.rd_wen & mem_wb_q.valid),
     .fwd_rs1_sel_o    (fwd_rs1_sel),
     .fwd_rs2_sel_o    (fwd_rs2_sel)
   );
@@ -360,6 +360,8 @@ module kronos_top
       id_ex_q.is_16b      <= if_id_q.is_16b;
       id_ex_q.pred_taken  <= if_id_q.pred_taken;
       id_ex_q.pred_target <= if_id_q.pred_target;
+      id_ex_q.fwd_rs1_sel <= fwd_rs1_sel;
+      id_ex_q.fwd_rs2_sel <= fwd_rs2_sel;
     end
   end
 
@@ -367,13 +369,13 @@ module kronos_top
   // EX stage
   // =========================================================================
   always_comb begin
-    unique case (fwd_rs1_sel)
+    unique case (id_ex_q.fwd_rs1_sel)
       FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data[31:0];
       FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs1_data = wb_result;
       default:   fwd_rs1_data = id_ex_q.rs1_data[31:0];
     endcase
-    unique case (fwd_rs2_sel)
+    unique case (id_ex_q.fwd_rs2_sel)
       FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data[31:0];
       FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result[31:0];
       FWD_MEMWB: fwd_rs2_data = wb_result;

--- a/rtl/stage4/kronos_top.sv
+++ b/rtl/stage4/kronos_top.sv
@@ -139,15 +139,15 @@ module kronos_top
   );
 
   kronos_forward u_forward (
-    .id_ex_rs1_i      (id_ex_q.dec.rs1),
-    .id_ex_rs1_used_i (id_ex_q.dec.rs1_used),
-    .id_ex_rs2_i      (id_ex_q.dec.rs2),
-    .id_ex_rs2_used_i (id_ex_q.dec.rs2_used),
+    .if_id_rs1_i      (id_dec.rs1),
+    .if_id_rs1_used_i (id_dec.rs1_used),
+    .if_id_rs2_i      (id_dec.rs2),
+    .if_id_rs2_used_i (id_dec.rs2_used),
+    .id_ex_rd_i       (id_ex_q.dec.rd),
+    .id_ex_rd_wen_i   (id_ex_q.dec.rd_wen & id_ex_q.valid),
+    .id_ex_is_load_i  (id_ex_q.dec.wb_sel == WB_MEM),
     .ex_mem_rd_i      (ex_mem_q.dec.rd),
     .ex_mem_rd_wen_i  (ex_mem_q.dec.rd_wen & ex_mem_q.valid),
-    .ex_mem_is_load_i (ex_mem_q.dec.wb_sel == WB_MEM),  // SC/AMO also need suppression
-    .mem_wb_rd_i      (mem_wb_q.dec.rd),
-    .mem_wb_rd_wen_i  (mem_wb_q.dec.rd_wen & mem_wb_q.valid),
     .fwd_rs1_sel_o    (fwd_rs1_sel),
     .fwd_rs2_sel_o    (fwd_rs2_sel)
   );
@@ -364,6 +364,8 @@ module kronos_top
       id_ex_q.is_16b      <= if_id_q.is_16b;
       id_ex_q.pred_taken  <= if_id_q.pred_taken;
       id_ex_q.pred_target <= if_id_q.pred_target;
+      id_ex_q.fwd_rs1_sel <= fwd_rs1_sel;
+      id_ex_q.fwd_rs2_sel <= fwd_rs2_sel;
     end
   end
 
@@ -371,13 +373,13 @@ module kronos_top
   // EX stage — 64-bit forwarding mux
   // =========================================================================
   always_comb begin
-    unique case (fwd_rs1_sel)
+    unique case (id_ex_q.fwd_rs1_sel)
       FWD_NONE:  fwd_rs1_data = id_ex_q.rs1_data;
       FWD_EXMEM: fwd_rs1_data = ex_mem_q.alu_result;
       FWD_MEMWB: fwd_rs1_data = wb_result_64;
       default:   fwd_rs1_data = id_ex_q.rs1_data;
     endcase
-    unique case (fwd_rs2_sel)
+    unique case (id_ex_q.fwd_rs2_sel)
       FWD_NONE:  fwd_rs2_data = id_ex_q.rs2_data;
       FWD_EXMEM: fwd_rs2_data = ex_mem_q.alu_result;
       FWD_MEMWB: fwd_rs2_data = wb_result_64;

--- a/tb/stage1/tb_forward.sv
+++ b/tb/stage1/tb_forward.sv
@@ -5,24 +5,24 @@
 module tb_forward;
   import kronos_pkg::*;
 
-  logic [4:0] id_ex_rs1_i, id_ex_rs2_i;
-  logic       id_ex_rs1_used_i, id_ex_rs2_used_i;
+  logic [4:0] if_id_rs1_i, if_id_rs2_i;
+  logic       if_id_rs1_used_i, if_id_rs2_used_i;
+  logic [4:0] id_ex_rd_i;
+  logic       id_ex_rd_wen_i, id_ex_is_load_i;
   logic [4:0] ex_mem_rd_i;
-  logic       ex_mem_rd_wen_i, ex_mem_is_load_i;
-  logic [4:0] mem_wb_rd_i;
-  logic       mem_wb_rd_wen_i;
+  logic       ex_mem_rd_wen_i;
   fwd_sel_e   fwd_rs1_sel_o, fwd_rs2_sel_o;
 
   kronos_forward u_fwd (
-    .id_ex_rs1_i      (id_ex_rs1_i),
-    .id_ex_rs1_used_i (id_ex_rs1_used_i),
-    .id_ex_rs2_i      (id_ex_rs2_i),
-    .id_ex_rs2_used_i (id_ex_rs2_used_i),
+    .if_id_rs1_i      (if_id_rs1_i),
+    .if_id_rs1_used_i (if_id_rs1_used_i),
+    .if_id_rs2_i      (if_id_rs2_i),
+    .if_id_rs2_used_i (if_id_rs2_used_i),
+    .id_ex_rd_i       (id_ex_rd_i),
+    .id_ex_rd_wen_i   (id_ex_rd_wen_i),
+    .id_ex_is_load_i  (id_ex_is_load_i),
     .ex_mem_rd_i      (ex_mem_rd_i),
     .ex_mem_rd_wen_i  (ex_mem_rd_wen_i),
-    .ex_mem_is_load_i (ex_mem_is_load_i),
-    .mem_wb_rd_i      (mem_wb_rd_i),
-    .mem_wb_rd_wen_i  (mem_wb_rd_wen_i),
     .fwd_rs1_sel_o    (fwd_rs1_sel_o),
     .fwd_rs2_sel_o    (fwd_rs2_sel_o)
   );
@@ -40,57 +40,57 @@ module tb_forward;
 
   initial begin
     // baseline: nothing produces, nothing consumes
-    id_ex_rs1_i = 5'd1; id_ex_rs1_used_i = 1;
-    id_ex_rs2_i = 5'd2; id_ex_rs2_used_i = 1;
-    ex_mem_rd_i = 5'd0; ex_mem_rd_wen_i = 0; ex_mem_is_load_i = 0;
-    mem_wb_rd_i = 5'd0; mem_wb_rd_wen_i = 0;
+    if_id_rs1_i = 5'd1; if_id_rs1_used_i = 1;
+    if_id_rs2_i = 5'd2; if_id_rs2_used_i = 1;
+    id_ex_rd_i = 5'd0; id_ex_rd_wen_i = 0; id_ex_is_load_i = 0;
+    ex_mem_rd_i = 5'd0; ex_mem_rd_wen_i = 0;
     check(FWD_NONE, FWD_NONE, "no hazard");
 
     // EX/MEM forward to RS1
-    ex_mem_rd_i = 5'd1; ex_mem_rd_wen_i = 1; ex_mem_is_load_i = 0;
+    id_ex_rd_i = 5'd1; id_ex_rd_wen_i = 1; id_ex_is_load_i = 0;
     check(FWD_EXMEM, FWD_NONE, "EX/MEM -> RS1");
 
     // EX/MEM forward to RS2
-    ex_mem_rd_i = 5'd2; ex_mem_rd_wen_i = 1; ex_mem_is_load_i = 0;
+    id_ex_rd_i = 5'd2; id_ex_rd_wen_i = 1; id_ex_is_load_i = 0;
     check(FWD_NONE, FWD_EXMEM, "EX/MEM -> RS2");
 
     // EX/MEM forward to both RS1 and RS2
-    id_ex_rs1_i = 5'd3; id_ex_rs2_i = 5'd3;
-    ex_mem_rd_i = 5'd3; ex_mem_rd_wen_i = 1; ex_mem_is_load_i = 0;
+    if_id_rs1_i = 5'd3; if_id_rs2_i = 5'd3;
+    id_ex_rd_i = 5'd3; id_ex_rd_wen_i = 1; id_ex_is_load_i = 0;
     check(FWD_EXMEM, FWD_EXMEM, "EX/MEM -> RS1+RS2");
 
     // EX/MEM is a load — no EX/MEM forward (load-use case, handled by stall)
-    id_ex_rs1_i = 5'd1; id_ex_rs2_i = 5'd2;
-    ex_mem_rd_i = 5'd1; ex_mem_rd_wen_i = 1; ex_mem_is_load_i = 1;
+    if_id_rs1_i = 5'd1; if_id_rs2_i = 5'd2;
+    id_ex_rd_i = 5'd1; id_ex_rd_wen_i = 1; id_ex_is_load_i = 1;
     check(FWD_NONE, FWD_NONE, "load in MEM - no EX/MEM fwd");
 
     // MEM/WB forward to RS1
-    ex_mem_rd_wen_i = 0; ex_mem_is_load_i = 0;
-    mem_wb_rd_i = 5'd1; mem_wb_rd_wen_i = 1;
+    id_ex_rd_wen_i = 0; id_ex_is_load_i = 0;
+    ex_mem_rd_i = 5'd1; ex_mem_rd_wen_i = 1;
     check(FWD_MEMWB, FWD_NONE, "MEM/WB -> RS1");
 
     // MEM/WB forward to RS2
-    id_ex_rs2_i = 5'd1;
+    if_id_rs2_i = 5'd1;
     check(FWD_MEMWB, FWD_MEMWB, "MEM/WB -> RS1+RS2");
 
     // EX/MEM takes priority over MEM/WB
-    id_ex_rs1_i = 5'd5; id_ex_rs2_i = 5'd5;
-    ex_mem_rd_i = 5'd5; ex_mem_rd_wen_i = 1; ex_mem_is_load_i = 0;
-    mem_wb_rd_i = 5'd5; mem_wb_rd_wen_i = 1;
+    if_id_rs1_i = 5'd5; if_id_rs2_i = 5'd5;
+    id_ex_rd_i = 5'd5; id_ex_rd_wen_i = 1; id_ex_is_load_i = 0;
+    ex_mem_rd_i = 5'd5; ex_mem_rd_wen_i = 1;
     check(FWD_EXMEM, FWD_EXMEM, "EX/MEM priority > MEM/WB");
 
     // No forward when rs_used=0 even if address matches
-    id_ex_rs1_i = 5'd1; id_ex_rs1_used_i = 0;
-    id_ex_rs2_i = 5'd1; id_ex_rs2_used_i = 0;
-    ex_mem_rd_i = 5'd1; ex_mem_rd_wen_i = 1; ex_mem_is_load_i = 0;
-    mem_wb_rd_i = 5'd1; mem_wb_rd_wen_i = 1;
+    if_id_rs1_i = 5'd1; if_id_rs1_used_i = 0;
+    if_id_rs2_i = 5'd1; if_id_rs2_used_i = 0;
+    id_ex_rd_i = 5'd1; id_ex_rd_wen_i = 1; id_ex_is_load_i = 0;
+    ex_mem_rd_i = 5'd1; ex_mem_rd_wen_i = 1;
     check(FWD_NONE, FWD_NONE, "rs_used=0 suppresses forward");
 
     // No forward when producer rd=x0
-    id_ex_rs1_used_i = 1; id_ex_rs2_used_i = 1;
+    if_id_rs1_used_i = 1; if_id_rs2_used_i = 1;
+    id_ex_rd_i = 5'd0; id_ex_rd_wen_i = 1;
     ex_mem_rd_i = 5'd0; ex_mem_rd_wen_i = 1;
-    mem_wb_rd_i = 5'd0; mem_wb_rd_wen_i = 1;
-    id_ex_rs1_i = 5'd0; id_ex_rs2_i = 5'd0;
+    if_id_rs1_i = 5'd0; if_id_rs2_i = 5'd0;
     check(FWD_NONE, FWD_NONE, "rd=x0 never forwarded");
 
     if (errors == 0) $display("ALL FORWARD TESTS PASSED");


### PR DESCRIPTION
## Summary

- Eliminates the 20-level combinational path (6× CARRY8 cascade, 6.527 ns data path delay) between `ex_mem_q.dec.rd` and the EX bypass mux that was limiting Fmax to ~149 MHz on XCK26-SFVC784-2LV-c (target: 200 MHz)
- Shifts the register-index comparison one pipeline stage earlier: compute `fwd_rs1_sel`/`fwd_rs2_sel` in ID, store in `id_ex_reg_t`, read the registered value in the EX mux — no comparison on the critical cycle
- No functional change; zero IPC impact

## Changes

- `rtl/kronos_pkg.sv` — add `fwd_rs1_sel`/`fwd_rs2_sel` (`fwd_sel_e`) to `id_ex_reg_t`
- `rtl/stage1/kronos_forward.sv` — shift consumer/producer port references one stage earlier
- `tb/stage1/tb_forward.sv` — rename ports to match new interface
- `rtl/stage{1,2,3,4}/kronos_top.sv` — re-wire `u_forward`, capture selects into `id_ex_q`, use `id_ex_q.fwd_rs*_sel` in EX bypass mux

## Test Plan

- [x] `sim-forward` unit test — all 10 cases pass
- [x] Stage 1 integration: `test_forwarding`, `test_load_use`, `test_branch_flush`, `test_csr_trap` — all pass (x10 = 0)
- [x] Stage 2 compliance — 52 tests pass
- [x] Stage 3 compliance — 17 tests pass
- [x] Stage 4 compliance — 15 tests pass
- [x] `make sim-all` — all unit testbenches + stage 4 compliance suite pass

## Notes

Stage 5 (`rtl/stage5/kronos_top.sv`) requires the same three changes but cannot land here since stage5 RTL is not on `main` yet. Instructions are recorded at the top of `docs/superpowers/specs/2026-04-16-stage5b-fdiv-fsqrt-design.md` for when `stage5a` is rebased.

Closes #11