### PR TITLE
fix(fpu): pipeline FADD stage 3 rounding path for timing closure at 148 MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ kronos-riscv/
 │       └── fpu/
 │           ├── kronos_fpu_fmisc.sv  # 1-cycle: FSGNJ, FMIN, FMAX, FCLASS, CMP, FMV
 │           ├── kronos_fpu_fcvt.sv   # 2-cycle: FCVT int↔FP and S↔D
-│           ├── kronos_fpu_fadd.sv   # 4-cycle: FADD/FSUB
+│           ├── kronos_fpu_fadd.sv   # 5-cycle: FADD/FSUB
 │           ├── kronos_fpu_fmul.sv   # 4-cycle: FMUL
 │           ├── kronos_fpu_fma.sv    # 5-cycle: FMADD/FMSUB/FNMADD/FNMSUB
 │           ├── kronos_fpu_scoreboard.sv # WAW busy-table + WB port reservation
@@ -150,7 +150,7 @@ cd sim && make build-s1   # stage 1 (RV32I)
 # Stage 5 FPU unit testbenches
 cd sim && make sim-fpu-fmisc   # FSGNJ/FMIN/FMAX/FCLASS/CMP/FMV
 cd sim && make sim-fpu-fcvt    # FCVT (int↔FP, S↔D)
-cd sim && make sim-fpu-fadd    # FADD/FSUB (4-stage)
+cd sim && make sim-fpu-fadd    # FADD/FSUB (5-stage)
 cd sim && make sim-fpu-fmul    # FMUL (4-stage)
 cd sim && make sim-fpu-fma     # FMA (5-stage)
 cd sim && make sim-fpu-fdiv-core   # FDIV radix-2 SRT core

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ kronos_top  (rtl/stage5/kronos_top.sv)
 └── u_fpu           kronos_fpu_top           (rtl/stage5/fpu/kronos_fpu_top.sv)       [stage 5a]
     ├── u_fmisc     kronos_fpu_fmisc         1-cycle: FSGNJ/FMIN/FMAX/FCLASS/CMP/FMV
     ├── u_fcvt      kronos_fpu_fcvt          2-cycle: FCVT
-    ├── u_fadd      kronos_fpu_fadd          4-cycle: FADD/FSUB
+    ├── u_fadd      kronos_fpu_fadd          5-cycle: FADD/FSUB
     ├── u_fmul      kronos_fpu_fmul          4-cycle: FMUL
     ├── u_fma       kronos_fpu_fma           5-cycle: FMADD/FMSUB/FNMADD/FNMSUB
     ├── u_iter      kronos_fpu_iter          variable: FDIV/FSQRT wrapper FSM          [stage 5b]
@@ -181,7 +181,7 @@ The FPU handles all F and D extension instructions. It is logically separate fro
 |------|--------|---------|------------|
 | fmisc | `kronos_fpu_fmisc` | 1 cycle | FSGNJ, FMIN, FMAX, FCLASS, FCMP, FMV.X.W, FMV.W.X, FMV.X.D, FMV.D.X |
 | fcvt | `kronos_fpu_fcvt` | 2 cycles | FCVT.W.S, FCVT.WU.S, FCVT.L.S, FCVT.LU.S, FCVT.S.W, FCVT.S.WU, FCVT.S.L, FCVT.S.LU, FCVT.S.D, FCVT.D.S, and D variants |
-| fadd | `kronos_fpu_fadd` | 4 cycles | FADD.S, FSUB.S, FADD.D, FSUB.D |
+| fadd | `kronos_fpu_fadd` | 5 cycles | FADD.S, FSUB.S, FADD.D, FSUB.D |
 | fmul | `kronos_fpu_fmul` | 4 cycles | FMUL.S, FMUL.D |
 | fma | `kronos_fpu_fma` | 5 cycles | FMADD.S, FMSUB.S, FNMADD.S, FNMSUB.S, FMADD.D, FMSUB.D, FNMADD.D, FNMSUB.D |
 | iter | `kronos_fpu_iter` | ≤ 29 (S) / ≤ 58 (D) cycles | FDIV.S, FDIV.D, FSQRT.S, FSQRT.D |

