### PR TITLE
fix(fpu): eliminate Verilator latch warnings

### DIFF
--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -134,7 +134,7 @@ targets:
       verilator:
         mode: lint-only
         verilator_options: [--Wall, --Wno-UNUSED, --Wno-WIDTHEXPAND,
-                            --Wno-WIDTHTRUNC, --Wno-LATCH, --Wno-PINCONNECTEMPTY]
+                            --Wno-WIDTHTRUNC, --Wno-PINCONNECTEMPTY]
     toplevel: kronos_top
     default_tool: verilator
 
@@ -180,7 +180,7 @@ targets:
       verilator:
         mode: lint-only
         verilator_options: [--Wall, --Wno-UNUSED, --Wno-WIDTHEXPAND,
-                            --Wno-WIDTHTRUNC, --Wno-LATCH, --Wno-PINCONNECTEMPTY]
+                            --Wno-WIDTHTRUNC, --Wno-PINCONNECTEMPTY]
     toplevel: kronos_top
     default_tool: verilator
 

--- a/rtl/stage5/fpu/kronos_fpu_fadd.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fadd.sv
@@ -181,6 +181,10 @@ module kronos_fpu_fadd
   logic b_sign_pre;  // sign of b after FSUB flip
 
   always_comb begin
+    // Block-local hoisted from specials sub-block
+    logic zero_sign;
+    zero_sign = 1'b0;
+
     // --- Double decomposition ---
     a_d_sign = a_i[63];
     b_d_sign = b_i[63];
@@ -334,7 +338,6 @@ module kronos_fpu_fadd
         // it's -0; else +0.
         s1_d.is_special = 1'b1;
         begin
-          logic zero_sign;
           if (!eff_sub_early) begin
             // Additive zero: both signs must match for a signed zero; otherwise
             // the sign is +0 except in RDN.
@@ -452,6 +455,12 @@ module kronos_fpu_fadd
       logic                    result_zero;
       logic                    small_sticky;
 
+      sum_sig      = '0;
+      carry_out    = 1'b0;
+      lzc          = 0;
+      norm_sig     = '0;
+      norm_exp     = '0;
+      result_zero  = 1'b0;
       small_sticky = s2_q.small_sticky_extra;
 
       if (!s2_q.op_sub) begin
@@ -523,8 +532,65 @@ module kronos_fpu_fadd
   logic [4:0]  s4_flags;
 
   always_comb begin
-    s4_result = '0;
-    s4_flags  = 5'd0;
+    // Hoisted locals from pack / subnormal / round / overflow sub-blocks
+    int unsigned             mant_w;
+    int unsigned             exp_w;
+    logic signed [EXP_W-1:0] emin;
+    logic signed [EXP_W-1:0] emax;
+    logic signed [EXP_W-1:0] bias;
+    logic signed [EXP_W-1:0] cur_exp;
+    logic [SIG_W-1:0]        cur_sig;
+    logic                    g, r, st;
+    int unsigned             sub_shift;
+    int unsigned             i;
+    logic                    lsb;
+    logic                    round_up;
+    logic [SIG_W-1:0]        rounded_sig;
+    logic                    carry_up;
+    logic [51:0]             out_mant_d;
+    logic [22:0]             out_mant_s;
+    logic [10:0]             out_expf_d;
+    logic [7:0]              out_expf_s;
+    logic                    overflow;
+    logic                    is_subnormal_out;
+    logic                    inexact;
+    int unsigned             sh;
+    logic [2:0]              grs_vec;
+    logic [SIG_W:0]          incremented;
+    logic [SIG_W-1:0]        mask_one;
+    logic                    to_inf;
+
+    // Defaults
+    s4_result        = '0;
+    s4_flags         = 5'd0;
+    mant_w           = 0;
+    exp_w            = 0;
+    emin             = '0;
+    emax             = '0;
+    bias             = '0;
+    cur_exp          = '0;
+    cur_sig          = '0;
+    g                = 1'b0;
+    r                = 1'b0;
+    st               = 1'b0;
+    sub_shift        = 0;
+    i                = 0;
+    lsb              = 1'b0;
+    round_up         = 1'b0;
+    rounded_sig      = '0;
+    carry_up         = 1'b0;
+    out_mant_d       = '0;
+    out_mant_s       = '0;
+    out_expf_d       = '0;
+    out_expf_s       = '0;
+    overflow         = 1'b0;
+    is_subnormal_out = 1'b0;
+    inexact          = 1'b0;
+    sh               = 0;
+    grs_vec          = '0;
+    incremented      = '0;
+    mask_one         = '0;
+    to_inf           = 1'b0;
 
     if (s3_q.is_special) begin
       s4_result = s3_q.special_res;
