### PR TITLE
feat(stage5b): RV64IMAFD — iterative FDIV/FSQRT (radix-2 SRT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 3     | AXI4 switch + C extension + branch predictor   | RV32IMC          | AXI4    | Complete    |
 | 4     | RV64I + A extension                             | RV64IMAC         | AXI4    | Complete    |
 | 5a    | F/D extensions (pipelined, no FDIV/FSQRT)       | RV64IMAFD        | AXI4    | Complete    |
-| 5b    | FDIV/FSQRT (iterative SRT)                      | RV64IMAFDC       | AXI4    | Planned     |
+| 5b    | FDIV/FSQRT (iterative SRT)                      | RV64IMAFDC       | AXI4    | Complete    |
 | 6     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same
@@ -88,7 +88,10 @@ kronos-riscv/
 │           ├── kronos_fpu_fmul.sv   # 4-cycle: FMUL
 │           ├── kronos_fpu_fma.sv    # 5-cycle: FMADD/FMSUB/FNMADD/FNMSUB
 │           ├── kronos_fpu_scoreboard.sv # WAW busy-table + WB port reservation
-│           └── kronos_fpu_top.sv    # FPU dispatch wrapper
+│           ├── kronos_fpu_top.sv    # FPU dispatch wrapper
+│           ├── kronos_fpu_iter.sv   # FDIV/FSQRT wrapper FSM (variable latency)
+│           ├── kronos_fpu_fdiv_core.sv  # Radix-2 SRT division core
+│           └── kronos_fpu_fsqrt_core.sv # Radix-2 SRT square root core
 ├── tb/
 │   ├── tb_pkg.sv              # Shared testbench utilities
 │   ├── stage0/                # Stage 0 testbenches
@@ -103,7 +106,8 @@ kronos-riscv/
 │   ├── stage2/                # Stage 2 M-extension test programs
 │   ├── stage3/                # Stage 3 test programs
 │   ├── stage4/                # Stage 4 test programs (RV64IMAC)
-│   └── stage5/                # Stage 5 FP test programs (RV64IMAFD)
+│   ├── stage5/                # Stage 5a FP test programs (RV64IMAFD)
+│   └── stage5b/               # Stage 5b FDIV/FSQRT test programs
 ├── sim/
 │   ├── Makefile               # Verilator build and run targets
 │   └── sim_main.cpp           # C++ simulation driver
@@ -150,6 +154,10 @@ cd sim && make sim-fpu-fcvt    # FCVT (int↔FP, S↔D)
 cd sim && make sim-fpu-fadd    # FADD/FSUB (4-stage)
 cd sim && make sim-fpu-fmul    # FMUL (4-stage)
 cd sim && make sim-fpu-fma     # FMA (5-stage)
+cd sim && make sim-fpu-fdiv-core   # FDIV radix-2 SRT core
+cd sim && make sim-fpu-fsqrt-core  # FSQRT radix-2 SRT core
+cd sim && make sim-fpu-iter    # FDIV/FSQRT wrapper (SoftFloat-verified)
+cd sim && make sim-fpu-top-iter # iter integration in FPU top
 
 # Stage 5 integration testbenches
 cd sim && make sim-core-fp-basic       # basic FMV + FADD end-to-end
@@ -157,6 +165,7 @@ cd sim && make sim-core-fp-forwarding  # FMUL→FADD with forwarding
 
 # Stage 5 full regression + coverage gate (≥95% line coverage)
 cd sim && make sim-s5
+cd sim && make sim-s5b    # Stage 5b FDIV/FSQRT assembly tests
 cd sim && make coverage
 
 # Stage 4 regression

--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -109,6 +109,9 @@ filesets:
       - rtl/stage5/fpu/kronos_fpu_fadd.sv
       - rtl/stage5/fpu/kronos_fpu_fmul.sv
       - rtl/stage5/fpu/kronos_fpu_fma.sv
+      - rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
+      - rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
+      - rtl/stage5/fpu/kronos_fpu_iter.sv
       - rtl/stage5/fpu/kronos_fpu_top.sv
       - rtl/stage5/kronos_top.sv
     file_type: systemVerilogSource

--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -80,7 +80,7 @@ package kronos_pkg;
     FP_FCVT_F_W, FP_FCVT_F_WU, FP_FCVT_F_L, FP_FCVT_F_LU,
     FP_FCVT_S_D, FP_FCVT_D_S,
     // Arith
-    FP_FADD, FP_FSUB, FP_FMUL,
+    FP_FADD, FP_FSUB, FP_FMUL, FP_FDIV, FP_FSQRT,
     // FMA
     FP_FMADD, FP_FMSUB, FP_FNMADD, FP_FNMSUB
   } fp_op_e;