--- a/rtl/stage5/fpu/kronos_fpu_fadd.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fadd.sv
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// kronos_fpu_fadd — 4-cycle pipelined FADD/FSUB unit (S and D precision).
+// kronos_fpu_fadd — 5-cycle pipelined FADD/FSUB unit (S and D precision).
 //
 // Pipeline layout:
 //   S1  decompose/unbox operands, classify specials, apply FSUB sign flip
 //   S2  exponent difference, align smaller operand, capture G/R/S
 //   S3  add / subtract significands, normalize (leading-zero count)
-//   S4  round, pack IEEE 754, generate flags, NaN-box single result
+//   S4  subnormal flush, rounding decision, increment
+//   S5  pack IEEE 754, generate flags, NaN-box single result
 //
 // Internal representation uses a 56-bit significand (MSB is hidden 1 + mantissa
 // + 2 alignment bits) — enough to hold both S (24-bit) and D (53-bit) values
@@ -140,12 +141,30 @@ module kronos_fpu_fadd
     logic                result_zero;
   } s3_t;
 
+  typedef struct packed {
+    logic                     valid;
+    logic                     fmt_d;
+    logic [2:0]               rm;
+    fpu_tag_t                 tag;
+    logic                     is_special;
+    logic [63:0]              special_res;
+    logic [4:0]               special_flg;
+    logic                     res_sign;
+    logic                     result_zero;
+    logic signed [EXP_W-1:0]  cur_exp;
+    logic [SIG_W-1:0]         rounded_sig;
+    logic                     inexact;
+    logic                     overflow;
+    logic                     is_subnormal_out;
+  } s4_t;
+
   // ---------------------------------------------------------------------------
   // Pipeline registers
   // ---------------------------------------------------------------------------
   s1_t s1_q;
   s2_t s2_q;
   s3_t s3_q;
+  s4_t s4_q;
 
   // ===========================================================================
   // Stage 1: decompose / classify
@@ -526,90 +545,63 @@ module kronos_fpu_fadd
   end
 
   // ===========================================================================
-  // Stage 4: round, pack, flags
+  // Stage 4: subnormal flush + rounding
   // ===========================================================================
-  logic [63:0] s4_result;
-  logic [4:0]  s4_flags;
+  s4_t s4_d;
 
   always_comb begin
-    // Hoisted locals from pack / subnormal / round / overflow sub-blocks
-    int unsigned             mant_w;
-    int unsigned             exp_w;
+    int unsigned              mant_w;
     logic signed [EXP_W-1:0] emin;
     logic signed [EXP_W-1:0] emax;
-    logic signed [EXP_W-1:0] bias;
     logic signed [EXP_W-1:0] cur_exp;
     logic [SIG_W-1:0]        cur_sig;
     logic                    g, r, st;
-    int unsigned             sub_shift;
     int unsigned             i;
     logic                    lsb;
     logic                    round_up;
     logic [SIG_W-1:0]        rounded_sig;
     logic                    carry_up;
-    logic [51:0]             out_mant_d;
-    logic [22:0]             out_mant_s;
-    logic [10:0]             out_expf_d;
-    logic [7:0]              out_expf_s;
-    logic                    overflow;
-    logic                    is_subnormal_out;
-    logic                    inexact;
-    int unsigned             sh;
     logic [2:0]              grs_vec;
     logic [SIG_W:0]          incremented;
     logic [SIG_W-1:0]        mask_one;
-    logic                    to_inf;
+    int unsigned             sh;
 
-    // Defaults
-    s4_result        = '0;
-    s4_flags         = 5'd0;
+    s4_d             = '0;
     mant_w           = 0;
-    exp_w            = 0;
     emin             = '0;
     emax             = '0;
-    bias             = '0;
     cur_exp          = '0;
     cur_sig          = '0;
     g                = 1'b0;
     r                = 1'b0;
     st               = 1'b0;
-    sub_shift        = 0;
     i                = 0;
     lsb              = 1'b0;
     round_up         = 1'b0;
     rounded_sig      = '0;
     carry_up         = 1'b0;
-    out_mant_d       = '0;
-    out_mant_s       = '0;
-    out_expf_d       = '0;
-    out_expf_s       = '0;
-    overflow         = 1'b0;
-    is_subnormal_out = 1'b0;
-    inexact          = 1'b0;
-    sh               = 0;
     grs_vec          = '0;
     incremented      = '0;
     mask_one         = '0;