@@ -533,27 +599,6 @@ module kronos_fpu_fadd
       if (s3_q.fmt_d) s4_result = {s3_q.res_sign, 63'd0};
       else            s4_result = {FP_NANBOX_UPPER, s3_q.res_sign, 31'd0};
     end else begin : pack
-      int unsigned             mant_w;
-      int unsigned             exp_w;
-      logic signed [EXP_W-1:0] emin;   // unbiased min normal exponent
-      logic signed [EXP_W-1:0] emax;   // unbiased max normal exponent
-      logic signed [EXP_W-1:0] bias;
-      logic signed [EXP_W-1:0] cur_exp;
-      logic [SIG_W-1:0]        cur_sig;
-      logic                    g, r, st;
-      int unsigned             sub_shift;
-      int unsigned             i;
-      logic                    lsb;
-      logic                    round_up;
-      logic [SIG_W-1:0]        rounded_sig;
-      logic                    carry_up;
-      logic [51:0]             out_mant_d;
-      logic [22:0]             out_mant_s;
-      logic [10:0]             out_expf_d;
-      logic [7:0]              out_expf_s;
-      logic                    overflow;
-      logic                    is_subnormal_out;
-      logic                    inexact;
 
       if (s3_q.fmt_d) begin
         mant_w = 52;
@@ -578,8 +623,6 @@ module kronos_fpu_fadd
       // --- Subnormal flush: if exp < emin, shift significand right until
       //     exp == emin, accumulating dropped bits into G/R/S.
       if (cur_exp < emin) begin
-        int unsigned sh;
-        logic [2:0]  grs_vec;
         grs_vec = {g, r, st};
         sh = int'(emin - cur_exp);
         // Pull guard/round/sticky back into significand LSBs so we can reuse
@@ -640,8 +683,6 @@ module kronos_fpu_fadd
 
       // Add 1 at position (SIG_W-1-mant_w) if rounding up.
       begin
-        logic [SIG_W:0] incremented;
-        logic [SIG_W-1:0] mask_one;
         mask_one = '0;
         mask_one[SIG_W - 1 - mant_w] = 1'b1;
         if (round_up)
@@ -668,7 +709,6 @@ module kronos_fpu_fadd
         s4_flags[FP_FFLAG_NX] = 1'b1;
         // RTZ / (RDN for pos) / (RUP for neg) → max finite; else ±Inf.
         begin
-          logic to_inf;
           unique case (s3_q.rm)
             FP_RM_RNE: to_inf = 1'b1;
             FP_RM_RTZ: to_inf = 1'b0;

--- a/rtl/stage5/fpu/kronos_fpu_fcvt.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fcvt.sv
@@ -189,6 +189,18 @@ module kronos_fpu_fcvt
     logic [63:0] frac_mask;
     logic [6:0]  shift_r;
     logic [7:0]  frac_bits;   // number of bits shifted right (fraction width)
+    logic [63:0] mag;
+    logic        over_after_round;
+    logic [63:0] signed_val;
+
+    // Defaults for block-local variables
+    sig64            = '0;
+    frac_mask        = '0;
+    shift_r          = '0;
+    frac_bits        = '0;
+    mag              = '0;
+    over_after_round = 1'b0;
+    signed_val       = '0;
 
     // Decompose: build a 64-bit significand with implicit 1 at bit 63
     if (src_is_s) begin
@@ -314,10 +326,6 @@ module kronos_fpu_fcvt
       s2_fflags[FP_FFLAG_NV] = 1'b1;
     end else begin
       // Take |value| = int_rounded (up to 65 bits), then apply sign.
-      logic [63:0] mag;
-      logic        over_after_round;
-      logic [63:0] signed_val;
-
       mag = int_rounded[63:0];
       over_after_round = 1'b0;
 

--- a/rtl/stage5/fpu/kronos_fpu_fmul.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fmul.sv
@@ -334,6 +334,28 @@ module kronos_fpu_fmul
     // Wide product, left-shifted to bring the leading 1 to bit PROD_W-2.
     // After left-shifting by (lz-1), all products have their hidden bit at bit 104.
     logic [PROD_W-1:0] prod_norm;
+    // Hoisted from subnormal sub-blocks
+    logic signed [EXP_EXT_W-1:0] shift_amt;
+    logic [SIG_W-1:0] mant_fullw;
+    logic g_in, r_in, s_in;
+    int unsigned sh;
+    logic [63:0] tail;
+    logic [63:0] shifted;
+    logic [63:0] lost_mask;
+
+    // Defaults
+    lz         = '0;
+    exp_adj    = '0;
+    prod_norm  = '0;
+    shift_amt  = '0;
+    mant_fullw = '0;
+    g_in       = 1'b0;
+    r_in       = 1'b0;
+    s_in       = 1'b0;
+    sh         = 0;
+    tail       = '0;
+    shifted    = '0;
+    lost_mask  = '0;
 
     // Start from the wide product.
     s3_prod = s2_prod_q;
@@ -382,11 +404,6 @@ module kronos_fpu_fmul
     // Subnormal handling: if s3_exp_norm_c <= 0, shift the mantissa right by
     // (1 - s3_exp_norm_c) to denormalize, accumulating into sticky.
     begin
-      logic signed [EXP_EXT_W-1:0] shift_amt;
-      logic [SIG_W-1:0] mant_fullw;
-      logic g_in, r_in, s_in;
-      int unsigned sh;
-
       mant_fullw = s3_mant_c;
       g_in = s3_guard_c;
       r_in = s3_round_c;
@@ -401,9 +418,6 @@ module kronos_fpu_fmul
         // Build a 64-bit tail to simplify sticky computation:
         // [mant (53)] [g (1)] [r (1)] [s (1)] ...
         begin
-          logic [63:0] tail;
-          logic [63:0] shifted;
-          logic [63:0] lost_mask;
           tail = {mant_fullw, g_in, r_in, s_in, 8'd0};
           if (sh >= 64) begin
             shifted   = 64'd0;

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -556,7 +556,7 @@ build-s5: $(SIM_BIN_S5)
 
 $(SIM_BIN_S5): $(SV_FILES_S5) $(abspath sim_main.cpp)
 	$(VERILATOR) --cc --exe --build -Wall --Wno-UNUSED --Wno-WIDTHEXPAND --Wno-WIDTHTRUNC \
-	  --Wno-PINCONNECTEMPTY --Wno-LATCH --Wno-TIMESCALEMOD \
+	  --Wno-PINCONNECTEMPTY --Wno-TIMESCALEMOD \
 	  --top-module $(TOP_S5) \
 	  $(SV_FILES_S5) $(abspath sim_main.cpp) \
 	  -CFLAGS "$(CFLAGS) -DKRONOS_HAS_FPU" \
@@ -572,7 +572,7 @@ TB_CORE_FP_BASIC_FILES := $(SV_FILES_S5) \
                           $(TB_DIR)/stage5/tb_core_fp_basic.sv
 sim-core-fp-basic:
 	$(VERILATOR) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD --Wno-UNUSED \
-	  --Wno-WIDTHTRUNC --Wno-PINCONNECTEMPTY --Wno-LATCH \
+	  --Wno-WIDTHTRUNC --Wno-PINCONNECTEMPTY \
 	  --top-module tb_core_fp_basic $(TB_CORE_FP_BASIC_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/core_fp_basic
 	$(OBJ_DIR)/core_fp_basic/Vtb_core_fp_basic
@@ -581,7 +581,7 @@ TB_CORE_FP_FORWARDING_FILES := $(SV_FILES_S5) \
                                 $(TB_DIR)/stage5/tb_core_fp_forwarding.sv
 sim-core-fp-forwarding:
 	$(VERILATOR) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD --Wno-UNUSED \
-	  --Wno-WIDTHTRUNC --Wno-PINCONNECTEMPTY --Wno-LATCH \
+	  --Wno-WIDTHTRUNC --Wno-PINCONNECTEMPTY \
 	  --top-module tb_core_fp_forwarding $(TB_CORE_FP_FORWARDING_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/core_fp_forwarding
 	$(OBJ_DIR)/core_fp_forwarding/Vtb_core_fp_forwarding


### PR DESCRIPTION
## Summary
- Hoist block-local variable declarations from conditional `begin/end` blocks to the top of their enclosing `always_comb` with defaults, eliminating all 60 `%Warning-LATCH` diagnostics across `kronos_fpu_fcvt`, `kronos_fpu_fadd`, and `kronos_fpu_fmul`
- Remove `--Wno-LATCH` suppression from `sim/Makefile` and `kronos_riscv.core` lint targets

## Test plan
- [x] Build with `--Wno-LATCH` removed — zero latch warnings
- [x] `make sim-s5` — 7/7 assembly + 2 integration TBs pass
- [x] `make sim-all` — 15/15 unit TBs + Stage 4 compliance pass