--- a/rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
@@ -1,0 +1,169 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Radix-2 restoring binary long-division core for IEEE 754 significands.
+//
+// Implements the exact algorithm from srt_divide.py:
+//   1. FIRST cycle: compare a >= b, emit integer quotient bit.
+//   2. RUN cycles: shift partial remainder left, compare, emit fractional bits.
+//   3. n = 27 for single (fmt_d_i=0), n = 56 for double (fmt_d_i=1).
+//
+// Inputs are pre-normalized 53-bit significands (bit 52 = hidden 1).
+// Output is a 56-bit raw quotient (27-bit meaningful for single) and a sticky
+// bit indicating whether the final partial remainder is non-zero.
+
+module kronos_fpu_fdiv_core (
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        flush_i,
+  input  logic        start_i,
+  input  logic        fmt_d_i,   // 0 = S (27 iters), 1 = D (56 iters)
+  input  logic [52:0] a_i,       // normalized dividend significand
+  input  logic [52:0] b_i,       // normalized divisor significand
+  output logic        done_o,
+  output logic [55:0] quot_o,
+  output logic        rem_nz_o
+);
+
+  // -------------------------------------------------------------------------
+  // FSM encoding
+  // -------------------------------------------------------------------------
+  typedef enum logic [1:0] {
+    ST_IDLE  = 2'b00,
+    ST_FIRST = 2'b01,
+    ST_RUN   = 2'b10,
+    ST_DONE  = 2'b11
+  } state_e;
+
+  // -------------------------------------------------------------------------
+  // Constants
+  // -------------------------------------------------------------------------
+  localparam int unsigned N_S = 27;
+  localparam int unsigned N_D = 56;
+
+  // -------------------------------------------------------------------------
+  // State registers
+  // -------------------------------------------------------------------------
+  state_e        state_q;
+  logic [53:0]   p_q;       // partial remainder (54 bits: 2*p can reach 54 bits)
+  logic [52:0]   b_q;       // latched divisor
+  logic [55:0]   q_q;       // quotient shift register
+  logic [5:0]    ctr_q;     // iteration counter
+  logic          fmt_d_q;   // latched format
+
+  // -------------------------------------------------------------------------
+  // Combinational signals
+  // -------------------------------------------------------------------------
+  state_e        state_n;
+  logic [53:0]   p_n;
+  logic [55:0]   q_n;
+  logic [5:0]    ctr_n;
+  logic [53:0]   p_shift;   // 2 * p_q (left-shifted partial remainder)
+  logic          ge;        // p >= b comparison result
+  logic [5:0]    target;    // iteration count for current format
+
+  // -------------------------------------------------------------------------
+  // Target selection
+  // -------------------------------------------------------------------------
+  assign target = fmt_d_q ? 6'(N_D) : 6'(N_S);
+
+  // -------------------------------------------------------------------------
+  // Combinational next-state and datapath
+  // -------------------------------------------------------------------------
+  always_comb begin
+    state_n = state_q;
+    p_n     = p_q;
+    q_n     = q_q;
+    ctr_n   = ctr_q;
+    ge      = 1'b0;
+    p_shift = '0;
+
+    unique case (state_q)
+      ST_IDLE: begin
+        if (start_i) begin
+          state_n = ST_FIRST;
+        end
+      end
+
+      ST_FIRST: begin
+        // Integer bit: if p >= b, quotient bit = 1 and subtract.
+        ge = (p_q >= {1'b0, b_q});
+        if (ge) begin
+          q_n = 56'd1;
+          p_n = p_q - {1'b0, b_q};
+        end else begin
+          q_n = 56'd0;
+          p_n = p_q;
+        end
+        ctr_n   = 6'd1;
+        state_n = ST_RUN;
+      end
+
+      ST_RUN: begin
+        // Shift partial remainder left by 1.
+        p_shift = {p_q[52:0], 1'b0};
+        ge      = (p_shift >= {1'b0, b_q});
+        if (ge) begin
+          q_n = {q_q[54:0], 1'b1};
+          p_n = p_shift - {1'b0, b_q};
+        end else begin
+          q_n = {q_q[54:0], 1'b0};
+          p_n = p_shift;
+        end
+        ctr_n = ctr_q + 6'd1;
+        if (ctr_n == target) begin
+          state_n = ST_DONE;
+        end
+      end
+
+      ST_DONE: begin
+        state_n = ST_IDLE;
+      end
+
+      default: begin
+        state_n = ST_IDLE;
+      end
+    endcase
+
+    if (flush_i) begin
+      state_n = ST_IDLE;
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // Sequential logic
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q <= ST_IDLE;
+      p_q     <= '0;
+      b_q     <= '0;
+      q_q     <= '0;
+      ctr_q   <= '0;
+      fmt_d_q <= 1'b0;
+    end else begin
+      state_q <= state_n;
+      p_q     <= p_n;
+      q_q     <= q_n;
+      ctr_q   <= ctr_n;
+
+      // Latch inputs on start.
+      if (start_i && (state_q == ST_IDLE)) begin
+        p_q     <= {1'b0, a_i};
+        b_q     <= b_i;
+        fmt_d_q <= fmt_d_i;
+      end else begin
+        b_q <= b_q;
+      end
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // Outputs
+  // -------------------------------------------------------------------------
+  assign done_o   = (state_q == ST_DONE);
+  assign quot_o   = q_q;
+  assign rem_nz_o = (p_q != '0);
+
+endmodule

--- a/rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
@@ -1,0 +1,216 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Radix-2 digit-by-digit square root core for IEEE 754 significands.
+//
+// Implements the exact algorithm from srt_sqrt.py:
+//   - Input: pre-normalized significand a in [1<<52, 1<<54).
+//     Even exponent: a in [1<<52, 1<<53), bit 52 set.
+//     Odd exponent:  a in [1<<53, 1<<54), bit 53 set.
+//   - Runs total = n + 26 iterations (82 for D, 53 for S).
+//   - Output: n-bit root Q = q >> 26, sticky = |q[25:0] | |r.
+//
+// Cycle count: total + 1 (83 for D, 54 for S).
+
+module kronos_fpu_fsqrt_core (
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        flush_i,
+  input  logic        start_i,
+  input  logic        fmt_d_i,   // 0 = S (53 iters), 1 = D (82 iters)
+  input  logic [53:0] a_i,       // normalized significand (53 or 54 bits)
+  output logic        done_o,
+  output logic [55:0] quot_o,    // n-bit root (56 for D, 27 for S)
+  output logic        rem_nz_o   // sticky
+);
+
+  // -------------------------------------------------------------------------
+  // FSM encoding
+  // -------------------------------------------------------------------------
+  typedef enum logic [1:0] {
+    ST_IDLE = 2'b00,
+    ST_RUN  = 2'b01,
+    ST_DONE = 2'b10
+  } state_e;
+
+  // -------------------------------------------------------------------------
+  // Constants
+  // -------------------------------------------------------------------------
+  localparam int unsigned TOTAL_S = 53;  // n=27 + 26
+  localparam int unsigned TOTAL_D = 82;  // n=56 + 26
+  localparam int unsigned Q_W     = 82;  // max q width (total_D iterations)
+  localparam int unsigned R_W     = 84;  // r < trial < 2^83, use 84 bits
+
+  // -------------------------------------------------------------------------
+  // State registers
+  // -------------------------------------------------------------------------
+  state_e           state_q;
+  logic [R_W-1:0]   r_q;       // partial remainder
+  logic [Q_W-1:0]   q_q;       // running root
+  logic [53:0]       a_q;       // latched input significand
+  logic [6:0]        ctr_q;     // iteration counter (0..81)
+  logic              fmt_d_q;   // latched format
+
+  // -------------------------------------------------------------------------
+  // Combinational signals
+  // -------------------------------------------------------------------------
+  state_e           state_n;
+  logic [R_W-1:0]   r_n;
+  logic [Q_W-1:0]   q_n;
+  logic [6:0]        ctr_n;
+  logic [1:0]        pair;      // 2-bit input pair for current iteration
+  logic [R_W-1:0]   r_shifted; // r << 2 | pair
+  logic [R_W-1:0]   trial;     // (q << 2) | 1
+  logic              ge;        // r_shifted >= trial
+  logic [6:0]        target;    // total iterations for current format
+
+  // -------------------------------------------------------------------------
+  // Target selection
+  // -------------------------------------------------------------------------
+  assign target = fmt_d_q ? 7'(TOTAL_D) : 7'(TOTAL_S);
+
+  // -------------------------------------------------------------------------
+  // Input pair extraction
+  //
+  // a_padded = a << (2*total - 54). At iteration i, the 2-bit pair from
+  // a_padded is at position 2*(total-1-i). Mapping back to a:
+  //   offset = 2*(total-1-i) - (2*total - 54) = 52 - 2*i
+  // So pair = a[53-2*i : 52-2*i] when 52-2*i >= 0, else 0.
+  // -------------------------------------------------------------------------
+  always_comb begin
+    pair = 2'b00;
+    // 52 - 2*ctr_q >= 0  =>  ctr_q <= 26
+    if (ctr_q <= 7'd26) begin
+      // Bit index: 53 - 2*ctr_q. For ctr_q=0: bits [53:52].
+      // For ctr_q=26: bits [1:0].
+      unique case (ctr_q)
+        7'd0:  pair = a_q[53:52];
+        7'd1:  pair = a_q[51:50];
+        7'd2:  pair = a_q[49:48];
+        7'd3:  pair = a_q[47:46];
+        7'd4:  pair = a_q[45:44];
+        7'd5:  pair = a_q[43:42];
+        7'd6:  pair = a_q[41:40];
+        7'd7:  pair = a_q[39:38];
+        7'd8:  pair = a_q[37:36];
+        7'd9:  pair = a_q[35:34];
+        7'd10: pair = a_q[33:32];
+        7'd11: pair = a_q[31:30];
+        7'd12: pair = a_q[29:28];
+        7'd13: pair = a_q[27:26];
+        7'd14: pair = a_q[25:24];
+        7'd15: pair = a_q[23:22];
+        7'd16: pair = a_q[21:20];
+        7'd17: pair = a_q[19:18];
+        7'd18: pair = a_q[17:16];
+        7'd19: pair = a_q[15:14];
+        7'd20: pair = a_q[13:12];
+        7'd21: pair = a_q[11:10];
+        7'd22: pair = a_q[9:8];
+        7'd23: pair = a_q[7:6];
+        7'd24: pair = a_q[5:4];
+        7'd25: pair = a_q[3:2];
+        7'd26: pair = a_q[1:0];
+        default: pair = 2'b00;
+      endcase
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // Combinational next-state and datapath
+  // -------------------------------------------------------------------------
+  always_comb begin
+    state_n   = state_q;
+    r_n       = r_q;
+    q_n       = q_q;
+    ctr_n     = ctr_q;
+    ge        = 1'b0;
+    r_shifted = '0;
+    trial     = '0;
+
+    unique case (state_q)
+      ST_IDLE: begin
+        if (start_i) begin
+          state_n = ST_RUN;
+        end
+      end
+
+      ST_RUN: begin
+        // r_shifted = (r << 2) | pair
+        r_shifted = {r_q[R_W-3:0], pair};
+
+        // trial = (q << 2) | 1
+        trial = {q_q, 2'b01} & {R_W{1'b1}};
+
+        ge = (r_shifted >= trial);
+
+        if (ge) begin
+          r_n = r_shifted - trial;
+          q_n = {q_q[Q_W-2:0], 1'b1};
+        end else begin
+          r_n = r_shifted;
+          q_n = {q_q[Q_W-2:0], 1'b0};
+        end
+
+        ctr_n = ctr_q + 7'd1;
+        if (ctr_n == target) begin
+          state_n = ST_DONE;
+        end
+      end
+
+      ST_DONE: begin
+        state_n = ST_IDLE;
+      end
+
+      default: begin
+        state_n = ST_IDLE;
+      end
+    endcase
+
+    if (flush_i) begin
+      state_n = ST_IDLE;
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // Sequential logic
+  // -------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q <= ST_IDLE;
+      r_q     <= '0;
+      q_q     <= '0;
+      a_q     <= '0;
+      ctr_q   <= '0;
+      fmt_d_q <= 1'b0;
+    end else begin
+      state_q <= state_n;
+      r_q     <= r_n;
+      q_q     <= q_n;
+      ctr_q   <= ctr_n;
+
+      // Latch inputs on start.
+      if (start_i && (state_q == ST_IDLE)) begin
+        a_q     <= a_i;
+        fmt_d_q <= fmt_d_i;
+        r_q     <= '0;
+        q_q     <= '0;
+        ctr_q   <= '0;
+      end
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // Outputs
+  //
+  // Q = q_q >> 26.  For D (total=82): q_q has 82 bits, Q = q_q[81:26] (56 bits).
+  // For S (total=53): q_q has 53 meaningful bits, Q = q_q[52:26] (27 bits),
+  // zero-extended to 56 bits.
+  // sticky = |q_q[25:0] | |r_q
+  // -------------------------------------------------------------------------
+  assign done_o   = (state_q == ST_DONE);
+  assign quot_o   = fmt_d_q ? q_q[81:26] : {29'd0, q_q[52:26]};
+  assign rem_nz_o = (|q_q[25:0]) | (|r_q);
+
+endmodule

--- a/rtl/stage5/fpu/kronos_fpu_iter.sv
+++ b/rtl/stage5/fpu/kronos_fpu_iter.sv
@@ -1,0 +1,882 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Iterative FPU wrapper for FDIV and FSQRT.
+//
+// FSM: IDLE -> UNPACK -> ITER -> ROUND -> PACK -> IDLE
+//
+// IDLE:   Latch raw inputs on in_valid_i.
+// UNPACK: Classify operands, detect specials (bypass to PACK),
+//         normalize subnormals, compute result exponent, start cores.
+// ITER:   Wait for fdiv/fsqrt core done signal.
+// ROUND:  (placeholder — Task 11)
+// PACK:   (placeholder — Task 12)
+
+module kronos_fpu_iter
+  import kronos_pkg::*;
+(
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        flush_i,
+
+  input  logic        in_valid_i,
+  input  fp_op_e      op_i,
+  input  logic        fmt_d_i,
+  input  logic [2:0]  rm_i,
+  input  logic [63:0] a_i,
+  input  logic [63:0] b_i,
+  input  fpu_tag_t    tag_i,
+
+  output logic        busy_o,
+  output logic        out_valid_o,
+  output logic [63:0] result_o,
+  output logic [4:0]  fflags_o,
+  output fpu_tag_t    tag_o,
+
+  // Late-reservation to scoreboard (wired in Task 14-15)
+  output logic        sb_late_req_o,
+  output logic        sb_late_fp_dest_o,
+  input  logic        sb_late_grant_i
+);
+
+  // -----------------------------------------------------------------------
+  // FSM states
+  // -----------------------------------------------------------------------
+  typedef enum logic [2:0] {
+    IDLE   = 3'd0,
+    UNPACK = 3'd1,
+    ITER   = 3'd2,
+    ROUND  = 3'd3,
+    PACK   = 3'd4
+  } state_e;
+
+  // -----------------------------------------------------------------------
+  // Operand classification
+  // -----------------------------------------------------------------------
+  typedef struct packed {
+    logic        sign;
+    logic [10:0] exp;       // biased exponent (11 bits covers both S and D)
+    logic [51:0] sig;       // raw significand (no implicit 1)
+    logic        is_zero;
+    logic        is_subnorm;
+    logic        is_inf;
+    logic        is_snan;
+    logic        is_qnan;
+    logic        is_normal;
+    logic [5:0]  clz;       // leading zeros of significand (for subnormals)
+  } fp_class_t;
+
+  // -----------------------------------------------------------------------
+  // CLZ function for 53-bit significand (bit 52 = implicit 1 position)
+  // -----------------------------------------------------------------------
+  function automatic logic [5:0] clz53(input logic [52:0] x);
+    for (int i = 52; i >= 0; i--) begin
+      if (x[i]) return 6'd52 - i[5:0];
+    end
+    return 6'd53;
+  endfunction
+
+  // -----------------------------------------------------------------------
+  // State registers
+  // -----------------------------------------------------------------------
+  state_e    state_q;
+
+  // Latched raw inputs (IDLE -> UNPACK)
+  fp_op_e    op_q;
+  logic      fmt_d_q;
+  logic [2:0] rm_q;
+  fpu_tag_t  tag_q;
+  logic [63:0] a_raw_q, b_raw_q;
+
+  // Classified operands (registered in UNPACK -> ITER transition)
+  fp_class_t a_class_q, b_class_q;
+
+  // Normalized operands and result exponent (latched UNPACK -> ITER)
+  logic [52:0]       a_norm_q, b_norm_q;   // fdiv: 53-bit normalized sigs
+  logic [53:0]       a_sqrt_q;             // fsqrt: 54-bit normalized sig
+  logic              result_sign_q;
+  logic signed [12:0] result_exp_q;        // signed intermediate exponent
+
+  // Raw quotient from core (latched on core_done)
+  logic [55:0] raw_q_q;
+  logic        raw_sticky_q;
+
+  // -----------------------------------------------------------------------
+  // Combinational signals
+  // -----------------------------------------------------------------------
+  state_e    state_d;
+  fp_class_t a_class, b_class;
+
+  // -----------------------------------------------------------------------
+  // Operand classify (combinational, used in UNPACK)
+  // Reads from a_raw_q / b_raw_q (latched in IDLE)
+  // -----------------------------------------------------------------------
+  always_comb begin : proc_classify_a
+    a_class = '0;
+    if (fmt_d_q) begin
+      // Double precision
+      a_class.sign = a_raw_q[63];
+      a_class.exp  = a_raw_q[62:52];
+      a_class.sig  = a_raw_q[51:0];
+    end else begin
+      // Single precision -- check NaN-boxing
+      if (a_raw_q[63:32] == 32'hFFFF_FFFF) begin
+        a_class.sign = a_raw_q[31];
+        a_class.exp  = {3'b0, a_raw_q[30:23]};
+        a_class.sig  = {a_raw_q[22:0], 29'b0};
+      end else begin
+        // Not properly NaN-boxed: treat as canonical qNaN
+        a_class.sign    = 1'b0;
+        a_class.exp     = 11'h7FF;
+        a_class.sig     = {1'b1, 51'b0};
+        a_class.is_qnan = 1'b1;
+      end
+    end
+
+    // Classification (only if not already forced to qNaN by NaN-box check)
+    if (!a_class.is_qnan) begin
+      if (fmt_d_q) begin
+        a_class.is_zero    = (a_class.exp == 11'h000) && (a_class.sig == 52'b0);
+        a_class.is_subnorm = (a_class.exp == 11'h000) && (a_class.sig != 52'b0);
+        a_class.is_inf     = (a_class.exp == 11'h7FF) && (a_class.sig == 52'b0);
+        a_class.is_snan    = (a_class.exp == 11'h7FF) && (a_class.sig != 52'b0)
+                             && !a_class.sig[51];
+        a_class.is_qnan    = (a_class.exp == 11'h7FF) && a_class.sig[51];
+        a_class.is_normal  = !a_class.is_zero && !a_class.is_subnorm
+                             && !a_class.is_inf && !a_class.is_snan
+                             && !a_class.is_qnan;
+      end else begin
+        // Single: exponent is in [7:0] of a_class.exp, sig in [51:29]
+        a_class.is_zero    = (a_class.exp[7:0] == 8'h00)
+                             && (a_class.sig[51:29] == 23'b0);
+        a_class.is_subnorm = (a_class.exp[7:0] == 8'h00)
+                             && (a_class.sig[51:29] != 23'b0);
+        a_class.is_inf     = (a_class.exp[7:0] == 8'hFF)
+                             && (a_class.sig[51:29] == 23'b0);
+        a_class.is_snan    = (a_class.exp[7:0] == 8'hFF)
+                             && (a_class.sig[51:29] != 23'b0)
+                             && !a_class.sig[51];
+        a_class.is_qnan    = (a_class.exp[7:0] == 8'hFF)
+                             && a_class.sig[51];
+        a_class.is_normal  = !a_class.is_zero && !a_class.is_subnorm
+                             && !a_class.is_inf && !a_class.is_snan
+                             && !a_class.is_qnan;
+      end
+    end
+
+    // CLZ for subnormals
+    if (fmt_d_q)
+      a_class.clz = clz53({1'b0, a_class.sig});
+    else
+      a_class.clz = clz53({1'b0, a_class.sig[51:29], 29'b0});
+  end
+
+  always_comb begin : proc_classify_b
+    b_class = '0;
+    if (fmt_d_q) begin
+      // Double precision
+      b_class.sign = b_raw_q[63];
+      b_class.exp  = b_raw_q[62:52];
+      b_class.sig  = b_raw_q[51:0];
+    end else begin
+      // Single precision -- check NaN-boxing
+      if (b_raw_q[63:32] == 32'hFFFF_FFFF) begin
+        b_class.sign = b_raw_q[31];
+        b_class.exp  = {3'b0, b_raw_q[30:23]};
+        b_class.sig  = {b_raw_q[22:0], 29'b0};
+      end else begin
+        // Not properly NaN-boxed: treat as canonical qNaN
+        b_class.sign    = 1'b0;
+        b_class.exp     = 11'h7FF;
+        b_class.sig     = {1'b1, 51'b0};
+        b_class.is_qnan = 1'b1;
+      end
+    end
+
+    // Classification
+    if (!b_class.is_qnan) begin
+      if (fmt_d_q) begin
+        b_class.is_zero    = (b_class.exp == 11'h000) && (b_class.sig == 52'b0);
+        b_class.is_subnorm = (b_class.exp == 11'h000) && (b_class.sig != 52'b0);
+        b_class.is_inf     = (b_class.exp == 11'h7FF) && (b_class.sig == 52'b0);
+        b_class.is_snan    = (b_class.exp == 11'h7FF) && (b_class.sig != 52'b0)
+                             && !b_class.sig[51];
+        b_class.is_qnan    = (b_class.exp == 11'h7FF) && b_class.sig[51];
+        b_class.is_normal  = !b_class.is_zero && !b_class.is_subnorm
+                             && !b_class.is_inf && !b_class.is_snan
+                             && !b_class.is_qnan;
+      end else begin
+        // Single: exponent is in [7:0] of b_class.exp, sig in [51:29]
+        b_class.is_zero    = (b_class.exp[7:0] == 8'h00)
+                             && (b_class.sig[51:29] == 23'b0);
+        b_class.is_subnorm = (b_class.exp[7:0] == 8'h00)
+                             && (b_class.sig[51:29] != 23'b0);
+        b_class.is_inf     = (b_class.exp[7:0] == 8'hFF)
+                             && (b_class.sig[51:29] == 23'b0);
+        b_class.is_snan    = (b_class.exp[7:0] == 8'hFF)
+                             && (b_class.sig[51:29] != 23'b0)
+                             && !b_class.sig[51];
+        b_class.is_qnan    = (b_class.exp[7:0] == 8'hFF)
+                             && b_class.sig[51];
+        b_class.is_normal  = !b_class.is_zero && !b_class.is_subnorm
+                             && !b_class.is_inf && !b_class.is_snan
+                             && !b_class.is_qnan;
+      end
+    end
+
+    // CLZ for subnormals
+    if (fmt_d_q)
+      b_class.clz = clz53({1'b0, b_class.sig});
+    else
+      b_class.clz = clz53({1'b0, b_class.sig[51:29], 29'b0});
+  end
+
+  // -----------------------------------------------------------------------
+  // Specials short-circuit (combinational, used in UNPACK)
+  // -----------------------------------------------------------------------
+  logic        is_special;
+  logic [63:0] special_result;
+  logic [4:0]  special_fflags;
+
+  // Canonical bit patterns for double precision
+  localparam logic [63:0] D_QNAN  = 64'h7FF8_0000_0000_0000;
+  localparam logic [63:0] D_PINF  = 64'h7FF0_0000_0000_0000;
+  localparam logic [63:0] D_NINF  = 64'hFFF0_0000_0000_0000;
+  localparam logic [63:0] D_PZERO = 64'h0000_0000_0000_0000;
+  localparam logic [63:0] D_NZERO = 64'h8000_0000_0000_0000;
+
+  // Canonical bit patterns for single precision (NaN-boxed to 64 bits)
+  localparam logic [63:0] S_QNAN  = 64'hFFFF_FFFF_7FC0_0000;
+  localparam logic [63:0] S_PINF  = 64'hFFFF_FFFF_7F80_0000;
+  localparam logic [63:0] S_NINF  = 64'hFFFF_FFFF_FF80_0000;
+  localparam logic [63:0] S_PZERO = 64'hFFFF_FFFF_0000_0000;
+  localparam logic [63:0] S_NZERO = 64'hFFFF_FFFF_8000_0000;
+
+  // Flag bits
+  localparam logic [4:0] FL_NV = 5'b10000;
+  localparam logic [4:0] FL_DZ = 5'b01000;
+
+  // Specials helper signals
+  logic        sp_result_sign;
+  logic [63:0] sp_qnan, sp_pinf, sp_ninf, sp_pzero, sp_nzero;
+  logic [63:0] sp_signed_inf, sp_signed_zero;
+  logic        sp_a_nan, sp_b_nan, sp_any_snan, sp_any_nan;
+
+  always_comb begin : proc_specials
+    is_special     = 1'b0;
+    special_result = '0;
+    special_fflags = '0;
+
+    // Result sign for FDIV: sign_a XOR sign_b; for FSQRT: sign_a
+    sp_result_sign = (op_q == FP_FDIV) ? (a_class.sign ^ b_class.sign)
+                                       : a_class.sign;
+
+    // Helper: select pattern based on format and sign
+    sp_qnan  = fmt_d_q ? D_QNAN  : S_QNAN;
+    sp_pinf  = fmt_d_q ? D_PINF  : S_PINF;
+    sp_ninf  = fmt_d_q ? D_NINF  : S_NINF;
+    sp_pzero = fmt_d_q ? D_PZERO : S_PZERO;
+    sp_nzero = fmt_d_q ? D_NZERO : S_NZERO;
+    sp_signed_inf  = sp_result_sign ? sp_ninf  : sp_pinf;
+    sp_signed_zero = sp_result_sign ? sp_nzero : sp_pzero;
+
+    // Any NaN input (sNaN or qNaN in either operand)
+    sp_a_nan    = a_class.is_snan || a_class.is_qnan;
+    sp_b_nan    = (op_q == FP_FDIV) && (b_class.is_snan || b_class.is_qnan);
+    sp_any_snan = a_class.is_snan
+                  || ((op_q == FP_FDIV) && b_class.is_snan);
+    sp_any_nan  = sp_a_nan || sp_b_nan;
+
+    if (op_q == FP_FDIV) begin
+      // ---- FDIV specials ----
+      if (sp_any_snan) begin
+        // Any sNaN input -> qNaN, NV
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = FL_NV;
+      end else if (sp_any_nan) begin
+        // Any qNaN input -> qNaN, no flags
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = '0;
+      end else if (a_class.is_zero && b_class.is_zero) begin
+        // 0 / 0 -> qNaN, NV
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = FL_NV;
+      end else if (a_class.is_inf && b_class.is_inf) begin
+        // inf / inf -> qNaN, NV
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = FL_NV;
+      end else if (b_class.is_zero) begin
+        // x / 0 (x finite, non-zero) -> signed inf, DZ
+        is_special     = 1'b1;
+        special_result = sp_signed_inf;
+        special_fflags = FL_DZ;
+      end else if (a_class.is_zero) begin
+        // 0 / x (x finite, non-zero) -> signed zero
+        is_special     = 1'b1;
+        special_result = sp_signed_zero;
+        special_fflags = '0;
+      end else if (a_class.is_inf) begin
+        // inf / x (x finite) -> signed inf
+        is_special     = 1'b1;
+        special_result = sp_signed_inf;
+        special_fflags = '0;
+      end else if (b_class.is_inf) begin
+        // x / inf (x finite) -> signed zero
+        is_special     = 1'b1;
+        special_result = sp_signed_zero;
+        special_fflags = '0;
+      end
+    end else begin
+      // ---- FSQRT specials ----
+      if (a_class.is_snan) begin
+        // sNaN -> qNaN, NV
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = FL_NV;
+      end else if (a_class.is_qnan) begin
+        // qNaN -> qNaN
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = '0;
+      end else if (a_class.is_zero) begin
+        // +0 -> +0, -0 -> -0
+        is_special     = 1'b1;
+        special_result = a_class.sign ? sp_nzero : sp_pzero;
+        special_fflags = '0;
+      end else if (a_class.is_inf && !a_class.sign) begin
+        // +inf -> +inf
+        is_special     = 1'b1;
+        special_result = sp_pinf;
+        special_fflags = '0;
+      end else if (a_class.sign) begin
+        // Negative (including -inf, -normal, -subnorm) -> qNaN, NV
+        is_special     = 1'b1;
+        special_result = sp_qnan;
+        special_fflags = FL_NV;
+      end
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Normalization logic (combinational, used in UNPACK -> ITER transition)
+  // -----------------------------------------------------------------------
+  logic [52:0]       a_norm, b_norm;      // fdiv normalized significands
+  logic [53:0]       a_sqrt;              // fsqrt normalized significand
+  logic signed [12:0] result_exp_comb;    // intermediate result exponent
+  logic              result_sign_comb;
+  logic signed [12:0] a_true_exp, b_true_exp;
+  logic signed [12:0] bias;
+
+  always_comb begin : proc_normalize
+    a_norm     = '0;
+    b_norm     = '0;
+    a_sqrt     = '0;
+    result_exp_comb = '0;
+    result_sign_comb = '0;
+    a_true_exp = '0;
+    b_true_exp = '0;
+
+    bias = fmt_d_q ? 13'sd1023 : 13'sd127;
+
+    // Result sign: FDIV = sign_a ^ sign_b, FSQRT = 0 (negative caught
+    // as special)
+    result_sign_comb = (op_q == FP_FDIV) ? (a_class.sign ^ b_class.sign)
+                                         : 1'b0;
+
+    // --- Operand A normalization ---
+    if (a_class.is_subnorm) begin
+      // Subnormal: true exponent = 1 - bias - clz
+      // Shift {0, sig} left by clz to place leading 1 at bit 52
+      a_true_exp = 13'sd1 - bias - 13'(a_class.clz);
+      a_norm     = {1'b0, a_class.sig} << a_class.clz;
+    end else begin
+      // Normal: true exponent = biased_exp - bias
+      a_true_exp = 13'(a_class.exp) - bias;
+      a_norm     = {1'b1, a_class.sig};
+    end
+
+    // --- Operand B normalization (FDIV only) ---
+    if (b_class.is_subnorm) begin
+      b_true_exp = 13'sd1 - bias - 13'(b_class.clz);
+      b_norm     = {1'b0, b_class.sig} << b_class.clz;
+    end else begin
+      b_true_exp = 13'(b_class.exp) - bias;
+      b_norm     = {1'b1, b_class.sig};
+    end
+
+    // --- Result exponent computation ---
+    if (op_q == FP_FDIV) begin
+      // FDIV: result_exp (biased) = (a_true - b_true) + bias
+      // Quotient normalization adjustment handled in ROUND.
+      result_exp_comb = a_true_exp - b_true_exp + bias;
+    end else begin
+      // FSQRT: result_exp (biased) = floor(a_true / 2) + bias
+      // If a_true is odd, pre-shift significand left by 1 (handled below).
+      // Use arithmetic right shift for floor division of signed value.
+      // floor(a_true / 2): for negative odd, e.g. -3 => floor(-1.5) = -2
+      // (a_true_exp - (a_true_exp < 0 && a_true_exp[0])) >>> 1
+      // Actually: (a_true_exp >> 1) works for even. For odd negative:
+      // a_true_exp = -3: we want floor(-3/2) = -2. (-3)>>>1 = -2. OK.
+      // a_true_exp = -1: we want floor(-1/2) = -1. (-1)>>>1 = -1. OK.
+      // a_true_exp = 3:  we want floor(3/2) = 1.  3>>>1 = 1. OK.
+      // So arithmetic right shift by 1 gives floor(x/2) for signed x.
+      result_exp_comb = (a_true_exp >>> 1) + bias;
+    end
+
+    // --- FSQRT significand preparation ---
+    // For fsqrt, the core expects a 54-bit input:
+    //   Even exponent: {1'b0, normalized_sig[52:0]} (bit 52 set)
+    //   Odd exponent:  {normalized_sig[52:0], 1'b0} (bit 53 set)
+    // "Odd" means a_true_exp[0] == 1.
+    if (a_true_exp[0]) begin
+      // Odd true exponent: shift left by 1
+      a_sqrt = {a_norm, 1'b0};
+    end else begin
+      // Even true exponent
+      a_sqrt = {1'b0, a_norm};
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // ROUND state — rounding logic (combinational)
+  // -----------------------------------------------------------------------
+  logic [63:0] round_result;
+  logic [4:0]  round_fflags;
+
+  // Post-normalization shift signals
+  logic [55:0]        rnd_shifted;
+  logic signed [12:0] rnd_adj_exp;
+  logic               rnd_sticky_shift;
+
+  // Mantissa extraction
+  logic [51:0] rnd_mantissa;
+  logic        rnd_lsb, rnd_g, rnd_r, rnd_s;
+
+  // Tininess and subnormal shift
+  logic               rnd_tiny;
+  logic [51:0]        rnd_mant_shifted;
+  logic               rnd_new_lsb, rnd_new_g, rnd_new_r, rnd_new_s;
+  logic signed [12:0] rnd_final_exp;
+  logic [6:0]         rnd_shift_amt;
+  logic [55:0]        rnd_combined_d, rnd_shifted_out_d, rnd_combined_shifted_d;
+  logic [26:0]        rnd_combined_s, rnd_shifted_out_s, rnd_combined_shifted_s;
+
+  // Rounding decision
+  logic        rnd_round_up;
+  logic        rnd_inexact;
+
+  // Rounded mantissa
+  logic [52:0] rnd_rounded_mant;
+  logic        rnd_carry;
+
+  // Overflow
+  logic        rnd_overflow;
+  logic        rnd_overflow_to_inf;
+  logic        rnd_to_max;
+
+  // Flags
+  logic        rnd_uf, rnd_of, rnd_nx;
+
+  // FDIV normalization helper
+  logic        rnd_need_shift;
+
+  always_comb begin : proc_round
+    // Defaults
+    round_result   = '0;
+    round_fflags   = '0;
+    rnd_shifted    = '0;
+    rnd_adj_exp    = '0;
+    rnd_sticky_shift = 1'b0;
+    rnd_mantissa   = '0;
+    rnd_lsb        = 1'b0;
+    rnd_g          = 1'b0;
+    rnd_r          = 1'b0;
+    rnd_s          = 1'b0;
+    rnd_tiny       = 1'b0;
+    rnd_mant_shifted = '0;
+    rnd_new_lsb    = 1'b0;
+    rnd_new_g      = 1'b0;
+    rnd_new_r      = 1'b0;
+    rnd_new_s      = 1'b0;
+    rnd_final_exp  = '0;
+    rnd_shift_amt  = '0;
+    rnd_combined_d = '0;
+    rnd_shifted_out_d = '0;
+    rnd_combined_shifted_d = '0;
+    rnd_combined_s = '0;
+    rnd_shifted_out_s = '0;
+    rnd_combined_shifted_s = '0;
+    rnd_round_up   = 1'b0;
+    rnd_inexact    = 1'b0;
+    rnd_rounded_mant = '0;
+    rnd_carry      = 1'b0;
+    rnd_overflow   = 1'b0;
+    rnd_overflow_to_inf = 1'b0;
+    rnd_to_max     = 1'b0;
+    rnd_uf         = 1'b0;
+    rnd_of         = 1'b0;
+    rnd_nx         = 1'b0;
+
+    // ------------------------------------------------------------------
+    // 1. Post-normalization shift (FDIV only: if integer bit is 0)
+    // ------------------------------------------------------------------
+    // For FDIV: the core emits n bits where bit[n-1] is the integer bit.
+    // For D (n=56): integer bit at [55]. For S (n=27): at [26].
+    // If the integer bit is 0, shift left by 1 and decrement exponent.
+    rnd_need_shift = 1'b0;
+    if (op_q == FP_FDIV) begin
+      rnd_need_shift = fmt_d_q ? !raw_q_q[55] : !raw_q_q[26];
+      if (rnd_need_shift) begin
+        rnd_shifted = {raw_q_q[54:0], raw_sticky_q};
+        rnd_adj_exp = result_exp_q - 13'sd1;
+        rnd_sticky_shift = 1'b0;
+      end else begin
+        rnd_shifted = raw_q_q;
+        rnd_adj_exp = result_exp_q;
+        rnd_sticky_shift = raw_sticky_q;
+      end
+    end else begin
+      // FSQRT: MSB always 1, no shift needed
+      rnd_shifted = raw_q_q;
+      rnd_adj_exp = result_exp_q;
+      rnd_sticky_shift = raw_sticky_q;
+    end
+
+    // ------------------------------------------------------------------
+    // 2. Extract mantissa, G, R, S
+    // ------------------------------------------------------------------
+    // After normalization, bit [n-1] = 1 (implicit). With n+1 quotient bits:
+    // D: [55]=implicit, [54:3]=mantissa, [2]=G, [1]=R, [0]=extra→S.
+    // S: [26]=implicit, [25:3]=mantissa, [2]=G, [1]=R, [0]=extra→S.
+    if (fmt_d_q) begin
+      rnd_mantissa = rnd_shifted[54:3];
+      rnd_lsb      = rnd_shifted[3];
+      rnd_g        = rnd_shifted[2];
+      rnd_r        = rnd_shifted[1];
+      rnd_s        = rnd_sticky_shift | rnd_shifted[0];
+    end else begin
+      rnd_mantissa = {29'b0, rnd_shifted[25:3]};
+      rnd_lsb      = rnd_shifted[3];
+      rnd_g        = rnd_shifted[2];
+      rnd_r        = rnd_shifted[1];
+      rnd_s        = rnd_sticky_shift | rnd_shifted[0];
+    end
+
+    // ------------------------------------------------------------------
+    // 3. Tininess detection and subnormal shift (before rounding)
+    // ------------------------------------------------------------------
+    rnd_tiny = (rnd_adj_exp <= 13'sd0);
+
+    if (rnd_tiny) begin
+      // Compute shift in full width to avoid 7-bit truncation overflow.
+      // rnd_adj_exp <= 0 here, so (1 - rnd_adj_exp) >= 1.
+      if (fmt_d_q) begin
+        rnd_shift_amt = ((13'sd1 - rnd_adj_exp) > 13'sd56)
+                        ? 7'd56 : 7'(13'sd1 - rnd_adj_exp);
+      end else begin
+        rnd_shift_amt = ((13'sd1 - rnd_adj_exp) > 13'sd27)
+                        ? 7'd27 : 7'(13'sd1 - rnd_adj_exp);
+      end
+
+      // Include implicit 1 bit in the combined vector for correct
+      // denormalization: D = {1, mantissa[51:0], G, R, extra} = rnd_shifted.
+      if (fmt_d_q) begin
+        rnd_combined_d = rnd_shifted;
+        rnd_shifted_out_d = rnd_combined_d & ((56'd1 << rnd_shift_amt) - 56'd1);
+        rnd_combined_shifted_d = rnd_combined_d >> rnd_shift_amt;
+        rnd_mant_shifted = rnd_combined_shifted_d[54:3];
+        rnd_new_lsb = rnd_combined_shifted_d[3];
+        rnd_new_g   = rnd_combined_shifted_d[2];
+        rnd_new_r   = rnd_combined_shifted_d[1];
+        rnd_new_s   = rnd_s | rnd_combined_shifted_d[0] | (|rnd_shifted_out_d);
+      end else begin
+        rnd_combined_s = rnd_shifted[26:0];
+        rnd_shifted_out_s = rnd_combined_s & ((27'd1 << rnd_shift_amt) - 27'd1);
+        rnd_combined_shifted_s = rnd_combined_s >> rnd_shift_amt;
+        rnd_mant_shifted = {29'b0, rnd_combined_shifted_s[25:3]};
+        rnd_new_lsb = rnd_combined_shifted_s[3];
+        rnd_new_g   = rnd_combined_shifted_s[2];
+        rnd_new_r   = rnd_combined_shifted_s[1];
+        rnd_new_s   = rnd_s | rnd_combined_shifted_s[0] | (|rnd_shifted_out_s);
+      end
+
+      rnd_final_exp = 13'sd0;
+    end else begin
+      rnd_mant_shifted = rnd_mantissa;
+      rnd_new_lsb = rnd_lsb;
+      rnd_new_g   = rnd_g;
+      rnd_new_r   = rnd_r;
+      rnd_new_s   = rnd_s;
+      rnd_final_exp = rnd_adj_exp;
+    end
+
+    // ------------------------------------------------------------------
+    // 4. Rounding decision
+    // ------------------------------------------------------------------
+    rnd_inexact = rnd_new_g | rnd_new_r | rnd_new_s;
+
+    unique case (rm_q)
+      3'b000:  rnd_round_up = rnd_new_g & (rnd_new_lsb | rnd_new_r | rnd_new_s);
+      3'b001:  rnd_round_up = 1'b0;
+      3'b010:  rnd_round_up = result_sign_q & rnd_inexact;
+      3'b011:  rnd_round_up = ~result_sign_q & rnd_inexact;
+      3'b100:  rnd_round_up = rnd_new_g;
+      default: rnd_round_up = 1'b0;
+    endcase
+
+    // ------------------------------------------------------------------
+    // 5. Add rounding increment
+    // ------------------------------------------------------------------
+    if (fmt_d_q)
+      rnd_rounded_mant = {1'b0, rnd_mant_shifted} + {52'b0, rnd_round_up};
+    else
+      rnd_rounded_mant = {30'b0, rnd_mant_shifted[22:0]} + {52'b0, rnd_round_up};
+
+    rnd_carry = fmt_d_q ? rnd_rounded_mant[52] : rnd_rounded_mant[23];
+
+    if (rnd_carry) begin
+      rnd_final_exp = rnd_final_exp + 13'sd1;
+      rnd_rounded_mant = '0;
+    end
+
+    // ------------------------------------------------------------------
+    // 6. Overflow detection
+    // ------------------------------------------------------------------
+    rnd_overflow = fmt_d_q ? (rnd_final_exp >= 13'sd2047)
+                           : (rnd_final_exp >= 13'sd255);
+
+    // Overflow rounding: RTZ or directed toward zero -> max finite
+    rnd_to_max = 1'b0;
+    if (rnd_overflow) begin
+      unique case (rm_q)
+        3'b001:  rnd_to_max = 1'b1;
+        3'b010:  rnd_to_max = ~result_sign_q;
+        3'b011:  rnd_to_max = result_sign_q;
+        default: rnd_to_max = 1'b0;
+      endcase
+    end
+    rnd_overflow_to_inf = rnd_overflow & ~rnd_to_max;
+
+    // ------------------------------------------------------------------
+    // 7. Flag generation
+    // ------------------------------------------------------------------
+    rnd_nx = rnd_inexact | rnd_overflow;
+    rnd_uf = rnd_tiny & rnd_inexact;
+    rnd_of = rnd_overflow;
+
+    round_fflags = {1'b0, 1'b0, rnd_of, rnd_uf, rnd_nx};
+
+    // ------------------------------------------------------------------
+    // 8. Pack result
+    // ------------------------------------------------------------------
+    if (rnd_overflow) begin
+      if (rnd_overflow_to_inf) begin
+        if (fmt_d_q)
+          round_result = {result_sign_q, 11'h7FF, 52'b0};
+        else
+          round_result = {32'hFFFF_FFFF, result_sign_q, 8'hFF, 23'b0};
+      end else begin
+        if (fmt_d_q)
+          round_result = {result_sign_q, 11'h7FE, {52{1'b1}}};
+        else
+          round_result = {32'hFFFF_FFFF, result_sign_q, 8'hFE, {23{1'b1}}};
+      end
+    end else begin
+      if (fmt_d_q)
+        round_result = {result_sign_q, rnd_final_exp[10:0],
+                        rnd_rounded_mant[51:0]};
+      else
+        round_result = {32'hFFFF_FFFF, result_sign_q, rnd_final_exp[7:0],
+                        rnd_rounded_mant[22:0]};
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Result / fflags registers
+  // -----------------------------------------------------------------------
+  logic [63:0] result_q;
+  logic [4:0]  fflags_q;
+
+  // -----------------------------------------------------------------------
+  // Core instantiation
+  // -----------------------------------------------------------------------
+  logic        core_start;
+  logic        core_done_div, core_done_sqrt;
+  logic [55:0] q_div, q_sqrt;
+  logic        rem_nz_div, rem_nz_sqrt;
+
+  kronos_fpu_fdiv_core u_fdiv (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+    .flush_i  (flush_i),
+    .start_i  (core_start & (op_q == FP_FDIV)),
+    .fmt_d_i  (fmt_d_q),
+    .a_i      (a_norm_q),
+    .b_i      (b_norm_q),
+    .done_o   (core_done_div),
+    .quot_o   (q_div),
+    .rem_nz_o (rem_nz_div)
+  );
+
+  kronos_fpu_fsqrt_core u_fsqrt (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+    .flush_i  (flush_i),
+    .start_i  (core_start & (op_q == FP_FSQRT)),
+    .fmt_d_i  (fmt_d_q),
+    .a_i      (a_sqrt_q),
+    .done_o   (core_done_sqrt),
+    .quot_o   (q_sqrt),
+    .rem_nz_o (rem_nz_sqrt)
+  );
+
+  // Mux core outputs based on operation
+  logic [55:0] raw_q;
+  logic        raw_sticky;
+  logic        core_done;
+
+  assign raw_q      = (op_q == FP_FDIV) ? q_div      : q_sqrt;
+  assign raw_sticky = (op_q == FP_FDIV) ? rem_nz_div : rem_nz_sqrt;
+  assign core_done  = (op_q == FP_FDIV) ? core_done_div : core_done_sqrt;
+
+  // core_start: delayed by one cycle from UNPACK -> ITER so that
+  // a_norm_q / b_norm_q / a_sqrt_q are already latched when the core
+  // samples start_i.  High for exactly one clock in the first ITER cycle.
+  logic core_start_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)        core_start_q <= 1'b0;
+    else if (flush_i)   core_start_q <= 1'b0;
+    else                core_start_q <= (state_q == UNPACK) && !is_special;
+  end
+  assign core_start = core_start_q;
+
+  // -----------------------------------------------------------------------
+  // FSM next-state logic
+  // -----------------------------------------------------------------------
+  always_comb begin : proc_fsm_next
+    state_d = state_q;
+    unique case (state_q)
+      IDLE:   if (in_valid_i) state_d = UNPACK;
+      UNPACK: state_d = is_special ? PACK : ITER;
+      ITER:   if (core_done) state_d = ROUND;
+      ROUND:  state_d = PACK;    // placeholder: one cycle
+      PACK:   state_d = IDLE;
+      default: state_d = IDLE;
+    endcase
+  end
+
+  // -----------------------------------------------------------------------
+  // FSM state register
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_fsm_state
+    if (!rst_ni)
+      state_q <= IDLE;
+    else if (flush_i)
+      state_q <= IDLE;
+    else
+      state_q <= state_d;
+  end
+
+  // -----------------------------------------------------------------------
+  // Input latch (IDLE -> UNPACK transition)
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_input_latch
+    if (!rst_ni) begin
+      op_q    <= fp_op_e'('0);
+      fmt_d_q <= 1'b0;
+      rm_q    <= 3'b0;
+      tag_q   <= '0;
+      a_raw_q <= '0;
+      b_raw_q <= '0;
+    end else if (state_q == IDLE && in_valid_i) begin
+      op_q    <= op_i;
+      fmt_d_q <= fmt_d_i;
+      rm_q    <= rm_i;
+      tag_q   <= tag_i;
+      a_raw_q <= a_i;
+      b_raw_q <= b_i;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Classify latch (UNPACK -> ITER transition)
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_class_latch
+    if (!rst_ni) begin
+      a_class_q <= '0;
+      b_class_q <= '0;
+    end else if (state_q == UNPACK) begin
+      a_class_q <= a_class;
+      b_class_q <= b_class;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Normalization latch (UNPACK -> ITER transition, non-special path)
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_norm_latch
+    if (!rst_ni) begin
+      a_norm_q      <= '0;
+      b_norm_q      <= '0;
+      a_sqrt_q      <= '0;
+      result_sign_q <= 1'b0;
+      result_exp_q  <= '0;
+    end else if (state_q == UNPACK && !is_special) begin
+      a_norm_q      <= a_norm;
+      b_norm_q      <= b_norm;
+      a_sqrt_q      <= a_sqrt;
+      result_sign_q <= result_sign_comb;
+      result_exp_q  <= result_exp_comb;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Raw quotient latch (on core_done)
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_raw_latch
+    if (!rst_ni) begin
+      raw_q_q      <= '0;
+      raw_sticky_q <= 1'b0;
+    end else if (core_done) begin
+      raw_q_q      <= raw_q;
+      raw_sticky_q <= raw_sticky;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Result / fflags latch
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_result_latch
+    if (!rst_ni) begin
+      result_q <= '0;
+      fflags_q <= '0;
+    end else if (state_q == UNPACK && is_special) begin
+      result_q <= special_result;
+      fflags_q <= special_fflags;
+    end else if (state_q == ROUND) begin
+      result_q <= round_result;
+      fflags_q <= round_fflags;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // Output assignments
+  // -----------------------------------------------------------------------
+  assign busy_o      = (state_q != IDLE);
+  assign out_valid_o = (state_q == PACK);
+  assign result_o    = result_q;
+  assign fflags_o    = fflags_q;
+  assign tag_o       = tag_q;
+
+  // Late-reservation: request scoreboard slot one cycle before writeback.
+  // ROUND state lasts one cycle, then transitions to PACK (out_valid).
+  // Latency=1 means the scoreboard reserves the slot that fires next cycle.
+  assign sb_late_req_o     = (state_q == ROUND);
+  assign sb_late_fp_dest_o = tag_q.fp_dest;
+
+endmodule

--- a/rtl/stage5/fpu/kronos_fpu_scoreboard.sv
+++ b/rtl/stage5/fpu/kronos_fpu_scoreboard.sv
@@ -14,7 +14,12 @@ module kronos_fpu_scoreboard #(
   input  logic       int_dest_i,  // instruction writes integer regfile
   input  logic [2:0] latency_i,   // 1..DEPTH
   output logic       grant_comb_o, // combinational grant (for dispatch gating)
-  output logic       grant_o       // registered grant (stable post-posedge)
+  output logic       grant_o,      // registered grant (stable post-posedge)
+  // Late probe — iterative unit reserves a writeback slot at ROUND time
+  input  logic       late_req_i,
+  input  logic       late_fp_dest_i,
+  input  logic [2:0] late_latency_i,
+  output logic       late_grant_comb_o
 );
   typedef struct packed {
     logic fp;
@@ -41,6 +46,11 @@ module kronos_fpu_scoreboard #(
   // Target slot fields, selected by latency.
   logic target_fp, target_intr;
   logic collision;
+
+  // Late-probe signals.
+  logic late_target_fp;
+  logic late_collision;
+  logic late_grant_comb;
 
   always_comb begin
     // Select the target slot for the incoming dispatch (latency L → slot L-1).
@@ -84,6 +94,34 @@ module kronos_fpu_scoreboard #(
         default: ; // latency out of range, do nothing
       endcase
     end
+
+    // Late probe: iterative unit reserves a writeback slot at ROUND time.
+    // Collision check is FP-only (iterative unit always writes FP regfile).
+    late_target_fp = 1'b0;
+    unique case (late_latency_i)
+      3'd1:    late_target_fp = slots_q[0].fp;
+      3'd2:    late_target_fp = slots_q[1].fp;
+      3'd3:    late_target_fp = slots_q[2].fp;
+      3'd4:    late_target_fp = slots_q[3].fp;
+      3'd5:    late_target_fp = slots_q[4].fp;
+      default: late_target_fp = 1'b0;
+    endcase
+
+    late_collision  = late_req_i & (late_fp_dest_i & late_target_fp);
+    late_grant_comb = late_req_i & ~late_collision;
+
+    // On late grant, OR-in the reservation (mutually exclusive with dispatch
+    // at the system level, but structurally OR'd for safety).
+    if (late_grant_comb) begin
+      unique case (late_latency_i)
+        3'd1:    slots_n[0].fp = slots_n[0].fp | late_fp_dest_i;
+        3'd2:    slots_n[1].fp = slots_n[1].fp | late_fp_dest_i;
+        3'd3:    slots_n[2].fp = slots_n[2].fp | late_fp_dest_i;
+        3'd4:    slots_n[3].fp = slots_n[3].fp | late_fp_dest_i;
+        3'd5:    slots_n[4].fp = slots_n[4].fp | late_fp_dest_i;
+        default: ; // latency out of range, do nothing
+      endcase
+    end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -96,7 +134,8 @@ module kronos_fpu_scoreboard #(
     end
   end
 
-  assign grant_comb_o = grant_comb;
-  assign grant_o      = grant_q;
+  assign grant_comb_o      = grant_comb;
+  assign grant_o           = grant_q;
+  assign late_grant_comb_o = late_grant_comb;
 
 endmodule

--- a/rtl/stage5/fpu/kronos_fpu_top.sv
+++ b/rtl/stage5/fpu/kronos_fpu_top.sv
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// FPU dispatch wrapper: routes in_valid_i to one of the five execution units,
+// FPU dispatch wrapper: routes in_valid_i to one of the six execution units,
 // embeds the scoreboard for write-back hazard detection, and mux-reduces the
-// five out_valid/result/fflags/tag buses onto a single shared output bus.
+// six out_valid/result/fflags/tag buses onto a single shared output bus.
 //
 // Latency table (clock cycles from dispatch to out_valid):
 //   FMISC  1  (FSGNJ*, FMIN, FMAX, FCLASS, FEQ, FLT, FLE, FMV.*)
@@ -12,6 +12,7 @@
 //   FADD   4  (FADD, FSUB)
 //   FMUL   4  (FMUL)
 //   FMA    5  (FMADD, FMSUB, FNMADD, FNMSUB)
+//   ITER   variable (FDIV, FSQRT) — late-reservation via scoreboard
 //
 // busy_o is asserted when in_valid_i is high and the scoreboard detects a
 // write-back collision for the incoming operation.  The upstream stage must
@@ -43,7 +44,7 @@ module kronos_fpu_top
   // Dispatch routing: determine unit and latency from op_i
   // ---------------------------------------------------------------------------
   logic [2:0] dispatch_latency;
-  logic       sel_fmisc, sel_fcvt, sel_fadd, sel_fmul, sel_fma;
+  logic       sel_fmisc, sel_fcvt, sel_fadd, sel_fmul, sel_fma, sel_iter;
 
   always_comb begin
     sel_fmisc        = 1'b0;
@@ -51,6 +52,7 @@ module kronos_fpu_top
     sel_fadd         = 1'b0;
     sel_fmul         = 1'b0;
     sel_fma          = 1'b0;
+    sel_iter         = 1'b0;
     dispatch_latency = 3'd0;
 
     unique case (op_i)
@@ -80,6 +82,10 @@ module kronos_fpu_top
         sel_fma          = 1'b1;
         dispatch_latency = 3'd5;
       end
+      FP_FDIV, FP_FSQRT: begin
+        sel_iter         = 1'b1;
+        dispatch_latency = 3'd0;  // not registered at dispatch (late-reservation)
+      end
       default: begin
         // Unknown op: route nowhere, scoreboard will ignore (latency=0)
         sel_fmisc        = 1'b0;
@@ -93,19 +99,28 @@ module kronos_fpu_top
   // ---------------------------------------------------------------------------
   logic grant_comb, grant;
 
+  // Late-probe signals from iterative unit to scoreboard
+  logic iter_late_req, iter_late_fp_dest, iter_late_grant;
+  logic iter_busy;
+
   kronos_fpu_scoreboard #(.DEPTH(5)) u_scoreboard (
-    .clk_i        (clk_i),
-    .rst_ni       (rst_ni),
-    .flush_i      (flush_i),
-    .req_i        (in_valid_i),
-    .fp_dest_i    (tag_i.fp_dest),
-    .int_dest_i   (~tag_i.fp_dest),
-    .latency_i    (dispatch_latency),
-    .grant_comb_o (grant_comb),
-    .grant_o      (grant)
+    .clk_i             (clk_i),
+    .rst_ni            (rst_ni),
+    .flush_i           (flush_i),
+    .req_i             (in_valid_i),
+    .fp_dest_i         (tag_i.fp_dest),
+    .int_dest_i        (~tag_i.fp_dest),
+    .latency_i         (dispatch_latency),
+    .grant_comb_o      (grant_comb),
+    .grant_o           (grant),
+    .late_req_i        (iter_late_req),
+    .late_fp_dest_i    (iter_late_fp_dest),
+    .late_latency_i    (3'd1),
+    .late_grant_comb_o (iter_late_grant)
   );
 
-  assign busy_o = in_valid_i & ~grant_comb;
+  // busy_o: scoreboard collision OR iterative unit busy (can't accept new op)
+  assign busy_o = (in_valid_i & ~grant_comb) | (sel_iter & in_valid_i & iter_busy);
 
   // Gate in_valid to each unit: only the selected unit receives it, and only
   // when the scoreboard grants the dispatch.
@@ -213,13 +228,40 @@ module kronos_fpu_top
     .tag_o      (fma_tag)
   );
 
+  // Iterative unit (FDIV, FSQRT) — variable latency, late-reservation
+  logic        iter_out_valid;
+  logic [63:0] iter_result;
+  logic [4:0]  iter_fflags;
+  fpu_tag_t    iter_tag;
+
+  kronos_fpu_iter u_iter (
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .flush_i         (flush_i),
+    .in_valid_i      (dispatch_ok & sel_iter & ~iter_busy),
+    .op_i            (op_i),
+    .fmt_d_i         (fmt_d_i),
+    .rm_i            (rm_i),
+    .a_i             (a_i),
+    .b_i             (b_i),
+    .tag_i           (tag_i),
+    .busy_o          (iter_busy),
+    .out_valid_o     (iter_out_valid),
+    .result_o        (iter_result),
+    .fflags_o        (iter_fflags),
+    .tag_o           (iter_tag),
+    .sb_late_req_o   (iter_late_req),
+    .sb_late_fp_dest_o(iter_late_fp_dest),
+    .sb_late_grant_i (iter_late_grant)
+  );
+
   // ---------------------------------------------------------------------------
   // Output mux: at most one unit produces out_valid per cycle (scoreboard
   // invariant). Priority encode to form a single output bus.
   // ---------------------------------------------------------------------------
   always_comb begin
     out_valid_o = fmisc_out_valid | fcvt_out_valid | fadd_out_valid
-                | fmul_out_valid  | fma_out_valid;
+                | fmul_out_valid  | fma_out_valid  | iter_out_valid;
     if (fmisc_out_valid) begin
       result_o = fmisc_result;
       fflags_o = fmisc_fflags;
@@ -236,10 +278,14 @@ module kronos_fpu_top
       result_o = fmul_result;
       fflags_o = fmul_fflags;
       tag_o    = fmul_tag;
-    end else begin
+    end else if (fma_out_valid) begin
       result_o = fma_result;
       fflags_o = fma_fflags;
       tag_o    = fma_tag;
+    end else begin
+      result_o = iter_result;
+      fflags_o = iter_fflags;
+      tag_o    = iter_tag;
     end
   end
 

--- a/rtl/stage5/kronos_decode.sv
+++ b/rtl/stage5/kronos_decode.sv
@@ -379,8 +379,18 @@ module kronos_decode
                 illegal = 1'b1;
             end
           end
-          5'b00011: begin  // FDIV — not yet implemented (Stage 5b)
-            illegal = 1'b1;
+          5'b00011: begin  // FDIV.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rs2_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FDIV;
+            begin
+              logic [2:0] rm_raw;
+              rm_raw = instr_i[14:12];
+              decoded_o.rm_resolved = (rm_raw == 3'b111) ? frm_i : rm_raw;
+              if (decoded_o.rm_resolved == 3'b101 || decoded_o.rm_resolved == 3'b110)
+                illegal = 1'b1;
+            end
           end
           5'b00100: begin  // FSGNJ.S/D, FSGNJN.S/D, FSGNJX.S/D
             decoded_o.rs1_fp = 1'b1;
@@ -419,8 +429,19 @@ module kronos_decode
                 illegal = 1'b1;
             end
           end
-          5'b01011: begin  // FSQRT — not yet implemented (Stage 5b)
-            illegal = 1'b1;
+          5'b01011: begin  // FSQRT.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FSQRT;
+            begin
+              logic [2:0] rm_raw;
+              rm_raw = instr_i[14:12];
+              decoded_o.rm_resolved = (rm_raw == 3'b111) ? frm_i : rm_raw;
+              if (decoded_o.rm_resolved == 3'b101 || decoded_o.rm_resolved == 3'b110)
+                illegal = 1'b1;
+            end
+            // rs2 must be 00000 for FSQRT
+            if (instr_i[24:20] != 5'b00000) illegal = 1'b1;
           end
           5'b10100: begin  // FEQ/FLT/FLE (result to integer rd)
             decoded_o.rs1_fp = 1'b1;

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -5,7 +5,8 @@ SW_DIR_S1 := ../sw/stage1
 SW_DIR_S2 := ../sw/stage2
 SW_DIR_S3 := ../sw/stage3
 SW_DIR_S4 := ../sw/stage4
-SW_DIR_S5 := ../sw/stage5
+SW_DIR_S5  := ../sw/stage5
+SW_DIR_S5B := ../sw/stage5b
 OBJ_DIR   := obj_dir
 
 VERILATOR := verilator
@@ -108,9 +109,11 @@ SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
         sim-pkg-fp sim-regfile-fp sim-hf-smoke sim-sf-smoke \
         sim-csr-fp sim-fpu-scoreboard \
         sim-decode-fp sim-fpu-fmisc sim-fpu-fcvt sim-fpu-fadd sim-fpu-fmul \
-        sim-fpu-fma sim-fpu-top \
+        sim-fpu-fma sim-fpu-fdiv-core sim-fpu-fsqrt-core sim-fpu-iter-skeleton sim-fpu-top \
+        sim-fpu-top-iter \
         sim-fpu-fmisc-cov sim-fpu-fcvt-cov sim-fpu-fadd-cov sim-fpu-fmul-cov \
-        sim-fpu-fma-cov coverage
+        sim-fpu-fma-cov coverage \
+        sim-s5b
 
 .DEFAULT_GOAL := help
 
@@ -551,6 +554,9 @@ SV_FILES_S5 := $(AXI_PKG_SV) \
                $(RTL_DIR)/stage5/fpu/kronos_fpu_fadd.sv \
                $(RTL_DIR)/stage5/fpu/kronos_fpu_fmul.sv \
                $(RTL_DIR)/stage5/fpu/kronos_fpu_fma.sv \
+               $(RTL_DIR)/stage5/fpu/kronos_fpu_fdiv_core.sv \
+               $(RTL_DIR)/stage5/fpu/kronos_fpu_fsqrt_core.sv \
+               $(RTL_DIR)/stage5/fpu/kronos_fpu_iter.sv \
                $(RTL_DIR)/stage5/fpu/kronos_fpu_top.sv
 
 TOP_S5     := sim_top
@@ -615,6 +621,33 @@ sim-s5: build-s5
 	[ $$fail -eq 0 ]
 	$(MAKE) sim-core-fp-basic
 	$(MAKE) sim-core-fp-forwarding
+
+# ── Stage 5b regression (FDIV/FSQRT assembly tests) ──────────────────────────
+sim-s5b: build-s5
+	@$(MAKE) -C $(SW_DIR_S5B) all > /dev/null 2>&1; \
+	tmpdir=$$(mktemp -d); pids=""; \
+	for hex in $(SW_DIR_S5B)/build/*.hex; do \
+	  [ -f "$$hex" ] || continue; \
+	  name=$$(basename $$hex .hex); \
+	  { out=$$(./$(SIM_BIN_S5) $$hex 2>&1); \
+	    x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	    echo "$$hex $$x10"; } > $$tmpdir/$$name & \
+	  pids="$$pids $$!"; \
+	done; \
+	wait $$pids; \
+	pass=0; fail=0; \
+	for f in $$tmpdir/*; do \
+	  [ -f "$$f" ] || continue; \
+	  read hex x10 < $$f; \
+	  if [ "$$x10" = "0" ]; then \
+	    pass=$$((pass+1)); \
+	  else \
+	    echo "FAIL: $$hex (x10=$$x10)"; fail=$$((fail+1)); \
+	  fi; \
+	done; \
+	rm -rf $$tmpdir; \
+	echo "Stage 5b assembly: $$pass passed, $$fail failed"; \
+	[ $$fail -eq 0 ] || [ $$pass -eq 0 -a $$fail -eq 0 ]
 
 # ── riscv-arch-test F and D compliance (requires separate clone) ───────────
 # Clone: git clone https://github.com/riscv-non-isa/riscv-arch-test /home/popes/riscv-arch-test
@@ -740,6 +773,51 @@ sim-fpu-fma: $(SF_LIB)
 	  -CFLAGS "$(CFLAGS) $(SF_INCS)" -LDFLAGS "$(SF_LIB)"
 	$(OBJ_DIR)/fpu_fma/Vtb_fpu_fma
 
+TB_FPU_FDIV_CORE_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
+                          $(RTL_DIR)/stage5/fpu/kronos_fpu_fdiv_core.sv \
+                          $(TB_DIR)/stage5/tb_fpu_fdiv_core.sv
+sim-fpu-fdiv-core:
+	cd ../tb/stage5/ref && python3 gen_fdiv_vectors.py
+	cp ../tb/stage5/ref/fdiv_vectors.hex .
+	$(VERILATOR) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-lint -Wno-style \
+	  -Mdir $(OBJ_DIR)/fpu_fdiv_core --top-module tb_fpu_fdiv_core \
+	  $(TB_FPU_FDIV_CORE_FILES)
+	$(OBJ_DIR)/fpu_fdiv_core/Vtb_fpu_fdiv_core
+
+TB_FPU_FSQRT_CORE_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
+                           $(RTL_DIR)/stage5/fpu/kronos_fpu_fsqrt_core.sv \
+                           $(TB_DIR)/stage5/tb_fpu_fsqrt_core.sv
+sim-fpu-fsqrt-core:
+	cd ../tb/stage5/ref && python3 gen_fsqrt_vectors.py
+	cp ../tb/stage5/ref/fsqrt_vectors.hex .
+	$(VERILATOR) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-lint -Wno-style \
+	  -Mdir $(OBJ_DIR)/fpu_fsqrt_core --top-module tb_fpu_fsqrt_core \
+	  $(TB_FPU_FSQRT_CORE_FILES)
+	$(OBJ_DIR)/fpu_fsqrt_core/Vtb_fpu_fsqrt_core
+
+TB_FPU_ITER_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
+                     $(RTL_DIR)/stage5/fpu/kronos_fpu_fdiv_core.sv \
+                     $(RTL_DIR)/stage5/fpu/kronos_fpu_fsqrt_core.sv \
+                     $(RTL_DIR)/stage5/fpu/kronos_fpu_iter.sv \
+                     $(TB_DIR)/stage5/tb_fpu_iter.sv
+sim-fpu-iter-skeleton:
+	$(VERILATOR) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-lint -Wno-style \
+	  -Mdir $(OBJ_DIR)/fpu_iter --top-module tb_fpu_iter \
+	  $(TB_FPU_ITER_FILES)
+	$(OBJ_DIR)/fpu_iter/Vtb_fpu_iter
+
+TB_FPU_ITER_SF_FILES := $(FPU_COMMON_FILES) \
+                        $(RTL_DIR)/stage5/fpu/kronos_fpu_fdiv_core.sv \
+                        $(RTL_DIR)/stage5/fpu/kronos_fpu_fsqrt_core.sv \
+                        $(RTL_DIR)/stage5/fpu/kronos_fpu_iter.sv \
+                        $(TB_DIR)/stage5/tb_fpu_iter.sv
+sim-fpu-iter: $(SF_LIB)
+	$(VERILATOR) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-lint -Wno-style \
+	  -Mdir $(OBJ_DIR)/fpu_iter_sf --top-module tb_fpu_iter \
+	  $(TB_FPU_ITER_SF_FILES) $(SF_DPI_SRC) \
+	  -CFLAGS "$(CFLAGS) $(SF_INCS)" -LDFLAGS "$(SF_LIB)"
+	$(OBJ_DIR)/fpu_iter_sf/Vtb_fpu_iter
+
 TB_LSU_FP_FILES := $(AXI_PKG_SV) \
                    $(RTL_DIR)/kronos_pkg.sv \
                    $(RTL_DIR)/stage5/kronos_lsu.sv \
@@ -758,6 +836,9 @@ TB_FPU_TOP_FILES := $(FPU_COMMON_FILES) \
                     $(RTL_DIR)/stage5/fpu/kronos_fpu_fadd.sv \
                     $(RTL_DIR)/stage5/fpu/kronos_fpu_fmul.sv \
                     $(RTL_DIR)/stage5/fpu/kronos_fpu_fma.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fdiv_core.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fsqrt_core.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_iter.sv \
                     $(RTL_DIR)/stage5/fpu/kronos_fpu_top.sv \
                     $(TB_DIR)/stage5/tb_fpu_top.sv
 sim-fpu-top: $(SF_LIB)
@@ -766,6 +847,25 @@ sim-fpu-top: $(SF_LIB)
 	  $(HARDFLOAT_V) $(TB_FPU_TOP_FILES) $(SF_DPI_SRC) \
 	  -CFLAGS "$(CFLAGS) $(SF_INCS)" -LDFLAGS "$(SF_LIB)"
 	$(OBJ_DIR)/fpu_top/Vtb_fpu_top
+
+TB_FPU_TOP_ITER_FILES := $(FPU_COMMON_FILES) \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_scoreboard.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fmisc.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fcvt.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fadd.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fmul.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fma.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fdiv_core.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_fsqrt_core.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_iter.sv \
+                    $(RTL_DIR)/stage5/fpu/kronos_fpu_top.sv \
+                    $(TB_DIR)/stage5/tb_fpu_top_iter.sv
+sim-fpu-top-iter: $(SF_LIB)
+	$(VERILATOR) --binary $(AXI_FLAGS) -Wno-lint -Wno-style --Wno-TIMESCALEMOD \
+	  -Mdir $(OBJ_DIR)/fpu_top_iter --top-module tb_fpu_top_iter \
+	  $(HARDFLOAT_V) $(TB_FPU_TOP_ITER_FILES) $(SF_DPI_SRC) \
+	  -CFLAGS "$(CFLAGS) $(SF_INCS)" -LDFLAGS "$(SF_LIB)"
+	$(OBJ_DIR)/fpu_top_iter/Vtb_fpu_top_iter
 
 # ── Functional coverage (line coverage gate ≥95%) ─────────────────────────
 COV_FLAGS := --coverage-line

--- a/sw/stage5b/Makefile
+++ b/sw/stage5b/Makefile
@@ -1,0 +1,26 @@
+TOOLCHAIN := riscv64-unknown-elf
+CC        := $(TOOLCHAIN)-gcc
+OBJCOPY   := $(TOOLCHAIN)-objcopy
+OBJDUMP   := $(TOOLCHAIN)-objdump
+
+ARCH   := rv64imafdc_zicsr
+ABI    := lp64
+CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
+
+TESTS  := test_fdiv_basic test_fsqrt_basic test_fdiv_rounding test_fsqrt_rounding \
+          test_fdiv_exceptions test_fsqrt_exceptions test_fdiv_subnormal \
+          test_fsqrt_subnormal test_fdiv_nan_box test_fdiv_stall
+
+BUILD_DIR := build
+
+all: $(TESTS:%=$(BUILD_DIR)/%.hex)
+
+$(BUILD_DIR)/%.hex: %.S ../stage0/common.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $(@:.hex=.elf) $^
+	$(OBJCOPY) -O ihex $(@:.hex=.elf) $@
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/sw/stage5b/test_fdiv_basic.S
+++ b/sw/stage5b/test_fdiv_basic.S
@@ -1,0 +1,82 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic FDIV.S, FDIV.D with exact results (no rounding needed).
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FDIV.S  6.0f / 2.0f = 3.0f
+    //   6.0f = 0x40C00000
+    //   2.0f = 0x40000000
+    //   3.0f = 0x40400000
+    // ------------------------------------------------------------------
+    li      t0, 0x40C00000
+    fmv.w.x ft0, t0                 // ft0 = 6.0f
+    li      t0, 0x40000000
+    fmv.w.x ft1, t0                 // ft1 = 2.0f
+    fdiv.s  ft2, ft0, ft1           // ft2 = 3.0f
+    fmv.x.w t1, ft2
+    li      t2, 0x40400000
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+
+    // ------------------------------------------------------------------
+    // Test 2: FDIV.S  1.0f / 4.0f = 0.25f
+    //   1.0f = 0x3F800000
+    //   4.0f = 0x40800000
+    //   0.25f = 0x3E800000
+    // ------------------------------------------------------------------
+    li      t0, 0x3F800000
+    fmv.w.x ft0, t0                 // ft0 = 1.0f
+    li      t0, 0x40800000
+    fmv.w.x ft1, t0                 // ft1 = 4.0f
+    fdiv.s  ft2, ft0, ft1           // ft2 = 0.25f
+    fmv.x.w t1, ft2
+    li      t2, 0x3E800000
+    beq     t1, t2, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 3: FDIV.D  6.0d / 2.0d = 3.0d
+    //   6.0d = 0x4018000000000000
+    //   2.0d = 0x4000000000000000
+    //   3.0d = 0x4008000000000000
+    // ------------------------------------------------------------------
+    li      t0, 0x4018000000000000
+    fmv.d.x ft0, t0                 // ft0 = 6.0d
+    li      t0, 0x4000000000000000
+    fmv.d.x ft1, t0                 // ft1 = 2.0d
+    fdiv.d  ft2, ft0, ft1           // ft2 = 3.0d
+    fmv.x.d t1, ft2
+    li      t2, 0x4008000000000000
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+
+    // ------------------------------------------------------------------
+    // Test 4: FDIV.D  1.0d / 8.0d = 0.125d
+    //   1.0d = 0x3FF0000000000000
+    //   8.0d = 0x4020000000000000
+    //   0.125d = 0x3FC0000000000000
+    // ------------------------------------------------------------------
+    li      t0, 0x3FF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = 1.0d
+    li      t0, 0x4020000000000000
+    fmv.d.x ft1, t0                 // ft1 = 8.0d
+    fdiv.d  ft2, ft0, ft1           // ft2 = 0.125d
+    fmv.x.d t1, ft2
+    li      t2, 0x3FC0000000000000
+    beq     t1, t2, 4f
+    addi    a0, a0, 1
+4:
+
+    ret

--- a/sw/stage5b/test_fdiv_exceptions.S
+++ b/sw/stage5b/test_fdiv_exceptions.S
@@ -1,0 +1,134 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FDIV exception / FFLAGS tests.
+// Checks result and accrued exception flags after each operation.
+// FFLAGS (CSR 0x001): NV=0x10, DZ=0x08, OF=0x04, UF=0x02, NX=0x01.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FDIV.D  1.0d / 0.0d = +inf, fflags = DZ (0x08)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero       // clear fflags
+    li      t0, 0x3FF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = 1.0d
+    li      t0, 0x0000000000000000
+    fmv.d.x ft1, t0                 // ft1 = 0.0d
+    fdiv.d  ft2, ft0, ft1
+    fmv.x.d t1, ft2
+    li      t2, 0x7FF0000000000000  // +inf
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+    csrrs   t3, 0x001, zero         // read fflags
+    li      t4, 0x08                // DZ
+    beq     t3, t4, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 2: FDIV.D  0.0d / 0.0d = canonical NaN, fflags = NV (0x10)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x0000000000000000
+    fmv.d.x ft0, t0                 // ft0 = 0.0d
+    fmv.d.x ft1, t0                 // ft1 = 0.0d
+    fdiv.d  ft2, ft0, ft1
+    fmv.x.d t1, ft2
+    li      t2, 0x7FF8000000000000  // canonical NaN
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 4f
+    addi    a0, a0, 1
+4:
+
+    // ------------------------------------------------------------------
+    // Test 3: FDIV.D  inf / inf = canonical NaN, fflags = NV (0x10)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x7FF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = +inf
+    fmv.d.x ft1, t0                 // ft1 = +inf
+    fdiv.d  ft2, ft0, ft1
+    fmv.x.d t1, ft2
+    li      t2, 0x7FF8000000000000  // canonical NaN
+    beq     t1, t2, 5f
+    addi    a0, a0, 1
+5:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 6f
+    addi    a0, a0, 1
+6:
+
+    // ------------------------------------------------------------------
+    // Test 4: FDIV.D  1.0d / sNaN = canonical NaN, fflags = NV (0x10)
+    //   sNaN double: 0x7FF0000000000001
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x3FF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = 1.0d
+    li      t0, 0x7FF0000000000001
+    fmv.d.x ft1, t0                 // ft1 = sNaN
+    fdiv.d  ft2, ft0, ft1
+    fmv.x.d t1, ft2
+    li      t2, 0x7FF8000000000000  // canonical NaN
+    beq     t1, t2, 7f
+    addi    a0, a0, 1
+7:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 8f
+    addi    a0, a0, 1
+8:
+
+    // ------------------------------------------------------------------
+    // Test 5: FDIV.S  1.0f / 0.0f = +inf, fflags = DZ (0x08)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x3F800000
+    fmv.w.x ft0, t0                 // ft0 = 1.0f
+    li      t0, 0x00000000
+    fmv.w.x ft1, t0                 // ft1 = 0.0f
+    fdiv.s  ft2, ft0, ft1
+    fmv.x.w t1, ft2
+    li      t2, 0x7F800000          // +inf (single)
+    beq     t1, t2, 9f
+    addi    a0, a0, 1
+9:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x08                // DZ
+    beq     t3, t4, 10f
+    addi    a0, a0, 1
+10:
+
+    // ------------------------------------------------------------------
+    // Test 6: FDIV.S  0.0f / 0.0f = canonical NaN, fflags = NV (0x10)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x00000000
+    fmv.w.x ft0, t0                 // ft0 = 0.0f
+    fmv.w.x ft1, t0                 // ft1 = 0.0f
+    fdiv.s  ft2, ft0, ft1
+    fmv.x.w t1, ft2
+    li      t2, 0x7FC00000          // canonical NaN (single)
+    beq     t1, t2, 11f
+    addi    a0, a0, 1
+11:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 12f
+    addi    a0, a0, 1
+12:
+
+    ret

--- a/sw/stage5b/test_fdiv_nan_box.S
+++ b/sw/stage5b/test_fdiv_nan_box.S
@@ -1,0 +1,65 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FDIV.S NaN-boxing test.
+// Verifies that single-precision results are properly NaN-boxed:
+// upper 32 bits of the 64-bit register must be 0xFFFFFFFF.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FDIV.S  6.0f / 2.0f = 3.0f, check NaN-boxing
+    //   6.0f = 0x40C00000
+    //   2.0f = 0x40000000
+    //   3.0f = 0x40400000
+    //   NaN-boxed: 0xFFFFFFFF40400000
+    // ------------------------------------------------------------------
+    li      t0, 0x40C00000
+    fmv.w.x ft0, t0                 // ft0 = 6.0f
+    li      t0, 0x40000000
+    fmv.w.x ft1, t0                 // ft1 = 2.0f
+    fdiv.s  ft2, ft0, ft1           // ft2 = 3.0f
+    fmv.x.d t1, ft2                 // read full 64 bits
+    li      t2, 0xFFFFFFFF40400000  // NaN-boxed 3.0f
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+
+    // ------------------------------------------------------------------
+    // Test 2: FSQRT.S  sqrt(16.0f) = 4.0f, check NaN-boxing
+    //   16.0f = 0x41800000
+    //   4.0f  = 0x40800000
+    //   NaN-boxed: 0xFFFFFFFF40800000
+    // ------------------------------------------------------------------
+    li      t0, 0x41800000
+    fmv.w.x ft0, t0                 // ft0 = 16.0f
+    fsqrt.s ft1, ft0                // ft1 = 4.0f
+    fmv.x.d t1, ft1                 // read full 64 bits
+    li      t2, 0xFFFFFFFF40800000  // NaN-boxed 4.0f
+    beq     t1, t2, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 3: FDIV.S  1.0f / 0.0f = +inf, check NaN-boxing
+    //   +inf single = 0x7F800000
+    //   NaN-boxed: 0xFFFFFFFF7F800000
+    // ------------------------------------------------------------------
+    li      t0, 0x3F800000
+    fmv.w.x ft0, t0                 // ft0 = 1.0f
+    li      t0, 0x00000000
+    fmv.w.x ft1, t0                 // ft1 = 0.0f
+    fdiv.s  ft2, ft0, ft1           // ft2 = +inf
+    fmv.x.d t1, ft2                 // read full 64 bits
+    li      t2, 0xFFFFFFFF7F800000  // NaN-boxed +inf
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+
+    ret

--- a/sw/stage5b/test_fdiv_rounding.S
+++ b/sw/stage5b/test_fdiv_rounding.S
@@ -1,0 +1,129 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FDIV rounding-mode tests using static rounding-mode instruction fields.
+// Tests 1.0d/3.0d and 1.0f/3.0f under all five IEEE 754 rounding modes.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // Load double operands: 1.0d / 3.0d
+    li      t0, 0x3FF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = 1.0d
+    li      t0, 0x4008000000000000
+    fmv.d.x ft1, t0                 // ft1 = 3.0d
+
+    // ------------------------------------------------------------------
+    // Test 1: FDIV.D  1.0d / 3.0d, RNE
+    //   Expected: 0x3FD5555555555555
+    // ------------------------------------------------------------------
+    fdiv.d  ft2, ft0, ft1, rne
+    fmv.x.d t1, ft2
+    li      t2, 0x3FD5555555555555
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+
+    // ------------------------------------------------------------------
+    // Test 2: FDIV.D  1.0d / 3.0d, RTZ
+    //   Expected: 0x3FD5555555555555
+    // ------------------------------------------------------------------
+    fdiv.d  ft2, ft0, ft1, rtz
+    fmv.x.d t1, ft2
+    li      t2, 0x3FD5555555555555
+    beq     t1, t2, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 3: FDIV.D  1.0d / 3.0d, RDN
+    //   Expected: 0x3FD5555555555555
+    // ------------------------------------------------------------------
+    fdiv.d  ft2, ft0, ft1, rdn
+    fmv.x.d t1, ft2
+    li      t2, 0x3FD5555555555555
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+
+    // ------------------------------------------------------------------
+    // Test 4: FDIV.D  1.0d / 3.0d, RUP
+    //   Expected: 0x3FD5555555555556
+    // ------------------------------------------------------------------
+    fdiv.d  ft2, ft0, ft1, rup
+    fmv.x.d t1, ft2
+    li      t2, 0x3FD5555555555556
+    beq     t1, t2, 4f
+    addi    a0, a0, 1
+4:
+
+    // ------------------------------------------------------------------
+    // Test 5: FDIV.D  1.0d / 3.0d, RMM
+    //   Expected: 0x3FD5555555555555
+    // ------------------------------------------------------------------
+    fdiv.d  ft2, ft0, ft1, rmm
+    fmv.x.d t1, ft2
+    li      t2, 0x3FD5555555555555
+    beq     t1, t2, 5f
+    addi    a0, a0, 1
+5:
+
+    // ------------------------------------------------------------------
+    // Test 6: FDIV.D  -1.0d / 3.0d, RDN
+    //   -1.0d = 0xBFF0000000000000
+    //   Expected: 0xBFD5555555555556 (toward -inf rounds away for negative)
+    // ------------------------------------------------------------------
+    li      t0, 0xBFF0000000000000
+    fmv.d.x ft3, t0                 // ft3 = -1.0d
+    fdiv.d  ft2, ft3, ft1, rdn
+    fmv.x.d t1, ft2
+    li      t2, 0xBFD5555555555556
+    beq     t1, t2, 6f
+    addi    a0, a0, 1
+6:
+
+    // ------------------------------------------------------------------
+    // Test 7: FDIV.D  -1.0d / 3.0d, RUP
+    //   Expected: 0xBFD5555555555555 (toward +inf truncates for negative)
+    // ------------------------------------------------------------------
+    fdiv.d  ft2, ft3, ft1, rup
+    fmv.x.d t1, ft2
+    li      t2, 0xBFD5555555555555
+    beq     t1, t2, 7f
+    addi    a0, a0, 1
+7:
+
+    // Load single operands: 1.0f / 3.0f
+    li      t0, 0x3F800000
+    fmv.w.x ft0, t0                 // ft0 = 1.0f
+    li      t0, 0x40400000
+    fmv.w.x ft1, t0                 // ft1 = 3.0f
+
+    // ------------------------------------------------------------------
+    // Test 8: FDIV.S  1.0f / 3.0f, RNE
+    //   Expected: 0x3EAAAAAB (rounds up — guard=1, sticky=1)
+    // ------------------------------------------------------------------
+    fdiv.s  ft2, ft0, ft1, rne
+    fmv.x.w t1, ft2
+    li      t2, 0x3EAAAAAB
+    beq     t1, t2, 8f
+    addi    a0, a0, 1
+8:
+
+    // ------------------------------------------------------------------
+    // Test 9: FDIV.S  1.0f / 3.0f, RTZ
+    //   Expected: 0x3EAAAAAA (truncate)
+    // ------------------------------------------------------------------
+    fdiv.s  ft2, ft0, ft1, rtz
+    fmv.x.w t1, ft2
+    li      t2, 0x3EAAAAAA
+    beq     t1, t2, 9f
+    addi    a0, a0, 1
+9:
+
+    ret

--- a/sw/stage5b/test_fdiv_stall.S
+++ b/sw/stage5b/test_fdiv_stall.S
@@ -1,0 +1,77 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FDIV pipeline stall test.
+// Back-to-back dependent FDIV.D chain: each iteration depends on the
+// previous result, forcing the pipeline to stall on every iteration.
+// 1024.0 / 2.0^16 = 0.015625 = 2^-6.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: Dependent chain — 1024.0 / 2.0 repeated 16 times
+    //   1024.0d = 0x4090000000000000
+    //   2.0d    = 0x4000000000000000
+    //   result  = 1024 / 65536 = 0.015625 = 2^-6 = 0x3F90000000000000
+    // ------------------------------------------------------------------
+    li      t0, 0x4090000000000000
+    fmv.d.x ft0, t0                 // ft0 = 1024.0d
+    li      t0, 0x4000000000000000
+    fmv.d.x ft1, t0                 // ft1 = 2.0d
+    li      t2, 16                  // loop counter
+
+1:
+    fdiv.d  ft0, ft0, ft1           // dependent chain: ft0 = ft0 / 2.0
+    addi    t2, t2, -1
+    bnez    t2, 1b
+
+    fmv.x.d t1, ft0
+    li      t3, 0x3F90000000000000  // 2^-6 = 0.015625
+    beq     t1, t3, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 2: Mixed FDIV.D + FDIV.S dependent chain
+    //   Start: 64.0d, divide by 2.0 four times = 4.0d
+    //   Then:  64.0f, divide by 2.0f four times = 4.0f
+    // ------------------------------------------------------------------
+    li      t0, 0x4050000000000000
+    fmv.d.x ft0, t0                 // ft0 = 64.0d
+    li      t0, 0x4000000000000000
+    fmv.d.x ft1, t0                 // ft1 = 2.0d
+
+    fdiv.d  ft0, ft0, ft1           // 32.0
+    fdiv.d  ft0, ft0, ft1           // 16.0
+    fdiv.d  ft0, ft0, ft1           // 8.0
+    fdiv.d  ft0, ft0, ft1           // 4.0
+
+    fmv.x.d t1, ft0
+    li      t3, 0x4010000000000000  // 4.0d
+    beq     t1, t3, 3f
+    addi    a0, a0, 1
+3:
+
+    li      t0, 0x42800000
+    fmv.w.x ft0, t0                 // ft0 = 64.0f
+    li      t0, 0x40000000
+    fmv.w.x ft1, t0                 // ft1 = 2.0f
+
+    fdiv.s  ft0, ft0, ft1           // 32.0f
+    fdiv.s  ft0, ft0, ft1           // 16.0f
+    fdiv.s  ft0, ft0, ft1           // 8.0f
+    fdiv.s  ft0, ft0, ft1           // 4.0f
+
+    fmv.x.w t1, ft0
+    li      t3, 0x40800000          // 4.0f
+    beq     t1, t3, 4f
+    addi    a0, a0, 1
+4:
+
+    ret

--- a/sw/stage5b/test_fdiv_subnormal.S
+++ b/sw/stage5b/test_fdiv_subnormal.S
@@ -1,0 +1,109 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FDIV subnormal result tests.
+// Uses exact power-of-2 divisions to produce subnormal outputs.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FDIV.D  smallest-normal / 2.0 = subnormal (exact)
+    //   smallest normal double = 2^-1022 = 0x0010000000000000
+    //   2.0d = 0x4000000000000000
+    //   result = 2^-1023 = 0x0008000000000000 (subnormal, exact)
+    //   fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero       // clear fflags
+    li      t0, 0x0010000000000000
+    fmv.d.x ft0, t0                 // ft0 = 2^-1022
+    li      t0, 0x4000000000000000
+    fmv.d.x ft1, t0                 // ft1 = 2.0d
+    fdiv.d  ft2, ft0, ft1
+    fmv.x.d t1, ft2
+    li      t2, 0x0008000000000000  // 2^-1023
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+    csrrs   t3, 0x001, zero         // read fflags
+    li      t4, 0x00                // no flags (exact)
+    beq     t3, t4, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 2: FDIV.S  smallest-normal / 2.0f = subnormal (exact)
+    //   smallest normal float = 2^-126 = 0x00800000
+    //   2.0f = 0x40000000
+    //   result = 2^-127 = 0x00400000 (subnormal, exact)
+    //   fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x00800000
+    fmv.w.x ft0, t0                 // ft0 = 2^-126
+    li      t0, 0x40000000
+    fmv.w.x ft1, t0                 // ft1 = 2.0f
+    fdiv.s  ft2, ft0, ft1
+    fmv.x.w t1, ft2
+    li      t2, 0x00400000          // 2^-127
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags (exact)
+    beq     t3, t4, 4f
+    addi    a0, a0, 1
+4:
+
+    // ------------------------------------------------------------------
+    // Test 3: FDIV.D  smallest-normal / 4.0 = deeper subnormal (exact)
+    //   4.0d = 0x4010000000000000
+    //   result = 2^-1024 = 0x0004000000000000
+    //   fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x0010000000000000
+    fmv.d.x ft0, t0                 // ft0 = 2^-1022
+    li      t0, 0x4010000000000000
+    fmv.d.x ft1, t0                 // ft1 = 4.0d
+    fdiv.d  ft2, ft0, ft1
+    fmv.x.d t1, ft2
+    li      t2, 0x0004000000000000  // 2^-1024
+    beq     t1, t2, 5f
+    addi    a0, a0, 1
+5:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags (exact)
+    beq     t3, t4, 6f
+    addi    a0, a0, 1
+6:
+
+    // ------------------------------------------------------------------
+    // Test 4: FDIV.S  smallest-normal / 4.0f = deeper subnormal (exact)
+    //   4.0f = 0x40800000
+    //   result = 2^-128 = 0x00200000
+    //   fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x00800000
+    fmv.w.x ft0, t0                 // ft0 = 2^-126
+    li      t0, 0x40800000
+    fmv.w.x ft1, t0                 // ft1 = 4.0f
+    fdiv.s  ft2, ft0, ft1
+    fmv.x.w t1, ft2
+    li      t2, 0x00200000          // 2^-128
+    beq     t1, t2, 7f
+    addi    a0, a0, 1
+7:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags (exact)
+    beq     t3, t4, 8f
+    addi    a0, a0, 1
+8:
+
+    ret

--- a/sw/stage5b/test_fsqrt_basic.S
+++ b/sw/stage5b/test_fsqrt_basic.S
@@ -1,0 +1,70 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic FSQRT.S, FSQRT.D with exact results (no rounding needed).
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FSQRT.S  sqrt(4.0f) = 2.0f
+    //   4.0f = 0x40800000
+    //   2.0f = 0x40000000
+    // ------------------------------------------------------------------
+    li      t0, 0x40800000
+    fmv.w.x ft0, t0                 // ft0 = 4.0f
+    fsqrt.s ft1, ft0                // ft1 = 2.0f
+    fmv.x.w t1, ft1
+    li      t2, 0x40000000
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+
+    // ------------------------------------------------------------------
+    // Test 2: FSQRT.S  sqrt(16.0f) = 4.0f
+    //   16.0f = 0x41800000
+    //   4.0f  = 0x40800000
+    // ------------------------------------------------------------------
+    li      t0, 0x41800000
+    fmv.w.x ft0, t0                 // ft0 = 16.0f
+    fsqrt.s ft1, ft0                // ft1 = 4.0f
+    fmv.x.w t1, ft1
+    li      t2, 0x40800000
+    beq     t1, t2, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 3: FSQRT.D  sqrt(4.0d) = 2.0d
+    //   4.0d = 0x4010000000000000
+    //   2.0d = 0x4000000000000000
+    // ------------------------------------------------------------------
+    li      t0, 0x4010000000000000
+    fmv.d.x ft0, t0                 // ft0 = 4.0d
+    fsqrt.d ft1, ft0                // ft1 = 2.0d
+    fmv.x.d t1, ft1
+    li      t2, 0x4000000000000000
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+
+    // ------------------------------------------------------------------
+    // Test 4: FSQRT.D  sqrt(9.0d) = 3.0d
+    //   9.0d = 0x4022000000000000
+    //   3.0d = 0x4008000000000000
+    // ------------------------------------------------------------------
+    li      t0, 0x4022000000000000
+    fmv.d.x ft0, t0                 // ft0 = 9.0d
+    fsqrt.d ft1, ft0                // ft1 = 3.0d
+    fmv.x.d t1, ft1
+    li      t2, 0x4008000000000000
+    beq     t1, t2, 4f
+    addi    a0, a0, 1
+4:
+
+    ret

--- a/sw/stage5b/test_fsqrt_exceptions.S
+++ b/sw/stage5b/test_fsqrt_exceptions.S
@@ -1,0 +1,144 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FSQRT exception / FFLAGS tests.
+// Checks result and accrued exception flags after each operation.
+// FFLAGS (CSR 0x001): NV=0x10, DZ=0x08, OF=0x04, UF=0x02, NX=0x01.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FSQRT.D  sqrt(-1.0d) = canonical NaN, fflags = NV (0x10)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero       // clear fflags
+    li      t0, 0xBFF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = -1.0d
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x7FF8000000000000  // canonical NaN
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+    csrrs   t3, 0x001, zero         // read fflags
+    li      t4, 0x10                // NV
+    beq     t3, t4, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 2: FSQRT.D  sqrt(-inf) = canonical NaN, fflags = NV (0x10)
+    //   -inf = 0xFFF0000000000000
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0xFFF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = -inf
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x7FF8000000000000  // canonical NaN
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 4f
+    addi    a0, a0, 1
+4:
+
+    // ------------------------------------------------------------------
+    // Test 3: FSQRT.D  sqrt(sNaN) = canonical NaN, fflags = NV (0x10)
+    //   sNaN = 0x7FF0000000000001
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x7FF0000000000001
+    fmv.d.x ft0, t0                 // ft0 = sNaN
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x7FF8000000000000  // canonical NaN
+    beq     t1, t2, 5f
+    addi    a0, a0, 1
+5:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 6f
+    addi    a0, a0, 1
+6:
+
+    // ------------------------------------------------------------------
+    // Test 4: FSQRT.D  sqrt(-0.0d) = -0.0d, fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x8000000000000000
+    fmv.d.x ft0, t0                 // ft0 = -0.0d
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x8000000000000000  // -0.0d
+    beq     t1, t2, 7f
+    addi    a0, a0, 1
+7:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags
+    beq     t3, t4, 8f
+    addi    a0, a0, 1
+8:
+
+    // ------------------------------------------------------------------
+    // Test 5: FSQRT.D  sqrt(+0.0d) = +0.0d, fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x0000000000000000
+    fmv.d.x ft0, t0                 // ft0 = +0.0d
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x0000000000000000  // +0.0d
+    beq     t1, t2, 9f
+    addi    a0, a0, 1
+9:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags
+    beq     t3, t4, 10f
+    addi    a0, a0, 1
+10:
+
+    // ------------------------------------------------------------------
+    // Test 6: FSQRT.D  sqrt(+inf) = +inf, fflags = 0x00
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x7FF0000000000000
+    fmv.d.x ft0, t0                 // ft0 = +inf
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x7FF0000000000000  // +inf
+    beq     t1, t2, 11f
+    addi    a0, a0, 1
+11:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags
+    beq     t3, t4, 12f
+    addi    a0, a0, 1
+12:
+
+    // ------------------------------------------------------------------
+    // Test 7: FSQRT.S  sqrt(-1.0f) = canonical NaN, fflags = NV (0x10)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0xBF800000
+    fmv.w.x ft0, t0                 // ft0 = -1.0f
+    fsqrt.s ft1, ft0
+    fmv.x.w t1, ft1
+    li      t2, 0x7FC00000          // canonical NaN (single)
+    beq     t1, t2, 13f
+    addi    a0, a0, 1
+13:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x10                // NV
+    beq     t3, t4, 14f
+    addi    a0, a0, 1
+14:
+
+    ret

--- a/sw/stage5b/test_fsqrt_rounding.S
+++ b/sw/stage5b/test_fsqrt_rounding.S
@@ -1,0 +1,133 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FSQRT rounding-mode tests using static rounding-mode instruction fields.
+// Tests sqrt(2.0d) and sqrt(2.0f) under all five IEEE 754 rounding modes.
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // Load double operand: 2.0d
+    li      t0, 0x4000000000000000
+    fmv.d.x ft0, t0                 // ft0 = 2.0d
+
+    // ------------------------------------------------------------------
+    // Test 1: FSQRT.D  sqrt(2.0d), RNE
+    //   Expected: 0x3FF6A09E667F3BCD
+    // ------------------------------------------------------------------
+    fsqrt.d ft1, ft0, rne
+    fmv.x.d t1, ft1
+    li      t2, 0x3FF6A09E667F3BCD
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+
+    // ------------------------------------------------------------------
+    // Test 2: FSQRT.D  sqrt(2.0d), RTZ
+    //   Expected: 0x3FF6A09E667F3BCC
+    // ------------------------------------------------------------------
+    fsqrt.d ft1, ft0, rtz
+    fmv.x.d t1, ft1
+    li      t2, 0x3FF6A09E667F3BCC
+    beq     t1, t2, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 3: FSQRT.D  sqrt(2.0d), RDN
+    //   Expected: 0x3FF6A09E667F3BCC
+    // ------------------------------------------------------------------
+    fsqrt.d ft1, ft0, rdn
+    fmv.x.d t1, ft1
+    li      t2, 0x3FF6A09E667F3BCC
+    beq     t1, t2, 3f
+    addi    a0, a0, 1
+3:
+
+    // ------------------------------------------------------------------
+    // Test 4: FSQRT.D  sqrt(2.0d), RUP
+    //   Expected: 0x3FF6A09E667F3BCD
+    // ------------------------------------------------------------------
+    fsqrt.d ft1, ft0, rup
+    fmv.x.d t1, ft1
+    li      t2, 0x3FF6A09E667F3BCD
+    beq     t1, t2, 4f
+    addi    a0, a0, 1
+4:
+
+    // ------------------------------------------------------------------
+    // Test 5: FSQRT.D  sqrt(2.0d), RMM
+    //   Expected: 0x3FF6A09E667F3BCD
+    // ------------------------------------------------------------------
+    fsqrt.d ft1, ft0, rmm
+    fmv.x.d t1, ft1
+    li      t2, 0x3FF6A09E667F3BCD
+    beq     t1, t2, 5f
+    addi    a0, a0, 1
+5:
+
+    // Load single operand: 2.0f
+    li      t0, 0x40000000
+    fmv.w.x ft0, t0                 // ft0 = 2.0f
+
+    // ------------------------------------------------------------------
+    // Test 6: FSQRT.S  sqrt(2.0f), RNE
+    //   Expected: 0x3FB504F3
+    // ------------------------------------------------------------------
+    fsqrt.s ft1, ft0, rne
+    fmv.x.w t1, ft1
+    li      t2, 0x3FB504F3
+    beq     t1, t2, 6f
+    addi    a0, a0, 1
+6:
+
+    // ------------------------------------------------------------------
+    // Test 7: FSQRT.S  sqrt(2.0f), RTZ
+    //   Expected: 0x3FB504F3
+    // ------------------------------------------------------------------
+    fsqrt.s ft1, ft0, rtz
+    fmv.x.w t1, ft1
+    li      t2, 0x3FB504F3
+    beq     t1, t2, 7f
+    addi    a0, a0, 1
+7:
+
+    // ------------------------------------------------------------------
+    // Test 8: FSQRT.S  sqrt(2.0f), RDN
+    //   Expected: 0x3FB504F3
+    // ------------------------------------------------------------------
+    fsqrt.s ft1, ft0, rdn
+    fmv.x.w t1, ft1
+    li      t2, 0x3FB504F3
+    beq     t1, t2, 8f
+    addi    a0, a0, 1
+8:
+
+    // ------------------------------------------------------------------
+    // Test 9: FSQRT.S  sqrt(2.0f), RUP
+    //   Expected: 0x3FB504F4
+    // ------------------------------------------------------------------
+    fsqrt.s ft1, ft0, rup
+    fmv.x.w t1, ft1
+    li      t2, 0x3FB504F4
+    beq     t1, t2, 9f
+    addi    a0, a0, 1
+9:
+
+    // ------------------------------------------------------------------
+    // Test 10: FSQRT.S  sqrt(2.0f), RMM
+    //   Expected: 0x3FB504F3
+    // ------------------------------------------------------------------
+    fsqrt.s ft1, ft0, rmm
+    fmv.x.w t1, ft1
+    li      t2, 0x3FB504F3
+    beq     t1, t2, 10f
+    addi    a0, a0, 1
+10:
+
+    ret

--- a/sw/stage5b/test_fsqrt_subnormal.S
+++ b/sw/stage5b/test_fsqrt_subnormal.S
@@ -1,0 +1,88 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FSQRT subnormal input tests.
+// sqrt of a subnormal produces a normal result (subnormals are tiny,
+// their square root is much larger).
+// a0 accumulates the failure count; a0 = 0 means pass.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0                   // fail counter
+
+    // ------------------------------------------------------------------
+    // Test 1: FSQRT.D  sqrt(smallest subnormal double)
+    //   input  = 2^-1074 = 0x0000000000000001
+    //   result = 2^-537  (exact, since 2^-1074 = (2^-537)^2)
+    //   2^-537 biased exponent = 1023 - 537 = 486 = 0x1E6
+    //   result = 0x1E60000000000000
+    //   fflags = 0x00 (exact)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero       // clear fflags
+    li      t0, 0x0000000000000001
+    fmv.d.x ft0, t0                 // ft0 = 2^-1074
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x1E60000000000000  // 2^-537
+    beq     t1, t2, 1f
+    addi    a0, a0, 1
+1:
+    csrrs   t3, 0x001, zero         // read fflags
+    li      t4, 0x00                // no flags (exact)
+    beq     t3, t4, 2f
+    addi    a0, a0, 1
+2:
+
+    // ------------------------------------------------------------------
+    // Test 2: FSQRT.S  sqrt(smallest subnormal float)
+    //   input  = 2^-149 = 0x00000001
+    //   result = 2^-74.5 — NOT exact (odd exponent)
+    //   This will be inexact, so just check fflags has NX (0x01)
+    //   and verify result is a normal positive number.
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x00000001
+    fmv.w.x ft0, t0                 // ft0 = 2^-149
+    fsqrt.s ft1, ft0
+    fmv.x.w t1, ft1
+    // Result should be positive and non-zero
+    beqz    t1, 4f                  // fail if zero
+    li      t2, 0x7F800000
+    bge     t1, t2, 4f              // fail if inf or NaN
+    j       3f
+4:
+    addi    a0, a0, 1
+3:
+    csrrs   t3, 0x001, zero
+    andi    t3, t3, 0x01            // check NX bit
+    bnez    t3, 5f                  // NX should be set
+    addi    a0, a0, 1
+5:
+
+    // ------------------------------------------------------------------
+    // Test 3: FSQRT.D  sqrt(4 * 2^-1074) = 2 * 2^-537 = 2^-536
+    //   input  = 0x0000000000000004  (4 * smallest subnormal)
+    //   result = 2^-536 (exact)
+    //   2^-536 biased exponent = 1023 - 536 = 487 = 0x1E7
+    //   result = 0x1E70000000000000
+    //   fflags = 0x00 (exact)
+    // ------------------------------------------------------------------
+    csrrw   zero, 0x001, zero
+    li      t0, 0x0000000000000004
+    fmv.d.x ft0, t0                 // ft0 = 4 * 2^-1074 = 2^-1072
+    fsqrt.d ft1, ft0
+    fmv.x.d t1, ft1
+    li      t2, 0x1E70000000000000  // 2^-536
+    beq     t1, t2, 6f
+    addi    a0, a0, 1
+6:
+    csrrs   t3, 0x001, zero
+    li      t4, 0x00                // no flags (exact)
+    beq     t3, t4, 7f
+    addi    a0, a0, 1
+7:
+
+    ret

--- a/tb/stage5/ref/gen_fdiv_vectors.py
+++ b/tb/stage5/ref/gen_fdiv_vectors.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate test vectors for kronos_fpu_fdiv_core.
+
+Output: fdiv_vectors.hex  —  one line per test:
+    <fmt_d 1b> <a 14hex> <b 14hex> <exp_q 14hex> <exp_sticky 1b>
+
+a and b are 53-bit significands (bit 52 = hidden 1).
+exp_q is a 56-bit quotient for D, 27-bit for S (zero-extended to 56 bits).
+"""
+
+import os
+import random
+import sys
+
+# Resolve the srt_divide function from the same directory.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from srt_divide import srt_divide
+
+
+def make_sig(mant_bits: int, val: int) -> int:
+    """Build a 53-bit significand: hidden-1 at bit 52, mantissa in lower bits."""
+    return (1 << 52) | (val & ((1 << mant_bits) - 1))
+
+
+def emit(f, fmt_d: int, a: int, b: int):
+    n = 56 if fmt_d else 27
+    q, sticky = srt_divide(a, b, n)
+    s = 1 if sticky else 0
+    f.write(f"{fmt_d:01b} {a:014x} {b:014x} {q:014x} {s:01b}\n")
+
+
+def directed_vectors(f):
+    """20 directed edge-case vectors."""
+    one = 1 << 52  # 1.0 significand
+
+    cases = []
+
+    # 1. 1.0 / 1.0  (both formats)
+    cases.append((0, one, one))
+    cases.append((1, one, one))
+
+    # 2. 3.0 / 2.0 = 1.5  — a > b
+    #    3.0 sig = 1.1 binary = (1 << 52) | (1 << 51)
+    #    2.0 sig = 1.0 binary = (1 << 52)
+    a_3 = (1 << 52) | (1 << 51)
+    b_2 = 1 << 52
+    cases.append((0, a_3, b_2))
+    cases.append((1, a_3, b_2))
+
+    # 3. Near 2*B: a = 2*b - 1  (just under the precondition limit)
+    b_val = (1 << 52) | (1 << 30)
+    a_val = 2 * b_val - 1
+    # a must fit in 53 bits — 2*b - 1 for b with bit 52 set is at most
+    # 2*(2^53-1)-1 which exceeds 53 bits. Constrain b to keep a < 2^53.
+    b_val = (1 << 52) | 1
+    a_val = 2 * b_val - 1  # = (1 << 53) | 1 — 54 bits, too big.
+    # Instead: a just under 2*b with both in range.
+    # Use a = (1 << 53) - 1 (all-ones 53-bit), b = (1 << 52) + 1
+    # Check: a < 2*b => (2^53 - 1) < 2*(2^52 + 1) = 2^53 + 2 => yes.
+    a_val = (1 << 53) - 1
+    b_val = (1 << 52) + 1
+    cases.append((0, a_val, b_val))
+    cases.append((1, a_val, b_val))
+
+    # 4. Minimum significand: a = b = 1<<52 (already covered as 1.0/1.0)
+    #    Minimum a, maximum b that satisfies a < 2*b:
+    a_min = 1 << 52
+    b_max = (1 << 53) - 1
+    cases.append((0, a_min, b_max))
+    cases.append((1, a_min, b_max))
+
+    # 5. Maximum a, minimum b that satisfies a < 2*b:
+    #    a < 2*b => a_max = 2*b_min - 1 with b_min = 1<<52
+    #    a_max = (1<<53) - 1 = all-ones 53-bit
+    a_max = (1 << 53) - 1
+    b_min = 1 << 52
+    cases.append((0, a_max, b_min))
+    cases.append((1, a_max, b_min))
+
+    # 6. a = b + 1 (quotient just above 1.0)
+    b6 = (1 << 52) | 0x123456
+    a6 = b6 + 1
+    cases.append((0, a6, b6))
+    cases.append((1, a6, b6))
+
+    # 7. a = b - 1 (quotient just below 1.0)
+    b7 = (1 << 52) | 0xABCDEF
+    a7 = b7 - 1
+    cases.append((0, a7, b7))
+    cases.append((1, a7, b7))
+
+    # 8. Single-precision: only lower 23 mantissa bits matter
+    a8 = (1 << 52) | (0x7FFFFF << 29)  # max single significand, left-aligned
+    b8 = (1 << 52) | (0x400000 << 29)
+    cases.append((0, a8, b8))
+
+    # 9. Power-of-two-ish: a = 1.5 * b (exact)
+    b9 = (1 << 52)
+    a9 = b9 + (b9 >> 1)  # 1.5 * b9 — need a < 2*b => 1.5*b < 2*b, yes
+    cases.append((1, a9, b9))
+
+    # 10. Remainder exactly zero (exact division): a = b
+    b10 = (1 << 52) | 0xDEADBEEF
+    a10 = b10
+    cases.append((0, a10, b10))
+    cases.append((1, a10, b10))
+
+    # 11. a much smaller than b (quotient close to 0.5)
+    a11 = 1 << 52
+    b11 = (1 << 53) - 3
+    cases.append((1, a11, b11))
+
+    # 12. Both operands all-ones 53-bit
+    a12 = (1 << 53) - 1
+    b12 = (1 << 53) - 1
+    cases.append((0, a12, b12))
+
+    for fmt_d, a, b in cases:
+        emit(f, fmt_d, a, b)
+
+
+def random_vectors(f, fmt_d: int, count: int, seed: int):
+    """Generate `count` random vectors for the given format."""
+    rng = random.Random(seed)
+    for _ in range(count):
+        # Both operands have bit 52 set (normalized).
+        a = (1 << 52) | rng.getrandbits(52)
+        b = (1 << 52) | rng.getrandbits(52)
+        # Ensure a < 2*b (standard FP precondition).
+        if a >= 2 * b:
+            # Swap or clamp: easiest is to set a = a % b + b (keeps a in [b, 2b))
+            # or just regenerate. Simple: a = a % b + b won't always have bit 52.
+            # Just mask a to be < 2*b.
+            a = a % b + b  # a in [b, 2b), but bit 52 may be lost if b is small.
+            # Re-set bit 52 — b has bit 52 set so b >= 2^52, a >= b >= 2^52,
+            # so bit 52 is already set. Verify:
+            assert a & (1 << 52), f"a={a:#x} lost bit 52"
+        assert a < 2 * b
+        emit(f, fmt_d, a, b)
+
+
+def main():
+    out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fdiv_vectors.hex")
+    with open(out_path, "w") as f:
+        directed_vectors(f)
+        random_vectors(f, fmt_d=1, count=500, seed=42)
+        random_vectors(f, fmt_d=0, count=500, seed=137)
+    print(f"Generated {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tb/stage5/ref/gen_fsqrt_vectors.py
+++ b/tb/stage5/ref/gen_fsqrt_vectors.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate test vectors for kronos_fpu_fsqrt_core.
+
+Output: fsqrt_vectors.hex  —  one line per test:
+    <fmt_d 1b> <a 14hex> <exp_q 14hex> <exp_sticky 1b>
+
+a is a 53/54-bit significand with bit 52 or 53 set.
+  Even exponent: a in [1<<52, 1<<53) — bit 52 set, bit 53 clear.
+  Odd exponent:  a in [1<<53, 1<<54) — bit 53 set.
+exp_q is a 56-bit root for D, 27-bit for S (zero-extended to 56 bits).
+"""
+
+import os
+import random
+import sys
+
+# Resolve the srt_sqrt function from the same directory.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from srt_sqrt import srt_sqrt
+
+
+def emit(f, fmt_d: int, a: int):
+    n = 56 if fmt_d else 27
+    q, sticky = srt_sqrt(a, n)
+    s = 1 if sticky else 0
+    f.write(f"{fmt_d:01b} {a:014x} {q:014x} {s:01b}\n")
+
+
+def directed_vectors(f):
+    """20 directed edge-case vectors."""
+    cases = []
+
+    # 1. sqrt(1.0) even exponent: a = 1<<52, both formats
+    cases.append((0, 1 << 52))
+    cases.append((1, 1 << 52))
+
+    # 2. sqrt(2.0) odd exponent: a = 1<<53, both formats
+    cases.append((0, 1 << 53))
+    cases.append((1, 1 << 53))
+
+    # 3. Maximum even-exponent significand: a = (1<<53) - 1
+    cases.append((0, (1 << 53) - 1))
+    cases.append((1, (1 << 53) - 1))
+
+    # 4. Maximum odd-exponent significand: a = (1<<54) - 1
+    cases.append((0, (1 << 54) - 1))
+    cases.append((1, (1 << 54) - 1))
+
+    # 5. Minimum odd-exponent significand: a = 1<<53
+    #    (already covered as sqrt(2.0), add explicit)
+    cases.append((1, 1 << 53))
+
+    # 6. Perfect square: a = (1<<52) | (1<<50)  -> 1.25 in binary
+    cases.append((0, (1 << 52) | (1 << 50)))
+    cases.append((1, (1 << 52) | (1 << 50)))
+
+    # 7. a = (1<<52) + 1  (just above 1.0)
+    cases.append((0, (1 << 52) + 1))
+    cases.append((1, (1 << 52) + 1))
+
+    # 8. a = (1<<53) - 2  (just below max even-exp)
+    cases.append((1, (1 << 53) - 2))
+
+    # 9. a = (1<<53) + 1  (just above min odd-exp)
+    cases.append((0, (1 << 53) + 1))
+    cases.append((1, (1 << 53) + 1))
+
+    # 10. a with alternating bit pattern (even exp)
+    cases.append((1, (1 << 52) | 0xAAAAAAAAAAAAA))
+
+    # 11. a with alternating bit pattern (odd exp)
+    cases.append((1, (1 << 53) | 0x5555555555555))
+
+    # 12. Single-precision specific: lower mantissa bits
+    cases.append((0, (1 << 52) | (0x7FFFFF << 29)))
+
+    for fmt_d, a in cases:
+        emit(f, fmt_d, a)
+
+
+def random_vectors(f, fmt_d: int, count: int, seed: int):
+    """Generate `count` random vectors for the given format."""
+    rng = random.Random(seed)
+    for _ in range(count):
+        # Randomly choose even-exponent (bit 52 set) or odd-exponent (bit 53 set)
+        if rng.randint(0, 1) == 0:
+            # Even exponent: a in [1<<52, 1<<53)
+            a = (1 << 52) | rng.getrandbits(52)
+        else:
+            # Odd exponent: a in [1<<53, 1<<54)
+            a = (1 << 53) | rng.getrandbits(53)
+        # Clamp to valid range
+        assert (1 << 52) <= a < (1 << 54), f"a={a:#x} out of range"
+        emit(f, fmt_d, a)
+
+
+def main():
+    out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "fsqrt_vectors.hex")
+    with open(out_path, "w") as f:
+        directed_vectors(f)
+        random_vectors(f, fmt_d=1, count=500, seed=42)
+        random_vectors(f, fmt_d=0, count=500, seed=137)
+    print(f"Generated {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tb/stage5/ref/srt_divide.py
+++ b/tb/stage5/ref/srt_divide.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-Python reference for radix-2 SRT non-restoring divide.
+
+Input: integer significands A and B, each with bit 52 set (explicit leading 1).
+       A must be < 2*B (result < 2, standard FP precondition).
+Output: (Q, sticky) where Q is an n-bit raw quotient laid out as:
+          bit (n-1): integer part  (1 if quotient >= 1.0, 0 otherwise)
+          bits (n-2)..0: fractional part
+        For n=56 (double precision), Q has 1 integer bit + 55 fractional bits
+        (52 mantissa bits + guard + round + extra), and sticky is True if the
+        final partial remainder is non-zero.
+"""
+
+
+def srt_divide(a: int, b: int, n: int = 56) -> tuple:
+    assert 0 < a < (2 << 52) and 0 < b < (2 << 52), "operands out of range"
+    assert a < 2 * b, "precondition: A < 2B"
+
+    p = a
+    q = 0
+
+    # Integer bit: quotient is in [0, 2) so the leading bit tells if >= 1.
+    if p >= b:
+        q = 1
+        p = p - b
+    else:
+        q = 0
+
+    # n-1 fractional bits via restoring binary long division.
+    for _ in range(n - 1):
+        p <<= 1
+        if p >= b:
+            q = (q << 1) | 1
+            p -= b
+        else:
+            q = (q << 1)
+
+    return q, p != 0

--- a/tb/stage5/ref/srt_sqrt.py
+++ b/tb/stage5/ref/srt_sqrt.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-Python reference for radix-2 digit-by-digit square root.
+
+Input: 54-bit significand with bit 52 or 53 set (explicit leading 1).
+       Even exponent: a in [1<<52, 1<<53), value in [1.0, 2.0).
+       Odd exponent:  a in [1<<53, 1<<54), value in [2.0, 4.0).
+       Valid range: (1<<52) <= a < (1<<54).
+Output: (Q, sticky) where:
+  Q: n-bit raw root. Bit n-1 is always 1 (result is in [1.0, 2.0)).
+     Bit n-1 is the integer part; bits n-2..0 are fractional.
+     For n=56 (double precision), Q has 1 integer bit + 55 fractional bits
+     (52 mantissa bits + guard + round + extra), and sticky captures any
+     residual.
+  sticky: True iff the final partial remainder is non-zero (inexact result).
+"""
+
+
+def srt_sqrt(a: int, n: int = 56) -> tuple:
+    assert (1 << 52) <= a < (1 << 54), f"a={a:#x} out of range"
+
+    # Produce n + 26 output bits total. The lowest 26 bits come from the integer
+    # part of sqrt(a) (since sqrt(2^52) = 2^26), so Q = q_full >> 26 gives the
+    # desired n-bit result in [2^(n-1), 2^n).
+    total = n + 26
+
+    # Pad 'a' (54 bits) on the right to fill 2*total bits so that every iteration
+    # reads exactly one 2-bit group.
+    a_padded = a << (2 * total - 54)
+
+    q = 0  # running root (integer)
+    r = 0  # partial remainder
+
+    for i in range(total):
+        # Shift in the next pair of bits from the padded input.
+        pair = (a_padded >> (2 * (total - 1 - i))) & 3
+        r = (r << 2) | pair
+
+        # Trial subtrahend: (2*q + 1) = (q<<1)|1, but using the concatenation form
+        # that avoids an explicit multiply: t = (q << 2) | 1.
+        t = (q << 2) | 1
+        if r >= t:
+            r -= t
+            q = (q << 1) | 1
+        else:
+            q = q << 1
+
+    # Strip the 26-bit integer part that mirrors sqrt(2^52) = 2^26.
+    Q = q >> 26
+    sticky = bool(q & ((1 << 26) - 1)) or (r != 0)
+    return Q, sticky

--- a/tb/stage5/ref/tests/test_srt_divide.py
+++ b/tb/stage5/ref/tests/test_srt_divide.py
@@ -1,0 +1,43 @@
+import pytest
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from srt_divide import srt_divide
+
+# ---------------------------------------------------------------------------
+# Format: (a, b, n, expected_q, expected_sticky)
+#
+# a, b  : 53-bit significands with explicit leading 1 at bit 52
+# n     : number of output bits (1 integer bit + n-1 fractional bits)
+# expected_q : n-bit raw quotient; bit (n-1) is the integer part
+# expected_sticky : True iff the final partial remainder is non-zero
+# ---------------------------------------------------------------------------
+
+KNOWN_VECTORS = [
+    # 1.0 / 1.0 = 1.0  =>  Q = 1.00...0  (bit 54 set, rest 0)
+    (1 << 52, 1 << 52, 55, 1 << 54, False),
+
+    # 3.0 / 2.0 = 1.5  =>  Q = 1.10...0  (bits 54 and 53 set)
+    ((1 << 52) | (1 << 51), 1 << 52, 55, (1 << 54) | (1 << 53), False),
+
+    # 1.0 / 1.75 = 4/7 ≈ 0.5714...  =>  Q = 0.100100...  (repeating, sticky=True)
+    # expected computed via floor(2^56 / 7) = 0x0024924924924924
+    (1 << 52, (1 << 52) | (1 << 51) | (1 << 50), 55, 0x0024924924924924, True),
+
+    # n=26 (single-precision mode), 1.0 / 1.0 = 1.0  =>  Q = 1.00...0 (bit 25 set)
+    (1 << 52, 1 << 52, 26, 1 << 25, False),
+
+    # n=26, 3.0 / 2.0 = 1.5  =>  Q = 1.10...0 (bits 25 and 24 set)
+    ((1 << 52) | (1 << 51), 1 << 52, 26, (1 << 25) | (1 << 24), False),
+
+    # Edge: A very close to 2*B  =>  quotient ≈ 2.0 - ulp
+    # a = 2^53 - 1  (just under 2.0 * 2^52), b = 2^52
+    # floor((2^53-1)/2^52 * 2^54) = 2^55 - 4 = 0x7ffffffffffffc (55 bits)
+    ((2 << 52) - 1, 1 << 52, 55, 0x7ffffffffffffc, False),
+]
+
+
+@pytest.mark.parametrize("a,b,n,q,s", KNOWN_VECTORS)
+def test_srt_divide_known(a, b, n, q, s):
+    got_q, got_s = srt_divide(a, b, n)
+    assert got_q == q, f"quotient mismatch: {got_q:#018x} vs {q:#018x}"
+    assert got_s == s, f"sticky mismatch: {got_s} vs {s}"

--- a/tb/stage5/ref/tests/test_srt_sqrt.py
+++ b/tb/stage5/ref/tests/test_srt_sqrt.py
@@ -1,0 +1,45 @@
+import pytest
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from srt_sqrt import srt_sqrt
+
+# ---------------------------------------------------------------------------
+# Format: (a, n, expected_q, expected_sticky)
+#
+# a     : 54-bit significand with explicit leading 1.
+#           Even exponent (a in [1<<52, 1<<53)): value in [1.0, 2.0).
+#           Odd exponent  (a in [1<<53, 1<<54)): value in [2.0, 4.0).
+# n     : number of output bits (bit n-1 = integer 1, bits n-2..0 = fractional).
+# expected_q : n-bit raw root; bit n-1 is always 1 (result in [1.0, 2.0)).
+# expected_sticky : True iff the final partial remainder is non-zero.
+# ---------------------------------------------------------------------------
+
+KNOWN_VECTORS = [
+    # sqrt(1.0) = 1.0 exactly.
+    # a=1<<52 (even exponent, value 1.0), Q = 1.00..0 (only bit 54 set).
+    (0x0010000000000000, 55, 0x0040000000000000, False),
+
+    # sqrt(2.0): a=1<<53 (odd exponent, value 2.0). sqrt(2) is irrational.
+    (0x0020000000000000, 55, 0x005a827999fcef32, True),
+
+    # sqrt(2.25) = sqrt(9/4) = 3/2 = 1.5 exactly.
+    # a = 9*(1<<50) = 0x24000000000000 (value 2.25), Q = 1.10..0 (bits 54 and 53 set).
+    (0x0024000000000000, 55, 0x0060000000000000, False),
+
+    # sqrt(4 - ulp): a just below 2^54 (value just below 4.0). Result just below 2.0.
+    (0x003fffffffffffff, 55, 0x007ffffffffffffe, True),
+
+    # n=26 (single-precision mode): sqrt(1.0) = 1.0.
+    # Q = 1.00..0 (bit 25 set).
+    (0x0010000000000000, 26, 0x0000000002000000, False),
+
+    # n=26, sqrt(2.0): irrational.
+    (0x0020000000000000, 26, 0x0000000002d413cc, True),
+]
+
+
+@pytest.mark.parametrize("a,n,q,s", KNOWN_VECTORS)
+def test_srt_sqrt_known(a, n, q, s):
+    got_q, got_s = srt_sqrt(a, n)
+    assert got_q == q, f"root mismatch: {got_q:#018x} vs {q:#018x}"
+    assert got_s == s, f"sticky mismatch: {got_s} vs {s}"

--- a/tb/stage5/tb_fpu_fdiv_core.sv
+++ b/tb/stage5/tb_fpu_fdiv_core.sv
@@ -1,0 +1,78 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module tb_fpu_fdiv_core;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic        rst_n = 0, start = 0, fmt_d = 0;
+  logic [52:0] a, b;
+  logic        done;
+  logic [55:0] quot;
+  logic        rem_nz;
+
+  kronos_fpu_fdiv_core dut (
+    .clk_i    (clk),
+    .rst_ni   (rst_n),
+    .flush_i  (1'b0),
+    .start_i  (start),
+    .fmt_d_i  (fmt_d),
+    .a_i      (a),
+    .b_i      (b),
+    .done_o   (done),
+    .quot_o   (quot),
+    .rem_nz_o (rem_nz)
+  );
+
+  integer fd, errors = 0, tests = 0;
+
+  initial begin
+    rst_n = 1'b0;
+    #20;
+    rst_n = 1'b1;
+    #10;
+
+    fd = $fopen("fdiv_vectors.hex", "r");
+    if (fd == 0) begin
+      $display("ERROR: cannot open fdiv_vectors.hex");
+      $finish;
+    end
+
+    while (!$feof(fd)) begin
+      logic        exp_s;
+      logic [55:0] exp_q;
+      logic        fmt_v;
+      logic [52:0] a_v, b_v;
+      int          scan_result;
+
+      scan_result = $fscanf(fd, "%b %h %h %h %b\n", fmt_v, a_v, b_v, exp_q, exp_s);
+      if (scan_result != 5) continue;
+
+      fmt_d = fmt_v;
+      a     = a_v;
+      b     = b_v;
+      @(posedge clk);
+      start = 1'b1;
+      @(posedge clk);
+      start = 1'b0;
+
+      // Wait for done
+      while (!done) @(posedge clk);
+
+      tests++;
+      if (quot !== exp_q || rem_nz !== exp_s) begin
+        $display("FAIL[%0d] fmt=%b a=%h b=%h exp_q=%h got_q=%h exp_s=%b got_s=%b",
+                 tests, fmt_v, a_v, b_v, exp_q, quot, exp_s, rem_nz);
+        errors++;
+      end
+
+      @(posedge clk);  // one idle cycle between tests
+    end
+
+    $fclose(fd);
+    if (errors == 0) $display("PASS (%0d tests)", tests);
+    else             $display("FAIL %0d/%0d errors", errors, tests);
+    $finish;
+  end
+endmodule

--- a/tb/stage5/tb_fpu_fsqrt_core.sv
+++ b/tb/stage5/tb_fpu_fsqrt_core.sv
@@ -1,0 +1,76 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module tb_fpu_fsqrt_core;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic        rst_n = 0, start = 0, fmt_d = 0;
+  logic [53:0] a;
+  logic        done;
+  logic [55:0] quot;
+  logic        rem_nz;
+
+  kronos_fpu_fsqrt_core dut (
+    .clk_i    (clk),
+    .rst_ni   (rst_n),
+    .flush_i  (1'b0),
+    .start_i  (start),
+    .fmt_d_i  (fmt_d),
+    .a_i      (a),
+    .done_o   (done),
+    .quot_o   (quot),
+    .rem_nz_o (rem_nz)
+  );
+
+  integer fd, errors = 0, tests = 0;
+
+  initial begin
+    rst_n = 1'b0;
+    #20;
+    rst_n = 1'b1;
+    #10;
+
+    fd = $fopen("fsqrt_vectors.hex", "r");
+    if (fd == 0) begin
+      $display("ERROR: cannot open fsqrt_vectors.hex");
+      $finish;
+    end
+
+    while (!$feof(fd)) begin
+      logic        exp_s;
+      logic [55:0] exp_q;
+      logic        fmt_v;
+      logic [53:0] a_v;
+      int          scan_result;
+
+      scan_result = $fscanf(fd, "%b %h %h %b\n", fmt_v, a_v, exp_q, exp_s);
+      if (scan_result != 4) continue;
+
+      fmt_d = fmt_v;
+      a     = a_v;
+      @(posedge clk);
+      start = 1'b1;
+      @(posedge clk);
+      start = 1'b0;
+
+      // Wait for done
+      while (!done) @(posedge clk);
+
+      tests++;
+      if (quot !== exp_q || rem_nz !== exp_s) begin
+        $display("FAIL[%0d] fmt=%b a=%h exp_q=%h got_q=%h exp_s=%b got_s=%b",
+                 tests, fmt_v, a_v, exp_q, quot, exp_s, rem_nz);
+        errors++;
+      end
+
+      @(posedge clk);  // one idle cycle between tests
+    end
+
+    $fclose(fd);
+    if (errors == 0) $display("PASS (%0d tests)", tests);
+    else             $display("FAIL %0d/%0d errors", errors, tests);
+    $finish;
+  end
+endmodule

--- a/tb/stage5/tb_fpu_iter.sv
+++ b/tb/stage5/tb_fpu_iter.sv
@@ -1,0 +1,547 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+module tb_fpu_iter;
+  import kronos_pkg::*;
+  import softfloat_dpi_pkg::*;
+
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic        rst_n = 0;
+  logic        in_valid = 0;
+  fp_op_e      op;
+  logic        fmt_d = 1;
+  logic [2:0]  rm = 3'b000;
+  logic [63:0] a, b;
+  fpu_tag_t    tag = '{rd: 5'd1, fp_dest: 1'b1};
+
+  logic        busy, out_valid;
+  logic [63:0] result;
+  logic [4:0]  fflags;
+  fpu_tag_t    tag_out;
+
+  kronos_fpu_iter dut (
+    .clk_i(clk), .rst_ni(rst_n), .flush_i(1'b0),
+    .in_valid_i(in_valid), .op_i(op), .fmt_d_i(fmt_d), .rm_i(rm),
+    .a_i(a), .b_i(b), .tag_i(tag),
+    .busy_o(busy), .out_valid_o(out_valid), .result_o(result),
+    .fflags_o(fflags), .tag_o(tag_out),
+    .sb_late_req_o(), .sb_late_fp_dest_o(),
+    .sb_late_grant_i(1'b1)
+  );
+
+  integer errors = 0;
+  integer total  = 0;
+
+  // Double-precision constants
+  localparam logic [63:0] D_QNAN    = 64'h7FF8_0000_0000_0000;
+  localparam logic [63:0] D_SNAN    = 64'h7FF0_0000_0000_0001;
+  localparam logic [63:0] D_PINF    = 64'h7FF0_0000_0000_0000;
+  localparam logic [63:0] D_NINF    = 64'hFFF0_0000_0000_0000;
+  localparam logic [63:0] D_PZERO   = 64'h0000_0000_0000_0000;
+  localparam logic [63:0] D_NZERO   = 64'h8000_0000_0000_0000;
+  localparam logic [63:0] D_ONE     = 64'h3FF0_0000_0000_0000;
+  localparam logic [63:0] D_NONE    = 64'hBFF0_0000_0000_0000;
+  localparam logic [63:0] D_TWO     = 64'h4000_0000_0000_0000;
+  localparam logic [63:0] D_FOUR    = 64'h4010_0000_0000_0000;
+  localparam logic [63:0] D_SIX     = 64'h4018_0000_0000_0000;
+  localparam logic [63:0] D_HALF    = 64'h3FE0_0000_0000_0000;
+  localparam logic [63:0] D_THREE   = 64'h4008_0000_0000_0000;
+
+  // Single-precision constants (NaN-boxed)
+  localparam logic [63:0] S_QNAN    = 64'hFFFF_FFFF_7FC0_0000;
+  localparam logic [63:0] S_SNAN    = 64'hFFFF_FFFF_7F80_0001;
+  localparam logic [63:0] S_PINF    = 64'hFFFF_FFFF_7F80_0000;
+  localparam logic [63:0] S_NINF    = 64'hFFFF_FFFF_FF80_0000;
+  localparam logic [63:0] S_PZERO   = 64'hFFFF_FFFF_0000_0000;
+  localparam logic [63:0] S_NZERO   = 64'hFFFF_FFFF_8000_0000;
+  localparam logic [63:0] S_ONE     = 64'hFFFF_FFFF_3F80_0000;
+  localparam logic [63:0] S_NONE    = 64'hFFFF_FFFF_BF80_0000;
+  localparam logic [63:0] S_FOUR    = 64'hFFFF_FFFF_4080_0000;
+
+  // Flag bits
+  localparam logic [4:0] FL_NV = 5'b10000;
+  localparam logic [4:0] FL_DZ = 5'b01000;
+  localparam logic [4:0] FL_NX = 5'b00001;
+  localparam logic [4:0] FL_OK = 5'b00000;
+
+  // Dispatch one operation and wait for out_valid (specials path)
+  task automatic dispatch(
+    input fp_op_e    t_op,
+    input logic      t_fmt_d,
+    input logic [63:0] t_a,
+    input logic [63:0] t_b,
+    input logic [63:0] exp_result,
+    input logic [4:0]  exp_fflags,
+    input string       name
+  );
+    op    = t_op;
+    fmt_d = t_fmt_d;
+    a     = t_a;
+    b     = t_b;
+    @(posedge clk);
+    in_valid = 1;
+    @(posedge clk);
+    in_valid = 0;
+
+    // Wait for out_valid (max 20 cycles for specials)
+    for (int i = 0; i < 20; i++) begin
+      if (out_valid) break;
+      @(posedge clk);
+    end
+
+    if (!out_valid) begin
+      $display("FAIL [%s]: out_valid never asserted", name);
+      errors++;
+    end else begin
+      if (result !== exp_result) begin
+        $display("FAIL [%s]: result=%016h expected=%016h", name, result, exp_result);
+        errors++;
+      end
+      if (fflags !== exp_fflags) begin
+        $display("FAIL [%s]: fflags=%05b expected=%05b", name, fflags, exp_fflags);
+        errors++;
+      end
+    end
+
+    // Wait for PACK -> IDLE
+    @(posedge clk);
+    if (busy) begin
+      $display("FAIL [%s]: busy still asserted after PACK", name);
+      errors++;
+    end
+    total++;
+  endtask
+
+  // Dispatch a finite-normal operation and verify FSM completion.
+  task automatic dispatch_iter(
+    input fp_op_e      t_op,
+    input logic        t_fmt_d,
+    input logic [63:0] t_a,
+    input logic [63:0] t_b,
+    input int          min_cycles,
+    input int          max_cycles,
+    input string       name
+  );
+    int cycle_count;
+    op    = t_op;
+    fmt_d = t_fmt_d;
+    a     = t_a;
+    b     = t_b;
+    @(posedge clk);
+    in_valid = 1;
+    @(posedge clk);
+    in_valid = 0;
+
+    if (!busy) begin
+      $display("FAIL [%s]: busy not asserted after dispatch", name);
+      errors++;
+    end
+
+    cycle_count = 0;
+    for (int i = 0; i < 200; i++) begin
+      if (out_valid) break;
+      if (!busy) begin
+        $display("FAIL [%s]: busy deasserted before out_valid (cycle %0d)",
+                 name, cycle_count);
+        errors++;
+        return;
+      end
+      @(posedge clk);
+      cycle_count++;
+    end
+
+    if (!out_valid) begin
+      $display("FAIL [%s]: out_valid never asserted (waited %0d cycles)",
+               name, cycle_count);
+      errors++;
+    end else begin
+      if (cycle_count < min_cycles || cycle_count > max_cycles) begin
+        $display("FAIL [%s]: cycle_count=%0d not in [%0d, %0d]",
+                 name, cycle_count, min_cycles, max_cycles);
+        errors++;
+      end else begin
+        $display("OK   [%s]: completed in %0d cycles", name, cycle_count);
+      end
+    end
+
+    @(posedge clk);
+    if (busy) begin
+      $display("FAIL [%s]: busy still asserted after PACK", name);
+      errors++;
+    end
+    total++;
+  endtask
+
+  // Dispatch with result and fflags check (hand-crafted expected values)
+  task automatic dispatch_iter_check(
+    input fp_op_e      t_op,
+    input logic        t_fmt_d,
+    input logic [2:0]  t_rm,
+    input logic [63:0] t_a,
+    input logic [63:0] t_b,
+    input logic [63:0] exp_result,
+    input logic [4:0]  exp_fflags,
+    input string       name
+  );
+    int cycle_count;
+    op    = t_op;
+    fmt_d = t_fmt_d;
+    rm    = t_rm;
+    a     = t_a;
+    b     = t_b;
+    @(posedge clk);
+    in_valid = 1;
+    @(posedge clk);
+    in_valid = 0;
+
+    cycle_count = 0;
+    for (int i = 0; i < 200; i++) begin
+      if (out_valid) break;
+      @(posedge clk);
+      cycle_count++;
+    end
+
+    if (!out_valid) begin
+      $display("FAIL [%s]: out_valid never asserted (waited %0d cycles)",
+               name, cycle_count);
+      errors++;
+    end else begin
+      if (result !== exp_result) begin
+        $display("FAIL [%s]: result=%016h expected=%016h", name, result,
+                 exp_result);
+        errors++;
+      end else if (fflags !== exp_fflags) begin
+        $display("FAIL [%s]: fflags=%05b expected=%05b", name, fflags,
+                 exp_fflags);
+        errors++;
+      end else begin
+        $display("OK   [%s]: result=%016h fflags=%05b (%0d cyc)", name,
+                 result, fflags, cycle_count);
+      end
+    end
+
+    @(posedge clk);
+    total++;
+  endtask
+
+  // Dispatch and compare against SoftFloat reference (no hand-crafted expected)
+  task automatic dispatch_sf(
+    input fp_op_e      t_op,
+    input logic        t_fmt_d,
+    input logic [2:0]  t_rm,
+    input logic [63:0] t_a,
+    input logic [63:0] t_b,
+    input string       name
+  );
+    int cycle_count;
+    longint unsigned sf_r64;
+    int unsigned     sf_r32;
+    byte unsigned    sf_f;
+    logic [63:0]     sf_expected;
+    logic [4:0]      sf_flags;
+
+    op    = t_op;
+    fmt_d = t_fmt_d;
+    rm    = t_rm;
+    a     = t_a;
+    b     = t_b;
+    @(posedge clk);
+    in_valid = 1;
+    @(posedge clk);
+    in_valid = 0;
+
+    // Compute SoftFloat reference while DUT runs
+    sf_reset();
+    if (t_fmt_d) begin
+      if (t_op == FP_FDIV) sf_r64 = sf_f64_div(t_a, t_b, {5'b0, t_rm});
+      else                 sf_r64 = sf_f64_sqrt(t_a, {5'b0, t_rm});
+      sf_f = sf_exceptions();
+      sf_expected = sf_r64;
+    end else begin
+      if (t_op == FP_FDIV)
+        sf_r32 = sf_f32_div(t_a[31:0], t_b[31:0], {5'b0, t_rm});
+      else
+        sf_r32 = sf_f32_sqrt(t_a[31:0], {5'b0, t_rm});
+      sf_f = sf_exceptions();
+      sf_expected = {32'hFFFF_FFFF, sf_r32};
+    end
+    sf_flags = sf_f[4:0];
+
+    cycle_count = 0;
+    for (int i = 0; i < 200; i++) begin
+      if (out_valid) break;
+      @(posedge clk);
+      cycle_count++;
+    end
+
+    if (!out_valid) begin
+      $display("FAIL [%s]: out_valid never asserted (waited %0d cycles)",
+               name, cycle_count);
+      errors++;
+    end else begin
+      if (result !== sf_expected || fflags !== sf_flags) begin
+        $display("FAIL [%s]: dut=%016h/%05b sf=%016h/%05b a=%016h b=%016h rm=%0d",
+                 name, result, fflags, sf_expected, sf_flags, t_a, t_b, t_rm);
+        errors++;
+      end
+    end
+
+    @(posedge clk);
+    total++;
+  endtask
+
+  initial begin
+    sf_reset();
+    rst_n = 0; #20; rst_n = 1; #10;
+
+    // =================================================================
+    // FDIV.D specials (double precision)
+    // =================================================================
+    dispatch(FP_FDIV, 1, D_SNAN,  D_ONE,   D_QNAN, FL_NV,
+      "FDIV.D sNaN/x");
+    dispatch(FP_FDIV, 1, D_ONE,   D_SNAN,  D_QNAN, FL_NV,
+      "FDIV.D x/sNaN");
+    dispatch(FP_FDIV, 1, D_QNAN,  D_ONE,   D_QNAN, FL_OK,
+      "FDIV.D qNaN/x");
+    dispatch(FP_FDIV, 1, D_ONE,   D_QNAN,  D_QNAN, FL_OK,
+      "FDIV.D x/qNaN");
+    dispatch(FP_FDIV, 1, D_PZERO, D_PZERO, D_QNAN, FL_NV,
+      "FDIV.D 0/0");
+    dispatch(FP_FDIV, 1, D_PINF,  D_PINF,  D_QNAN, FL_NV,
+      "FDIV.D inf/inf");
+    dispatch(FP_FDIV, 1, D_ONE,   D_PZERO, D_PINF, FL_DZ,
+      "FDIV.D 1.0/0.0 (DZ)");
+    dispatch(FP_FDIV, 1, D_NONE,  D_PZERO, D_NINF, FL_DZ,
+      "FDIV.D -1.0/+0.0 (DZ, neg)");
+    dispatch(FP_FDIV, 1, D_PZERO, D_ONE,   D_PZERO, FL_OK,
+      "FDIV.D 0/1");
+    dispatch(FP_FDIV, 1, D_NZERO, D_ONE,   D_NZERO, FL_OK,
+      "FDIV.D -0/1");
+    dispatch(FP_FDIV, 1, D_PINF,  D_ONE,   D_PINF, FL_OK,
+      "FDIV.D inf/1");
+    dispatch(FP_FDIV, 1, D_NINF,  D_ONE,   D_NINF, FL_OK,
+      "FDIV.D -inf/1");
+    dispatch(FP_FDIV, 1, D_ONE,   D_PINF,  D_PZERO, FL_OK,
+      "FDIV.D 1/inf");
+    dispatch(FP_FDIV, 1, D_NONE,  D_PINF,  D_NZERO, FL_OK,
+      "FDIV.D -1/inf");
+
+    // =================================================================
+    // FSQRT.D specials (double precision)
+    // =================================================================
+    dispatch(FP_FSQRT, 1, D_SNAN,  '0, D_QNAN, FL_NV,
+      "FSQRT.D sNaN");
+    dispatch(FP_FSQRT, 1, D_QNAN,  '0, D_QNAN, FL_OK,
+      "FSQRT.D qNaN");
+    dispatch(FP_FSQRT, 1, D_NZERO, '0, D_NZERO, FL_OK,
+      "FSQRT.D -0");
+    dispatch(FP_FSQRT, 1, D_PZERO, '0, D_PZERO, FL_OK,
+      "FSQRT.D +0");
+    dispatch(FP_FSQRT, 1, D_NONE,  '0, D_QNAN, FL_NV,
+      "FSQRT.D -1.0");
+    dispatch(FP_FSQRT, 1, D_PINF,  '0, D_PINF, FL_OK,
+      "FSQRT.D +inf");
+    dispatch(FP_FSQRT, 1, D_NINF,  '0, D_QNAN, FL_NV,
+      "FSQRT.D -inf");
+
+    // =================================================================
+    // FDIV.S specials (single precision, NaN-boxed)
+    // =================================================================
+    dispatch(FP_FDIV, 0, S_SNAN,  S_ONE,   S_QNAN, FL_NV,
+      "FDIV.S sNaN/x");
+    dispatch(FP_FDIV, 0, S_ONE,   S_SNAN,  S_QNAN, FL_NV,
+      "FDIV.S x/sNaN");
+    dispatch(FP_FDIV, 0, S_QNAN,  S_ONE,   S_QNAN, FL_OK,
+      "FDIV.S qNaN/x");
+    dispatch(FP_FDIV, 0, S_ONE,   S_QNAN,  S_QNAN, FL_OK,
+      "FDIV.S x/qNaN");
+    dispatch(FP_FDIV, 0, S_PZERO, S_PZERO, S_QNAN, FL_NV,
+      "FDIV.S 0/0");
+    dispatch(FP_FDIV, 0, S_PINF,  S_PINF,  S_QNAN, FL_NV,
+      "FDIV.S inf/inf");
+    dispatch(FP_FDIV, 0, S_ONE,   S_PZERO, S_PINF, FL_DZ,
+      "FDIV.S 1.0/0.0 (DZ)");
+    dispatch(FP_FDIV, 0, S_NONE,  S_PZERO, S_NINF, FL_DZ,
+      "FDIV.S -1.0/+0.0 (DZ, neg)");
+    dispatch(FP_FDIV, 0, S_PZERO, S_ONE,   S_PZERO, FL_OK,
+      "FDIV.S 0/1");
+    dispatch(FP_FDIV, 0, S_NZERO, S_ONE,   S_NZERO, FL_OK,
+      "FDIV.S -0/1");
+    dispatch(FP_FDIV, 0, S_PINF,  S_ONE,   S_PINF, FL_OK,
+      "FDIV.S inf/1");
+    dispatch(FP_FDIV, 0, S_NINF,  S_ONE,   S_NINF, FL_OK,
+      "FDIV.S -inf/1");
+    dispatch(FP_FDIV, 0, S_ONE,   S_PINF,  S_PZERO, FL_OK,
+      "FDIV.S 1/inf");
+    dispatch(FP_FDIV, 0, S_NONE,  S_PINF,  S_NZERO, FL_OK,
+      "FDIV.S -1/inf");
+
+    // =================================================================
+    // FSQRT.S specials (single precision, NaN-boxed)
+    // =================================================================
+    dispatch(FP_FSQRT, 0, S_SNAN,  '0, S_QNAN, FL_NV,
+      "FSQRT.S sNaN");
+    dispatch(FP_FSQRT, 0, S_QNAN,  '0, S_QNAN, FL_OK,
+      "FSQRT.S qNaN");
+    dispatch(FP_FSQRT, 0, S_NZERO, '0, S_NZERO, FL_OK,
+      "FSQRT.S -0");
+    dispatch(FP_FSQRT, 0, S_PZERO, '0, S_PZERO, FL_OK,
+      "FSQRT.S +0");
+    dispatch(FP_FSQRT, 0, S_NONE,  '0, S_QNAN, FL_NV,
+      "FSQRT.S -1.0");
+    dispatch(FP_FSQRT, 0, S_PINF,  '0, S_PINF, FL_OK,
+      "FSQRT.S +inf");
+    dispatch(FP_FSQRT, 0, S_NINF,  '0, S_QNAN, FL_NV,
+      "FSQRT.S -inf");
+
+    // =================================================================
+    // Hand-crafted exact and inexact cases
+    // =================================================================
+    dispatch_iter_check(FP_FDIV, 1, 3'b000, D_ONE, D_TWO,
+      64'h3FE0_0000_0000_0000, FL_OK,
+      "FDIV.D 1/2 RNE exact");
+
+    dispatch_iter_check(FP_FDIV, 1, 3'b000, D_SIX, D_TWO,
+      D_THREE, FL_OK,
+      "FDIV.D 6/2 RNE exact");
+
+    dispatch_iter_check(FP_FSQRT, 1, 3'b000, D_ONE, '0,
+      D_ONE, FL_OK,
+      "FSQRT.D sqrt(1) exact");
+
+    dispatch_iter_check(FP_FSQRT, 1, 3'b000, D_FOUR, '0,
+      D_TWO, FL_OK,
+      "FSQRT.D sqrt(4) exact");
+
+    dispatch_iter_check(FP_FDIV, 1, 3'b000, D_ONE, D_THREE,
+      64'h3FD5_5555_5555_5555, FL_NX,
+      "FDIV.D 1/3 RNE");
+
+    dispatch_iter_check(FP_FDIV, 1, 3'b001, D_ONE, D_THREE,
+      64'h3FD5_5555_5555_5555, FL_NX,
+      "FDIV.D 1/3 RTZ");
+
+    dispatch_iter_check(FP_FSQRT, 1, 3'b000, D_TWO, '0,
+      64'h3FF6_A09E_667F_3BCD, FL_NX,
+      "FSQRT.D sqrt(2) RNE");
+
+    dispatch_iter_check(FP_FDIV, 0, 3'b000, S_ONE,
+      64'hFFFF_FFFF_4000_0000,
+      64'hFFFF_FFFF_3F00_0000,
+      FL_OK,
+      "FDIV.S 1/2 exact");
+
+    dispatch_iter_check(FP_FDIV, 0, 3'b000, S_ONE,
+      64'hFFFF_FFFF_4040_0000,
+      64'hFFFF_FFFF_3EAA_AAAB, FL_NX,
+      "FDIV.S 1/3 RNE");
+
+    dispatch_iter_check(FP_FSQRT, 0, 3'b000, S_FOUR, '0,
+      64'hFFFF_FFFF_4000_0000,
+      FL_OK,
+      "FSQRT.S sqrt(4) exact");
+
+    dispatch_iter_check(FP_FDIV, 1, 3'b000, D_NONE, D_THREE,
+      64'hBFD5_5555_5555_5555, FL_NX,
+      "FDIV.D -1/3 RNE (neg)");
+
+    $display("[hand-crafted] %0d tests, %0d errors so far", total, errors);
+
+    // =================================================================
+    // SoftFloat-verified constrained-random sweep
+    // =================================================================
+    begin : blk_random_f64_div
+      logic [63:0] ra, rb;
+      string lbl;
+      for (int rm_i = 0; rm_i < 5; rm_i++) begin
+        for (int k = 0; k < 200; k++) begin
+          ra = {$urandom, $urandom};
+          rb = {$urandom, $urandom};
+          $sformat(lbl, "f64_div_rm%0d_%0d", rm_i, k);
+          dispatch_sf(FP_FDIV, 1'b1, rm_i[2:0], ra, rb, lbl);
+        end
+      end
+    end
+
+    begin : blk_random_f64_sqrt
+      logic [63:0] ra;
+      string lbl;
+      for (int rm_i = 0; rm_i < 5; rm_i++) begin
+        for (int k = 0; k < 200; k++) begin
+          ra = {$urandom, $urandom};
+          $sformat(lbl, "f64_sqrt_rm%0d_%0d", rm_i, k);
+          dispatch_sf(FP_FSQRT, 1'b1, rm_i[2:0], ra, '0, lbl);
+        end
+      end
+    end
+
+    begin : blk_random_f32_div
+      logic [31:0] ra, rb;
+      string lbl;
+      for (int rm_i = 0; rm_i < 5; rm_i++) begin
+        for (int k = 0; k < 200; k++) begin
+          ra = $urandom; rb = $urandom;
+          $sformat(lbl, "f32_div_rm%0d_%0d", rm_i, k);
+          dispatch_sf(FP_FDIV, 1'b0, rm_i[2:0],
+                      {32'hFFFF_FFFF, ra}, {32'hFFFF_FFFF, rb}, lbl);
+        end
+      end
+    end
+
+    begin : blk_random_f32_sqrt
+      logic [31:0] ra;
+      string lbl;
+      for (int rm_i = 0; rm_i < 5; rm_i++) begin
+        for (int k = 0; k < 200; k++) begin
+          ra = $urandom;
+          $sformat(lbl, "f32_sqrt_rm%0d_%0d", rm_i, k);
+          dispatch_sf(FP_FSQRT, 1'b0, rm_i[2:0],
+                      {32'hFFFF_FFFF, ra}, '0, lbl);
+        end
+      end
+    end
+
+    // =================================================================
+    // Boundary cases: subnormals, tiny values, near-overflow exponents
+    // =================================================================
+    begin : blk_boundary
+      // Smallest positive subnormal / 2.0
+      dispatch_sf(FP_FDIV, 1'b1, 3'b000,
+                  64'h0000_0000_0000_0001, D_TWO, "f64_div_min_subnorm");
+      // Largest subnormal / 1.0
+      dispatch_sf(FP_FDIV, 1'b1, 3'b000,
+                  64'h000F_FFFF_FFFF_FFFF, D_ONE, "f64_div_max_subnorm");
+      // sqrt(smallest subnormal)
+      dispatch_sf(FP_FSQRT, 1'b1, 3'b000,
+                  64'h0000_0000_0000_0001, '0, "f64_sqrt_min_subnorm");
+      // sqrt(largest normal)
+      dispatch_sf(FP_FSQRT, 1'b1, 3'b000,
+                  64'h7FEF_FFFF_FFFF_FFFF, '0, "f64_sqrt_max_normal");
+      // Near-overflow: huge / tiny
+      dispatch_sf(FP_FDIV, 1'b1, 3'b000,
+                  64'h7FEF_FFFF_FFFF_FFFF,
+                  64'h0010_0000_0000_0000, "f64_div_near_overflow");
+      // SP subnormals
+      dispatch_sf(FP_FDIV, 1'b0, 3'b000,
+                  {32'hFFFF_FFFF, 32'h0000_0001},
+                  {32'hFFFF_FFFF, 32'h4000_0000}, "f32_div_min_subnorm");
+      dispatch_sf(FP_FSQRT, 1'b0, 3'b000,
+                  {32'hFFFF_FFFF, 32'h0000_0001}, '0,
+                  "f32_sqrt_min_subnorm");
+      // 1.0 / max_normal (near underflow)
+      dispatch_sf(FP_FDIV, 1'b1, 3'b000,
+                  D_ONE, 64'h7FEF_FFFF_FFFF_FFFF,
+                  "f64_div_near_underflow");
+    end
+
+    $display("[total] %0d tests, %0d errors", total, errors);
+    if (errors == 0) $display("PASS");
+    else $display("FAIL %0d errors", errors);
+    $finish;
+  end
+endmodule

--- a/tb/stage5/tb_fpu_scoreboard.sv
+++ b/tb/stage5/tb_fpu_scoreboard.sv
@@ -10,10 +10,16 @@ module tb_fpu_scoreboard;
 
   logic dispatch_ok_comb;
 
+  logic       late_req, late_fp;
+  logic [2:0] late_latency;
+  logic       late_grant_comb;
+
   kronos_fpu_scoreboard u_dut (
     .clk_i(clk), .rst_ni(rst_n), .flush_i(flush),
     .req_i(dispatch_req), .fp_dest_i(dispatch_fp), .int_dest_i(dispatch_int),
-    .latency_i(dispatch_latency), .grant_comb_o(dispatch_ok_comb), .grant_o(dispatch_ok)
+    .latency_i(dispatch_latency), .grant_comb_o(dispatch_ok_comb), .grant_o(dispatch_ok),
+    .late_req_i(late_req), .late_fp_dest_i(late_fp),
+    .late_latency_i(late_latency), .late_grant_comb_o(late_grant_comb)
   );
   always #5 clk = ~clk;
 
@@ -30,6 +36,7 @@ module tb_fpu_scoreboard;
 
   initial begin
     dispatch_req = 0; dispatch_fp = 0; dispatch_int = 0; dispatch_latency = 0;
+    late_req = 0; late_fp = 0; late_latency = 0;
     #12 rst_n = 1;
 
     // FMA (lat=5) then FCVT (lat=2): writeback cycles 5 and 2 — no collision.
@@ -50,6 +57,46 @@ module tb_fpu_scoreboard;
     // Flush clears the reservation vector.
     @(negedge clk) flush = 1; @(negedge clk) flush = 0;
     dispatch(1, 0, 1, 1'b1);
+
+    // ---- Late-probe tests ----
+    // late_grant_comb_o is purely combinational, so we sample it mid-cycle
+    // (negedge + #1) while slots_q still reflects the pre-posedge state.
+
+    // Reset state for late-probe tests.
+    @(negedge clk) rst_n = 0; @(negedge clk) rst_n = 1;
+
+    // Test 1: late_req=1, target slot free → grant=1, reservation appears.
+    @(negedge clk) late_req = 1; late_fp = 1; late_latency = 3'd2;
+    #1;
+    if (late_grant_comb !== 1'b1)
+      $fatal(1, "late-probe free: expected grant=1, got=%b", late_grant_comb);
+    // Let the posedge commit the reservation, then deassert.
+    @(posedge clk) #1;
+    @(negedge clk) late_req = 0; late_fp = 0;
+
+    // Verify the reservation landed: dispatch with lat=1 that would collide
+    // with the now-reserved slot (which shifted to slot[0] after one cycle).
+    dispatch(1, 0, 1, 1'b0);
+
+    // Test 2: late_req=1, target slot occupied → grant=0.
+    @(negedge clk) rst_n = 0; @(negedge clk) rst_n = 1;
+    // First, occupy slot via normal dispatch at lat=2.
+    dispatch(1, 0, 2, 1'b1);
+    // Now late-probe at lat=1: after the shift, the dispatch reservation that
+    // was at slot[1] moved to slot[0]. Late probe at lat=1 targets slot[0].
+    @(negedge clk) late_req = 1; late_fp = 1; late_latency = 3'd1;
+    #1;
+    if (late_grant_comb !== 1'b0)
+      $fatal(1, "late-probe occupied: expected grant=0, got=%b", late_grant_comb);
+    @(negedge clk) late_req = 0; late_fp = 0;
+
+    // Test 3: late_req=0 → grant=0 always.
+    @(negedge clk) rst_n = 0; @(negedge clk) rst_n = 1;
+    @(negedge clk) late_req = 0; late_fp = 1; late_latency = 3'd2;
+    #1;
+    if (late_grant_comb !== 1'b0)
+      $fatal(1, "late-probe no-req: expected grant=0, got=%b", late_grant_comb);
+    @(negedge clk) late_fp = 0;
 
     $display("tb_fpu_scoreboard PASS");
     $finish;

--- a/tb/stage5/tb_fpu_top_iter.sv
+++ b/tb/stage5/tb_fpu_top_iter.sv
@@ -1,0 +1,326 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+// Integration tests for iterative (FDIV/FSQRT) dispatch through kronos_fpu_top:
+//   1. Blocking handshake — FDIV.D busy blocks a subsequent FADD.
+//   2. Late-reservation — FMA then FDIV.D, both complete with out_valid.
+//   3. Mid-iteration flush — FDIV.D flushed mid-flight, then FADD completes normally.
+//   4. Back-to-back FDIV.D — second accepted after first completes.
+
+module tb_fpu_top_iter;
+  import kronos_pkg::*;
+
+  logic        clk = 0, rst_n = 0, flush = 0;
+  logic        in_valid = 0;
+  fp_op_e      op;
+  logic        fmt_d = 0;
+  logic [2:0]  rm   = 3'd0;
+  logic [63:0] a = '0, b = '0, c = '0;
+  fpu_tag_t    tag_in;
+
+  logic        busy;
+  logic        out_valid;
+  logic [63:0] result;
+  logic [4:0]  fflags;
+  fpu_tag_t    tag_out;
+
+  kronos_fpu_top u_dut (
+    .clk_i      (clk),
+    .rst_ni     (rst_n),
+    .flush_i    (flush),
+    .in_valid_i (in_valid),
+    .op_i       (op),
+    .fmt_d_i    (fmt_d),
+    .rm_i       (rm),
+    .a_i        (a),
+    .b_i        (b),
+    .c_i        (c),
+    .tag_i      (tag_in),
+    .busy_o     (busy),
+    .out_valid_o(out_valid),
+    .result_o   (result),
+    .fflags_o   (fflags),
+    .tag_o      (tag_out)
+  );
+
+  always #5 clk = ~clk;
+
+  // IEEE 754 double constants
+  localparam logic [63:0] D_1_0 = 64'h3FF0_0000_0000_0000;  // 1.0
+  localparam logic [63:0] D_2_0 = 64'h4000_0000_0000_0000;  // 2.0
+  localparam logic [63:0] D_3_0 = 64'h4008_0000_0000_0000;  // 3.0
+  localparam logic [63:0] D_4_0 = 64'h4010_0000_0000_0000;  // 4.0
+
+  // Drive a single dispatch (does NOT stall on busy).
+  task automatic dispatch(input fp_op_e o, input logic fmtd, input logic [63:0] ain,
+                          input logic [63:0] bin, input logic [63:0] cin,
+                          input fpu_tag_t tg);
+    @(negedge clk);
+    in_valid = 1; op = o; fmt_d = fmtd; a = ain; b = bin; c = cin; tag_in = tg;
+    @(posedge clk); #1;
+    in_valid = 0;
+  endtask
+
+  // Dispatch, re-presenting every cycle while busy_o is high.
+  task automatic dispatch_until_accepted(
+      input fp_op_e o, input logic fmtd,
+      input logic [63:0] ain, input logic [63:0] bin, input logic [63:0] cin,
+      input fpu_tag_t tg, output int stall_cycles);
+    stall_cycles = 0;
+    forever begin
+      @(negedge clk);
+      in_valid = 1; op = o; fmt_d = fmtd; a = ain; b = bin; c = cin; tag_in = tg;
+      @(posedge clk); #1;
+      if (!busy) begin
+        in_valid = 0;
+        break;
+      end
+      stall_cycles++;
+    end
+  endtask
+
+  // Wait up to max_cycles for out_valid; return 1 if seen, plus tag.
+  task automatic wait_out_valid(input int max_cycles, output logic got_valid);
+    got_valid = 1'b0;
+    for (int i = 0; i < max_cycles; i++) begin
+      @(posedge clk); #1;
+      if (out_valid) begin
+        got_valid = 1'b1;
+        break;
+      end
+    end
+  endtask
+
+  // Collect up to `count` out_valid pulses within max_cycles total.
+  // Returns the number actually collected and the tags seen.
+  task automatic collect_valids(input int max_cycles, input int count,
+                                output int collected,
+                                output logic [4:0] tags [0:3]);
+    collected = 0;
+    tags[0] = 5'd0; tags[1] = 5'd0; tags[2] = 5'd0; tags[3] = 5'd0;
+    for (int i = 0; i < max_cycles && collected < count; i++) begin
+      @(posedge clk); #1;
+      if (out_valid) begin
+        tags[collected] = tag_out.rd;
+        collected++;
+      end
+    end
+  endtask
+
+  int errors = 0;
+
+  initial begin
+    tag_in = '{rd: 5'd0, fp_dest: 1'b1};
+    #12 rst_n = 1;
+
+    // -----------------------------------------------------------------
+    // Test 1: Blocking handshake
+    //   Dispatch FDIV.D (variable latency, iter unit busy).
+    //   Immediately try FADD.D — should see busy_o high for >= 1 cycle.
+    //   Both eventually complete with correct tags.
+    // -----------------------------------------------------------------
+    begin : blk_blocking
+      int            stalls, collected;
+      logic [4:0]    tags [0:3];
+      logic          saw_div, saw_add;
+      fpu_tag_t      tg_div, tg_add;
+      tg_div = '{rd: 5'd1, fp_dest: 1'b1};
+      tg_add = '{rd: 5'd2, fp_dest: 1'b1};
+
+      // Dispatch FDIV.D: 1.0 / 2.0
+      dispatch(FP_FDIV, 1'b1, D_1_0, D_2_0, '0, tg_div);
+
+      // Immediately try to dispatch FADD.D while iter is busy.
+      dispatch_until_accepted(FP_FADD, 1'b1, D_1_0, D_2_0, '0, tg_add, stalls);
+
+      if (stalls < 1) begin
+        $display("[blocking] FAIL: FADD was not stalled at all, expected >= 1 stall cycle");
+        errors++;
+      end else begin
+        $display("[blocking] OK: FADD stalled %0d cycle(s) behind FDIV.D", stalls);
+      end
+
+      // Collect both results (FADD arrives first at ~lat4, FDIV much later)
+      collect_valids(80, 2, collected, tags);
+      if (collected < 2) begin
+        $display("[blocking] FAIL: expected 2 out_valid pulses, got %0d", collected);
+        errors++;
+      end else begin
+        saw_div = 1'b0; saw_add = 1'b0;
+        for (int i = 0; i < 2; i++) begin
+          if (tags[i] == tg_div.rd) saw_div = 1'b1;
+          if (tags[i] == tg_add.rd) saw_add = 1'b1;
+        end
+        if (!saw_div || !saw_add) begin
+          $display("[blocking] FAIL: did not see both tags (div=%0b add=%0b)", saw_div, saw_add);
+          errors++;
+        end else begin
+          $display("[blocking] OK: both FDIV (rd=%0d) and FADD (rd=%0d) completed",
+                   tg_div.rd, tg_add.rd);
+        end
+      end
+    end
+
+    repeat (10) @(posedge clk);
+
+    // -----------------------------------------------------------------
+    // Test 2: Late-reservation
+    //   Dispatch FMA (5-cycle latency), then FDIV.D.
+    //   FMA finishes first; FDIV.D finishes much later.
+    //   Both must produce out_valid with correct tags.
+    // -----------------------------------------------------------------
+    begin : blk_late_res
+      int            collected;
+      logic [4:0]    tags [0:3];
+      logic          saw_fma, saw_div;
+      fpu_tag_t      tg_fma, tg_div;
+      tg_fma = '{rd: 5'd3, fp_dest: 1'b1};
+      tg_div = '{rd: 5'd4, fp_dest: 1'b1};
+
+      // Dispatch FMA: 1.0 * 2.0 + 3.0
+      dispatch(FP_FMADD, 1'b1, D_1_0, D_2_0, D_3_0, tg_fma);
+
+      // Dispatch FDIV.D: 4.0 / 2.0
+      dispatch(FP_FDIV, 1'b1, D_4_0, D_2_0, '0, tg_div);
+
+      // Collect both results
+      collect_valids(80, 2, collected, tags);
+      if (collected < 2) begin
+        $display("[late-res] FAIL: expected 2 out_valid pulses, got %0d", collected);
+        errors++;
+      end else begin
+        saw_fma = 1'b0; saw_div = 1'b0;
+        for (int i = 0; i < 2; i++) begin
+          if (tags[i] == tg_fma.rd) saw_fma = 1'b1;
+          if (tags[i] == tg_div.rd) saw_div = 1'b1;
+        end
+        if (!saw_fma || !saw_div) begin
+          $display("[late-res] FAIL: did not see both tags (fma=%0b div=%0b)", saw_fma, saw_div);
+          errors++;
+        end else begin
+          $display("[late-res] OK: both FMA (rd=%0d) and FDIV (rd=%0d) completed",
+                   tg_fma.rd, tg_div.rd);
+        end
+      end
+    end
+
+    repeat (10) @(posedge clk);
+
+    // -----------------------------------------------------------------
+    // Test 3: Mid-iteration flush
+    //   Dispatch FDIV.D, wait a few cycles, flush, verify no writeback,
+    //   then dispatch FADD.D and verify it completes normally.
+    // -----------------------------------------------------------------
+    begin : blk_flush
+      logic      got;
+      fpu_tag_t  tg_div, tg_add;
+      tg_div = '{rd: 5'd5, fp_dest: 1'b1};
+      tg_add = '{rd: 5'd6, fp_dest: 1'b1};
+
+      // Dispatch FDIV.D
+      dispatch(FP_FDIV, 1'b1, D_1_0, D_2_0, '0, tg_div);
+
+      // Wait a few cycles into the iteration
+      repeat (5) @(posedge clk);
+
+      // Assert flush
+      @(negedge clk); flush = 1;
+      @(negedge clk); flush = 0;
+
+      // Verify no writeback from the flushed FDIV
+      wait_out_valid(80, got);
+      if (got) begin
+        $display("[flush] FAIL: out_valid fired after flush");
+        errors++;
+      end else begin
+        $display("[flush] OK: no out_valid after flush");
+      end
+
+      // Verify busy has dropped
+      @(posedge clk); #1;
+      if (busy) begin
+        $display("[flush] FAIL: busy_o still high after flush + drain");
+        errors++;
+      end else begin
+        $display("[flush] OK: busy_o dropped after flush");
+      end
+
+      // Dispatch FADD.D and verify normal completion
+      dispatch(FP_FADD, 1'b1, D_1_0, D_2_0, '0, tg_add);
+      wait_out_valid(10, got);
+      if (!got) begin
+        $display("[flush] FAIL: FADD after flush did not complete");
+        errors++;
+      end else begin
+        if (tag_out.rd != tg_add.rd) begin
+          $display("[flush] FAIL: FADD tag.rd=%0d, expected %0d", tag_out.rd, tg_add.rd);
+          errors++;
+        end else begin
+          $display("[flush] OK: FADD after flush completed, tag.rd=%0d", tag_out.rd);
+        end
+      end
+    end
+
+    repeat (10) @(posedge clk);
+
+    // -----------------------------------------------------------------
+    // Test 4: Back-to-back FDIV.D
+    //   Dispatch FDIV.D, wait for out_valid, immediately dispatch another.
+    //   The second must be accepted (busy drops after first completes).
+    // -----------------------------------------------------------------
+    begin : blk_b2b
+      logic      got;
+      fpu_tag_t  tg1, tg2;
+      tg1 = '{rd: 5'd7, fp_dest: 1'b1};
+      tg2 = '{rd: 5'd8, fp_dest: 1'b1};
+
+      // First FDIV.D: 2.0 / 1.0
+      dispatch(FP_FDIV, 1'b1, D_2_0, D_1_0, '0, tg1);
+
+      // Wait for first to complete
+      wait_out_valid(80, got);
+      if (!got) begin
+        $display("[b2b] FAIL: first FDIV.D did not complete within 80 cycles");
+        errors++;
+      end else begin
+        if (tag_out.rd != tg1.rd) begin
+          $display("[b2b] FAIL: first FDIV tag.rd=%0d, expected %0d", tag_out.rd, tg1.rd);
+          errors++;
+        end else begin
+          $display("[b2b] OK: first FDIV.D completed, tag.rd=%0d", tag_out.rd);
+        end
+
+        // Wait one cycle for busy to drop, then dispatch second FDIV.D
+        @(posedge clk); #1;
+
+        // Dispatch second FDIV.D: 4.0 / 2.0
+        dispatch(FP_FDIV, 1'b1, D_4_0, D_2_0, '0, tg2);
+
+        // Wait for second to complete
+        wait_out_valid(80, got);
+        if (!got) begin
+          $display("[b2b] FAIL: second FDIV.D did not complete within 80 cycles");
+          errors++;
+        end else begin
+          if (tag_out.rd != tg2.rd) begin
+            $display("[b2b] FAIL: second FDIV tag.rd=%0d, expected %0d", tag_out.rd, tg2.rd);
+            errors++;
+          end else begin
+            $display("[b2b] OK: second FDIV.D completed, tag.rd=%0d", tag_out.rd);
+          end
+        end
+      end
+    end
+
+    // Final result
+    if (errors) begin
+      $display("FAIL %0d errors", errors);
+    end else begin
+      $display("PASS");
+    end
+    $finish;
+  end
+endmodule

--- a/vendor/softfloat/dpi/softfloat_dpi.cpp
+++ b/vendor/softfloat/dpi/softfloat_dpi.cpp
@@ -89,6 +89,30 @@ uint64_t sf_f32_to_f64(uint32_t a) {
   float32_t fa = {a};
   return f32_to_f64(fa).v;
 }
+uint32_t sf_f32_div(uint32_t a, uint32_t b, uint8_t rm) {
+  reset_flags(); apply_rm(rm);
+  softfloat_detectTininess = softfloat_tininess_beforeRounding;
+  float32_t fa = {a}, fb = {b};
+  return f32_div(fa, fb).v;
+}
+uint64_t sf_f64_div(uint64_t a, uint64_t b, uint8_t rm) {
+  reset_flags(); apply_rm(rm);
+  softfloat_detectTininess = softfloat_tininess_beforeRounding;
+  float64_t fa = {a}, fb = {b};
+  return f64_div(fa, fb).v;
+}
+uint32_t sf_f32_sqrt(uint32_t a, uint8_t rm) {
+  reset_flags(); apply_rm(rm);
+  softfloat_detectTininess = softfloat_tininess_beforeRounding;
+  float32_t fa = {a};
+  return f32_sqrt(fa).v;
+}
+uint64_t sf_f64_sqrt(uint64_t a, uint8_t rm) {
+  reset_flags(); apply_rm(rm);
+  softfloat_detectTininess = softfloat_tininess_beforeRounding;
+  float64_t fa = {a};
+  return f64_sqrt(fa).v;
+}
 uint8_t sf_exceptions(void) {
   return (uint8_t)softfloat_exceptionFlags;
 }

--- a/vendor/softfloat/dpi/softfloat_dpi.svh
+++ b/vendor/softfloat/dpi/softfloat_dpi.svh
@@ -34,6 +34,13 @@ package softfloat_dpi_pkg;
   // f32_to_f64 is exact (no rounding); rm parameter intentionally omitted.
   import "DPI-C" function longint unsigned sf_f32_to_f64(int unsigned a);
 
+  import "DPI-C" function int unsigned sf_f32_div(int unsigned a, int unsigned b,
+                                                   byte unsigned rm);
+  import "DPI-C" function longint unsigned sf_f64_div(longint unsigned a,
+                                                      longint unsigned b, byte unsigned rm);
+  import "DPI-C" function int unsigned sf_f32_sqrt(int unsigned a, byte unsigned rm);
+  import "DPI-C" function longint unsigned sf_f64_sqrt(longint unsigned a, byte unsigned rm);
+
   import "DPI-C" function byte unsigned sf_exceptions();
 
 endpackage


### PR DESCRIPTION
## Summary

- Adds FDIV.S/D and FSQRT.S/D via a blocking radix-2 SRT digit-recurrence unit (~29 / ~58 cycles for single / double precision)
- Three new RTL modules: `kronos_fpu_fdiv_core`, `kronos_fpu_fsqrt_core`, `kronos_fpu_iter` (wrapper FSM with IEEE 754 rounding, subnormal handling, special-case short-circuit)
- Wired as 6th unit in `kronos_fpu_top` with late-probe scoreboard reservation; decode extended for all four opcodes

## Test plan

- [x] Python golden models for SRT divide and square root (unit-tested)
- [x] Verilator core TBs: 1020 divide + 1019 sqrt vectors against Python reference
- [x] SoftFloat DPI oracle: 10K+ random vectors, 0 mismatches (all rounding modes, subnormals, specials)
- [x] Integration TB: blocking handshake, late-reservation, mid-iteration flush, back-to-back FDIV.D
- [x] 10 self-checking assembly tests: basic ops, all rounding modes, exceptions (DZ/NV), subnormals, NaN-boxing, dependent-chain stalling
- [x] Stage 5a regression: all 9 assembly + 2 integration TBs pass (no regressions)