-    to_inf           = 1'b0;
+    sh               = 0;
 
-    if (s3_q.is_special) begin
-      s4_result = s3_q.special_res;
-      s4_flags  = s3_q.special_flg;
-    end else if (s3_q.result_zero) begin
-      if (s3_q.fmt_d) s4_result = {s3_q.res_sign, 63'd0};
-      else            s4_result = {FP_NANBOX_UPPER, s3_q.res_sign, 31'd0};
-    end else begin : pack
+    s4_d.valid       = s3_q.valid;
+    s4_d.fmt_d       = s3_q.fmt_d;
+    s4_d.rm          = s3_q.rm;
+    s4_d.tag         = s3_q.tag;
+    s4_d.is_special  = s3_q.is_special;
+    s4_d.special_res = s3_q.special_res;
+    s4_d.special_flg = s3_q.special_flg;
+    s4_d.res_sign    = s3_q.res_sign;
+    s4_d.result_zero = s3_q.result_zero;
 
+    if (!s3_q.is_special && !s3_q.result_zero) begin : round_blk
       if (s3_q.fmt_d) begin
         mant_w = 52;
-        exp_w  = 11;
-        bias   = 13'sd1023;
         emin   = -13'sd1022;
         emax   = 13'sd1023;
       end else begin
         mant_w = 23;
-        exp_w  = 8;
-        bias   = 13'sd127;
         emin   = -13'sd126;
         emax   = 13'sd127;
       end
@@ -620,17 +612,10 @@ module kronos_fpu_fadd
       r  = s3_q.round_b;
       st = s3_q.sticky;
 
-      // --- Subnormal flush: if exp < emin, shift significand right until
-      //     exp == emin, accumulating dropped bits into G/R/S.
       if (cur_exp < emin) begin
         grs_vec = {g, r, st};
         sh = {19'd0, 13'(emin - cur_exp)};
-        // Pull guard/round/sticky back into significand LSBs so we can reuse
-        // the same shifter.
-        // We'll iterate shifting right 1 bit at a time.
         for (i = 0; i < SIG_W + 3; i++) if (i < sh) begin
-          // Capture LSB into sticky, shift GRS right, load new G from current
-          // significand bit after shift.
           grs_vec[0] = grs_vec[0] | grs_vec[1];
           grs_vec[1] = grs_vec[2];
           grs_vec[2] = cur_sig[0];
@@ -642,24 +627,6 @@ module kronos_fpu_fadd
         cur_exp = emin;
       end
 
-      // --- Round ---
-      // For S, significand effective LSB sits higher in cur_sig: LSB is at bit
-      // (SIG_W-1-mant_w) above the implicit 3 alignment bits. But we already
-      // left-justify single operands with 3 lower zero bits... For S we must
-      // treat guard/round/sticky as bits just below the 24-bit significand.
-      // Because S operands were placed left-justified with zero padding in the
-      // low (SIG_W-24) bits, the guard/round/sticky bits for S came from those
-      // pad bits during alignment — same encoding applies. So we extract:
-      //   lsb at index (SIG_W - 1 - mant_w)
-      //   guard already in bit 2, round in bit 1, sticky in bit 0 for D.
-      // For S, guard/round are actually stored bits inside cur_sig BELOW the
-      // mantissa LSB — we must move them.
-      //
-      // Simplify: recompute G/R/S from cur_sig for both formats uniformly.
-      // cur_sig layout: [hidden | mant | padding (for S) | G R S]
-      //   D: SIG_W=56, 1 + 52 + 3 bits = 56. G=sig[2], R=sig[1], S=sig[0].
-      //   S: 1 + 23 + (SIG_W-1-23) = 1 + 23 + 32 padding. The mantissa LSB is
-      //      at bit 32. G=bit31, R=bit30, S=OR of bits[29:0] OR current st.
       if (!s3_q.fmt_d) begin
         g  = cur_sig[SIG_W - 1 - mant_w - 1];
         r  = cur_sig[SIG_W - 1 - mant_w - 2];
@@ -667,7 +634,6 @@ module kronos_fpu_fadd
           if (cur_sig[i]) st = 1'b1;
         end
       end
-      // LSB of kept significand.
       lsb = cur_sig[SIG_W - 1 - mant_w];
 
       round_up = 1'b0;
@@ -680,68 +646,101 @@ module kronos_fpu_fadd
         default:   round_up = 1'b0;
       endcase
 
-      // Add 1 at position (SIG_W-1-mant_w) if rounding up.
-      begin
-        mask_one = '0;
-        mask_one[SIG_W - 1 - mant_w] = 1'b1;
-        if (round_up)
-          incremented = {1'b0, cur_sig} + {1'b0, mask_one};
-        else
-          incremented = {1'b0, cur_sig};
-        carry_up    = incremented[SIG_W];
-        rounded_sig = incremented[SIG_W-1:0];
-      end
+      mask_one = '0;
+      mask_one[SIG_W - 1 - mant_w] = 1'b1;
+      if (round_up)
+        incremented = {1'b0, cur_sig} + {1'b0, mask_one};
+      else
+        incremented = {1'b0, cur_sig};
+      carry_up    = incremented[SIG_W];
+      rounded_sig = incremented[SIG_W-1:0];
 
       if (carry_up) begin
         rounded_sig = {1'b1, rounded_sig[SIG_W-1:1]};
         cur_exp     = cur_exp + 13'sd1;
       end
 
-      inexact  = g | r | st;
-      overflow = (cur_exp > emax);
+      s4_d.cur_exp          = cur_exp;
+      s4_d.rounded_sig      = rounded_sig;
+      s4_d.inexact          = g | r | st;
+      s4_d.overflow         = (cur_exp > emax);
+      s4_d.is_subnormal_out = (rounded_sig[SIG_W-1] == 1'b0);
+    end
+  end
 
-      // Subnormal determination: hidden bit (bit SIG_W-1) = 0 after rounding.
-      is_subnormal_out = (rounded_sig[SIG_W-1] == 1'b0);
+  // ===========================================================================
+  // Stage 5: pack IEEE result
+  // ===========================================================================
+  logic [63:0] s5_result;
+  logic [4:0]  s5_flags;
 
-      if (overflow) begin
-        s4_flags[FP_FFLAG_OF] = 1'b1;
-        s4_flags[FP_FFLAG_NX] = 1'b1;
-        // RTZ / (RDN for pos) / (RUP for neg) → max finite; else ±Inf.
-        begin
-          unique case (s3_q.rm)
-            FP_RM_RNE: to_inf = 1'b1;
-            FP_RM_RTZ: to_inf = 1'b0;
-            FP_RM_RDN: to_inf = s3_q.res_sign;
-            FP_RM_RUP: to_inf = !s3_q.res_sign;
-            FP_RM_RMM: to_inf = 1'b1;
-            default:   to_inf = 1'b1;
-          endcase
-          if (s3_q.fmt_d) begin
-            if (to_inf) s4_result = {s3_q.res_sign, 11'h7FF, 52'd0};
-            else        s4_result = {s3_q.res_sign, 11'h7FE, {52{1'b1}}};
-          end else begin
-            if (to_inf) s4_result = {FP_NANBOX_UPPER, s3_q.res_sign, 8'hFF, 23'd0};
-            else        s4_result = {FP_NANBOX_UPPER, s3_q.res_sign, 8'hFE, {23{1'b1}}};
-          end
+  always_comb begin
+    int unsigned              mant_w;
+    logic signed [EXP_W-1:0] bias;
+    logic [51:0]              out_mant_d;
+    logic [22:0]              out_mant_s;
+    logic [10:0]              out_expf_d;
+    logic [7:0]               out_expf_s;
+    logic                     to_inf;
+
+    s5_result  = '0;
+    s5_flags   = 5'd0;
+    mant_w     = 0;
+    bias       = '0;
+    out_mant_d = '0;
+    out_mant_s = '0;
+    out_expf_d = '0;
+    out_expf_s = '0;
+    to_inf     = 1'b0;
+
+    if (s4_q.is_special) begin
+      s5_result = s4_q.special_res;
+      s5_flags  = s4_q.special_flg;
+    end else if (s4_q.result_zero) begin
+      if (s4_q.fmt_d) s5_result = {s4_q.res_sign, 63'd0};
+      else            s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, 31'd0};
+    end else begin : pack_blk
+      if (s4_q.fmt_d) begin
+        mant_w = 52;
+        bias   = 13'sd1023;
+      end else begin
+        mant_w = 23;
+        bias   = 13'sd127;
+      end
+
+      if (s4_q.overflow) begin
+        s5_flags[FP_FFLAG_OF] = 1'b1;
+        s5_flags[FP_FFLAG_NX] = 1'b1;
+        unique case (s4_q.rm)
+          FP_RM_RNE: to_inf = 1'b1;
+          FP_RM_RTZ: to_inf = 1'b0;
+          FP_RM_RDN: to_inf = s4_q.res_sign;
+          FP_RM_RUP: to_inf = !s4_q.res_sign;
+          FP_RM_RMM: to_inf = 1'b1;
+          default:   to_inf = 1'b1;
+        endcase
+        if (s4_q.fmt_d) begin
+          if (to_inf) s5_result = {s4_q.res_sign, 11'h7FF, 52'd0};
+          else        s5_result = {s4_q.res_sign, 11'h7FE, {52{1'b1}}};
+        end else begin
+          if (to_inf) s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, 8'hFF, 23'd0};
+          else        s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, 8'hFE, {23{1'b1}}};
         end
       end else begin
