### PR TITLE
fix(fpu): eliminate LATCH and UNUSEDPARAM Verilator warnings

### DIFF
--- a/rtl/stage5/fpu/kronos_fpu_fma.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fma.sv
@@ -370,14 +370,21 @@ module kronos_fpu_fma
   logic                s3_eff_sub_comb;
 
   always_comb begin
-    automatic logic signed [13:0] exp_diff;
-    automatic logic signed [13:0] shift_amt;
-    automatic logic [SUM_W-1:0]   c_extended;
-    automatic logic [SUM_W-1:0]   p_extended;
-    automatic int unsigned        sh;
-    automatic logic [SUM_W-1:0]   shifted;
-    automatic logic               sticky;
-    automatic int unsigned        i;
+    logic signed [13:0] exp_diff;
+    logic signed [13:0] shift_amt;
+    logic [SUM_W-1:0]   c_extended;
+    logic [SUM_W-1:0]   p_extended;
+    int unsigned        sh;
+    logic [SUM_W-1:0]   shifted;
+    logic               sticky;
+    int unsigned        i;
+
+    // Defaults — prevents latches in branches that don't touch these.
+    exp_diff  = '0;
+    shift_amt = '0;
+    sh        = 0;
+    shifted   = '0;
+    sticky    = 1'b0;
 
     s3_eff_sub_comb = s3_prod_sign ^ s3_addend_sign;
 

--- a/rtl/stage5/fpu/kronos_fpu_iter.sv
+++ b/rtl/stage5/fpu/kronos_fpu_iter.sv
@@ -254,8 +254,8 @@ module kronos_fpu_iter
   localparam logic [63:0] S_NZERO = 64'hFFFF_FFFF_8000_0000;
 
   // Flag bits
-  localparam logic [4:0] FL_NV = 5'b10000;
-  localparam logic [4:0] FL_DZ = 5'b01000;
+  localparam logic [4:0] FL_NV = 5'(1) << FP_FFLAG_NV;
+  localparam logic [4:0] FL_DZ = 5'(1) << FP_FFLAG_DZ;
 
   // Specials helper signals
   logic        sp_result_sign;


### PR DESCRIPTION
## Problem

Two Verilator warnings that were masked by `--Wno-UNUSED` in the kronos sim but surface when the RTL is compiled in OpenSoC's stricter lint target.

**LATCH in `kronos_fpu_fma.sv`** — the alignment `always_comb` block (S3 lane alignment) declared `shift_amt`, `sh`, `shifted`, and `sticky` with `automatic` but only assigned them in the `exp_diff >= 0` and `else` branches. The `s3_prod_zero` and `s3_c_zero` branches never touched them, so Verilator inferred latches. PR #15 cleaned `fadd`, `fmul`, and `fcvt` but missed `fma`.

**UNUSEDPARAM for `FP_FFLAG_DZ`** — added to `kronos_pkg` in stage5a for completeness, but `kronos_fpu_iter` defined its own `FL_DZ = 5'b01000` bitmask literal instead of referencing it. `FP_FFLAG_DZ` was never referenced anywhere in the RTL.

## Fix

- `kronos_fpu_fma`: drop `automatic`, hoist declarations to top of `always_comb`, add zero defaults before the `if` tree.
- `kronos_fpu_iter`: derive `FL_NV` and `FL_DZ` from `FP_FFLAG_NV` / `FP_FFLAG_DZ` via `5'(1) << FP_FFLAG_*`, eliminating the magic literals and making the package constants reachable.