-        // Normal / subnormal packing.
-        if (s3_q.fmt_d) begin
-          out_mant_d = rounded_sig[SIG_W-2 -: 52];  // 52 bits below hidden
-          if (is_subnormal_out) out_expf_d = 11'd0;
-          else                  out_expf_d = 11'(cur_exp + bias);
-          s4_result = {s3_q.res_sign, out_expf_d, out_mant_d};
+        if (s4_q.fmt_d) begin
+          out_mant_d = s4_q.rounded_sig[SIG_W-2 -: 52];
+          if (s4_q.is_subnormal_out) out_expf_d = 11'd0;
+          else                       out_expf_d = 11'(s4_q.cur_exp + bias);
+          s5_result = {s4_q.res_sign, out_expf_d, out_mant_d};
         end else begin
-          // Single: mantissa is the 23 bits just below the hidden bit.
-          out_mant_s = rounded_sig[SIG_W-2 -: 23];
-          if (is_subnormal_out) out_expf_s = 8'd0;
-          else                  out_expf_s = 8'(cur_exp + bias);
-          s4_result = {FP_NANBOX_UPPER, s3_q.res_sign, out_expf_s, out_mant_s};
+          out_mant_s = s4_q.rounded_sig[SIG_W-2 -: 23];
+          if (s4_q.is_subnormal_out) out_expf_s = 8'd0;
+          else                       out_expf_s = 8'(s4_q.cur_exp + bias);
+          s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, out_expf_s, out_mant_s};
         end
 
-        if (inexact) s4_flags[FP_FFLAG_NX] = 1'b1;
-        // Underflow (tininess after rounding) AND inexact → UF.
-        if (is_subnormal_out && inexact) s4_flags[FP_FFLAG_UF] = 1'b1;
+        if (s4_q.inexact) s5_flags[FP_FFLAG_NX] = 1'b1;
+        if (s4_q.is_subnormal_out && s4_q.inexact) s5_flags[FP_FFLAG_UF] = 1'b1;
       end
     end
   end
@@ -754,14 +753,17 @@ module kronos_fpu_fadd
       s1_q <= '0;
       s2_q <= '0;
       s3_q <= '0;
+      s4_q <= '0;
     end else begin
       s1_q <= s1_d;
       s2_q <= s2_d;
       s3_q <= s3_d;
+      s4_q <= s4_d;
       if (flush_i) begin
         s1_q.valid <= 1'b0;
         s2_q.valid <= 1'b0;
         s3_q.valid <= 1'b0;
+        s4_q.valid <= 1'b0;
       end
     end
   end
@@ -773,10 +775,10 @@ module kronos_fpu_fadd
       fflags_o    <= '0;
       tag_o       <= '0;
     end else begin
-      out_valid_o <= flush_i ? 1'b0 : s3_q.valid;
-      result_o    <= s4_result;
-      fflags_o    <= s4_flags;
-      tag_o       <= s3_q.tag;
+      out_valid_o <= flush_i ? 1'b0 : s4_q.valid;
+      result_o    <= s5_result;
+      fflags_o    <= s5_flags;
+      tag_o       <= s4_q.tag;
     end
   end
 

--- a/rtl/stage5/fpu/kronos_fpu_top.sv
+++ b/rtl/stage5/fpu/kronos_fpu_top.sv
@@ -9,7 +9,7 @@
 // Latency table (clock cycles from dispatch to out_valid):
 //   FMISC  1  (FSGNJ*, FMIN, FMAX, FCLASS, FEQ, FLT, FLE, FMV.*)
 //   FCVT   2  (FCVT.*.* integer↔FP conversions)
-//   FADD   4  (FADD, FSUB)
+//   FADD   5  (FADD, FSUB)
 //   FMUL   4  (FMUL)
 //   FMA    5  (FMADD, FMSUB, FNMADD, FNMSUB)
 //   ITER   variable (FDIV, FSQRT) — late-reservation via scoreboard
@@ -72,7 +72,7 @@ module kronos_fpu_top
       end
       FP_FADD, FP_FSUB: begin
         sel_fadd         = 1'b1;
-        dispatch_latency = 3'd4;
+        dispatch_latency = 3'd5;
       end
       FP_FMUL: begin
         sel_fmul         = 1'b1;

--- a/tb/stage5/tb_fpu_fadd.sv
+++ b/tb/stage5/tb_fpu_fadd.sv
@@ -29,8 +29,8 @@ module tb_fpu_fadd;
 
   always #5 clk = ~clk;
 
-  // Drive inputs for one cycle, then wait for output to emerge after 4 cycles.
-  task automatic apply4(input fp_op_e o, input logic fmtd, input logic [2:0] r,
+  // Drive inputs for one cycle, then wait for output to emerge after 5 cycles.
+  task automatic apply5(input fp_op_e o, input logic fmtd, input logic [2:0] r,
                         input logic [63:0] ain, input logic [63:0] bin);
     @(negedge clk);
     in_valid = 1;
@@ -41,8 +41,8 @@ module tb_fpu_fadd;
     b        = bin;
     @(negedge clk);
     in_valid = 0;
-    // Four pipeline stages → sample after 4 posedges from capture.
-    repeat (4) @(posedge clk);
+    // Five pipeline stages → sample after 5 posedges from capture.
+    repeat (5) @(posedge clk);
     #1;
   endtask
 
@@ -69,7 +69,7 @@ module tb_fpu_fadd;
         line = "";
         void'($fgets(line, fd));
         if (!fp_tb_pkg::parse_vec_line(line, v)) continue;
-        apply4(FP_FADD, 1'b0, v.rm[2:0],
+        apply5(FP_FADD, 1'b0, v.rm[2:0],
                {32'hFFFF_FFFF, v.a[31:0]},
                {32'hFFFF_FFFF, v.b[31:0]});
         sf_reset();
@@ -102,7 +102,7 @@ module tb_fpu_fadd;
         line = "";
         void'($fgets(line, fd));
         if (!fp_tb_pkg::parse_vec_line(line, v)) continue;
-        apply4(FP_FSUB, 1'b0, v.rm[2:0],
+        apply5(FP_FSUB, 1'b0, v.rm[2:0],
                {32'hFFFF_FFFF, v.a[31:0]},
                {32'hFFFF_FFFF, v.b[31:0]});
         sf_reset();
@@ -134,7 +134,7 @@ module tb_fpu_fadd;
         line = "";
         void'($fgets(line, fd));
         if (!fp_tb_pkg::parse_vec_line(line, v)) continue;
-        apply4(FP_FADD, 1'b1, v.rm[2:0], v.a, v.b);
+        apply5(FP_FADD, 1'b1, v.rm[2:0], v.a, v.b);
         sf_reset();
         sf_r = sf_f64_add(v.a, v.b, v.rm);
         sf_f = sf_exceptions();
@@ -162,7 +162,7 @@ module tb_fpu_fadd;
         // F32 ADD random
         for (int k = 0; k < 200; k++) begin
           ra = $urandom; rb = $urandom;
-          apply4(FP_FADD, 1'b0, rm_i[2:0],
+          apply5(FP_FADD, 1'b0, rm_i[2:0],
                  {32'hFFFF_FFFF, ra}, {32'hFFFF_FFFF, rb});
           sf_reset();
           sf_r32 = sf_f32_add(ra, rb, rm_i);
@@ -178,7 +178,7 @@ module tb_fpu_fadd;
         // F32 SUB random
         for (int k = 0; k < 200; k++) begin
           ra = $urandom; rb = $urandom;
-          apply4(FP_FSUB, 1'b0, rm_i[2:0],
+          apply5(FP_FSUB, 1'b0, rm_i[2:0],
                  {32'hFFFF_FFFF, ra}, {32'hFFFF_FFFF, rb});
           sf_reset();
           sf_r32 = sf_f32_sub(ra, rb, rm_i);
@@ -194,7 +194,7 @@ module tb_fpu_fadd;
         // F64 ADD random
         for (int k = 0; k < 200; k++) begin
           da = {$urandom, $urandom}; db = {$urandom, $urandom};
-          apply4(FP_FADD, 1'b1, rm_i[2:0], da, db);
+          apply5(FP_FADD, 1'b1, rm_i[2:0], da, db);
           sf_reset();
           sf_r64 = sf_f64_add(da, db, rm_i);
           sf_f = sf_exceptions();
@@ -208,7 +208,7 @@ module tb_fpu_fadd;
         // F64 SUB random
         for (int k = 0; k < 200; k++) begin
           da = {$urandom, $urandom}; db = {$urandom, $urandom};
-          apply4(FP_FSUB, 1'b1, rm_i[2:0], da, db);
+          apply5(FP_FSUB, 1'b1, rm_i[2:0], da, db);
           sf_reset();
           sf_r64 = sf_f64_sub(da, db, rm_i);
           sf_f = sf_exceptions();
@@ -224,7 +224,7 @@ module tb_fpu_fadd;
 
     // ── Directed: Inf + finite → Inf propagation ─────────────────────────
     // +Inf.S + 1.0S → +Inf.S (NaN-boxed), no flags
-    apply4(FP_FADD, 1'b0, 3'd0,
+    apply5(FP_FADD, 1'b0, 3'd0,
            {32'hFFFF_FFFF, 32'h7F80_0000},
            {32'hFFFF_FFFF, 32'h3F80_0000});
     total++;
@@ -233,7 +233,7 @@ module tb_fpu_fadd;
       errors++;
     end
     // 1.0S + (-Inf.S) → -Inf.S (NaN-boxed), no flags
-    apply4(FP_FADD, 1'b0, 3'd0,
+    apply5(FP_FADD, 1'b0, 3'd0,
            {32'hFFFF_FFFF, 32'h3F80_0000},
            {32'hFFFF_FFFF, 32'hFF80_0000});
     total++;
@@ -242,7 +242,7 @@ module tb_fpu_fadd;
       errors++;
     end
     // +Inf.D + 1.0D → +Inf.D, no flags
-    apply4(FP_FADD, 1'b1, 3'd0,
+    apply5(FP_FADD, 1'b1, 3'd0,
            64'h7FF0_0000_0000_0000,
            64'h3FF0_0000_0000_0000);
     total++;
@@ -251,7 +251,7 @@ module tb_fpu_fadd;
       errors++;
     end
     // 1.0D + (-Inf.D) → -Inf.D, no flags
-    apply4(FP_FADD, 1'b1, 3'd0,
+    apply5(FP_FADD, 1'b1, 3'd0,
            64'h3FF0_0000_0000_0000,
            64'hFFF0_0000_0000_0000);
     total++;


### PR DESCRIPTION
## Summary

- Splits the combined round+pack Stage 4 in `kronos_fpu_fadd` into two stages: S4 (subnormal flush + rounding) and S5 (IEEE pack), breaking a 30-level critical path that prevented timing closure at 148 MHz (WNS −2.157 ns on KV260)
- Advances FADD/FSUB from 4-cycle to 5-cycle latency; scoreboard `dispatch_latency` updated from `3'd4` → `3'd5`
- Updates unit testbench (`tb_fpu_fadd`) to sample at cycle 5; README and architecture doc updated

## Test Plan

- [x] `make sim-fpu-fadd` — 4034 vectors pass
- [x] `make sim-all` — 15/15 unit TBs pass
- [x] `make sim-arch-test-s5` — 303/303 RV64IMAFD ACT4 compliance tests pass

Closes #26