### PR TITLE
fix(fpu): pipeline fma/fmul/iter for timing closure at high Fmax

### DIFF
--- a/rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
@@ -6,7 +6,8 @@
 //
 // Implements the exact algorithm from srt_divide.py:
 //   1. FIRST cycle: compare a >= b, emit integer quotient bit.
-//   2. RUN cycles: shift partial remainder left, compare, emit fractional bits.
+//   2. CMP/UPD cycle pairs: shift partial remainder left, compare (CMP),
+//      then conditionally subtract (UPD), emitting fractional bits.
 //   3. n = 27 for single (fmt_d_i=0), n = 56 for double (fmt_d_i=1).
 //
 // Inputs are pre-normalized 53-bit significands (bit 52 = hidden 1).
@@ -29,11 +30,12 @@ module kronos_fpu_fdiv_core (
   // -------------------------------------------------------------------------
   // FSM encoding
   // -------------------------------------------------------------------------
-  typedef enum logic [1:0] {
-    ST_IDLE  = 2'b00,
-    ST_FIRST = 2'b01,
-    ST_RUN   = 2'b10,
-    ST_DONE  = 2'b11
+  typedef enum logic [2:0] {
+    ST_IDLE  = 3'b000,
+    ST_FIRST = 3'b001,
+    ST_CMP   = 3'b010,
+    ST_UPD   = 3'b011,
+    ST_DONE  = 3'b100
   } state_e;
 
   // -------------------------------------------------------------------------
@@ -46,11 +48,13 @@ module kronos_fpu_fdiv_core (
   // State registers
   // -------------------------------------------------------------------------
   state_e        state_q;
-  logic [53:0]   p_q;       // partial remainder (54 bits: 2*p can reach 54 bits)
-  logic [52:0]   b_q;       // latched divisor
-  logic [55:0]   q_q;       // quotient shift register
-  logic [5:0]    ctr_q;     // iteration counter
-  logic          fmt_d_q;   // latched format
+  logic [53:0]   p_q;         // partial remainder (54 bits: 2*p can reach 54 bits)
+  logic [52:0]   b_q;         // latched divisor
+  logic [55:0]   q_q;         // quotient shift register
+  logic [5:0]    ctr_q;       // iteration counter
+  logic          fmt_d_q;     // latched format
+  logic [53:0]   p_shift_q;   // registered p_q shifted left by 1
+  logic          ge_q;        // registered comparison result
 
   // -------------------------------------------------------------------------
   // Combinational signals
@@ -59,9 +63,9 @@ module kronos_fpu_fdiv_core (
   logic [53:0]   p_n;
   logic [55:0]   q_n;
   logic [5:0]    ctr_n;
-  logic [53:0]   p_shift;   // 2 * p_q (left-shifted partial remainder)
-  logic          ge;        // p >= b comparison result
-  logic [5:0]    target;    // iteration count for current format
+  logic [53:0]   p_shift;     // 2 * p_q (left-shifted partial remainder)
+  logic          ge;          // p >= b comparison result
+  logic [5:0]    target;      // iteration count for current format
 
   // -------------------------------------------------------------------------
   // Target selection
@@ -81,13 +85,10 @@ module kronos_fpu_fdiv_core (
 
     unique case (state_q)
       ST_IDLE: begin
-        if (start_i) begin
-          state_n = ST_FIRST;
-        end
+        if (start_i) state_n = ST_FIRST;
       end
 
       ST_FIRST: begin
-        // Integer bit: if p >= b, quotient bit = 1 and subtract.
         ge = (p_q >= {1'b0, b_q});
         if (ge) begin
           q_n = 56'd1;
@@ -97,33 +98,33 @@ module kronos_fpu_fdiv_core (
           p_n = p_q;
         end
         ctr_n   = 6'd1;
-        state_n = ST_RUN;
+        state_n = ST_CMP;
       end
 
-      ST_RUN: begin
-        // Shift partial remainder left by 1.
+      ST_CMP: begin
         p_shift = {p_q[52:0], 1'b0};
         ge      = (p_shift >= {1'b0, b_q});
-        if (ge) begin
+        state_n = ST_UPD;
+      end
+
+      ST_UPD: begin
+        if (ge_q) begin
           q_n = {q_q[54:0], 1'b1};
-          p_n = p_shift - {1'b0, b_q};
+          p_n = p_shift_q - {1'b0, b_q};
         end else begin
           q_n = {q_q[54:0], 1'b0};
-          p_n = p_shift;
+          p_n = p_shift_q;
         end
         ctr_n = ctr_q + 6'd1;
-        if (ctr_n == target) begin
-          state_n = ST_DONE;
-        end
+        if (ctr_n == target) state_n = ST_DONE;
+        else                  state_n = ST_CMP;
       end
 
       ST_DONE: begin
         state_n = ST_IDLE;
       end
 
-      default: begin
-        state_n = ST_IDLE;
-      end
+      default: state_n = ST_IDLE;
     endcase
 
     if (flush_i) begin
@@ -136,19 +137,25 @@ module kronos_fpu_fdiv_core (
   // -------------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      state_q <= ST_IDLE;
-      p_q     <= '0;
-      b_q     <= '0;
-      q_q     <= '0;
-      ctr_q   <= '0;
-      fmt_d_q <= 1'b0;
+      state_q   <= ST_IDLE;
+      p_q       <= '0;
+      b_q       <= '0;
+      q_q       <= '0;
+      ctr_q     <= '0;
+      fmt_d_q   <= 1'b0;
+      p_shift_q <= '0;
+      ge_q      <= 1'b0;
     end else begin
       state_q <= state_n;
       p_q     <= p_n;
       q_q     <= q_n;
       ctr_q   <= ctr_n;
 
-      // Latch inputs and clear scratch state on start.
+      if (state_q == ST_CMP) begin
+        p_shift_q <= p_shift;
+        ge_q      <= ge;
+      end
+
       if (start_i && (state_q == ST_IDLE)) begin
         p_q     <= {1'b0, a_i};
         b_q     <= b_i;

--- a/rtl/stage5/fpu/kronos_fpu_fma.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fma.sv
@@ -4,12 +4,9 @@
 
 // Single-rounded fused multiply-add for binary32 and binary64.
 // Computes +/-(a*b) +/- c with a single rounding step applied after the
-// full-precision multiply-add.  Pipelined over 5 cycles:
-//   S1 : decompose operands, decode specials, compute prod sign/exponent
-//   S2 : significand multiply (48b for S, 106b for D)
-//   S3 : align addend against product (wide sticky capture)
-//   S4 : add / subtract, leading-zero normalize, collect G/R/S
-//   S5 : round, encode result, merge special handling and flags
+// full-precision multiply-add.  Pipelined over 7 cycles:
+// S1(decompose) → S2(align+DSP) → S3(product reg) →
+//   S4(add) → S4b(LZC) → S5(shift) → S5b(round+pack) → output
 //
 // Subnormal inputs are treated like normals with zero leading bit and the
 // biased exponent bumped to the subnormal emin.  Subnormal outputs fall out of
@@ -478,6 +475,23 @@ module kronos_fpu_fma
   logic              s4_eff_sub;
   fpu_tag_t          s4_tag;
 
+  // ---------------------------------------------------------------------------
+  // Stage 4 → 4b register (after 160-bit add, before LZC)
+  // ---------------------------------------------------------------------------
+  logic              s4b_valid;
+  logic              s4b_special;
+  logic [63:0]       s4b_special_result;
+  logic [4:0]        s4b_special_flags;
+  logic              s4b_fmt_d;
+  logic [2:0]        s4b_rm;
+  logic              s4b_res_sign;
+  logic              s4b_zero;
+  logic signed [12:0] s4b_base_exp;
+  logic [SUM_W-1:0]  s4b_mag;
+  logic              s4b_eff_sub;
+  logic              s4b_prod_sign;
+  fpu_tag_t          s4b_tag;
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       s4_valid          <= 1'b0;
@@ -511,84 +525,106 @@ module kronos_fpu_fma
   end
 
   // ---------------------------------------------------------------------------
-  // Stage 4: add/subtract, leading-zero normalize
+  // Stage 4: add/subtract only (LZC moves to s4b stage)
   // ---------------------------------------------------------------------------
-  logic [SUM_W:0]      s4_sum_comb;     // 161b with room for 1-bit carry
-  logic                s4_res_sign_comb;
-  logic                s4_zero_comb;
-  logic signed [12:0]  s4_norm_exp_comb;
-  logic [SUM_W-1:0]    s4_norm_mag_comb;
+  logic [SUM_W:0]     s4_sum_comb;
+  logic               s4_res_sign_comb;
+  logic               s4_zero_comb;
+  logic [SUM_W-1:0]   s4_mag_comb;
 
   always_comb begin
-    logic [SUM_W-1:0]   diff;
-    logic [SUM_W-1:0]   mag;
-    logic               sign;
-    int                 msb_pos;
-    int unsigned        i;
-    logic signed [12:0] exp;
-    int                 ref_pos;
+    logic [SUM_W-1:0] diff;
 
-    diff    = '0;
-    mag     = '0;
-    sign    = 1'b0;
-    msb_pos = -1;
-    exp     = '0;
-    ref_pos = SUM_W - 3;  // 157
+    diff = '0;
+    s4_sum_comb      = '0;
+    s4_res_sign_comb = 1'b0;
+    s4_zero_comb     = 1'b0;
+    s4_mag_comb      = '0;
 
     if (!s4_eff_sub) begin
       s4_sum_comb = {1'b0, s4_prod_lane} + {1'b0, s4_c_lane};
-      mag         = s4_sum_comb[SUM_W-1:0];
-      sign        = s4_prod_sign;
+      s4_mag_comb = s4_sum_comb[SUM_W-1:0];
+      s4_res_sign_comb = s4_prod_sign;
     end else begin
       if (s4_prod_lane >= s4_c_lane) begin
         diff = s4_prod_lane - s4_c_lane;
-        sign = s4_prod_sign;
+        s4_res_sign_comb = s4_prod_sign;
       end else begin
         diff = s4_c_lane - s4_prod_lane;
-        sign = s4_addend_sign;
+        s4_res_sign_comb = s4_addend_sign;
       end
       s4_sum_comb = {1'b0, diff};
-      mag         = diff;
+      s4_mag_comb = diff;
     end
 
-    s4_zero_comb = (mag == '0);
-
-    // Find position of MSB (highest set bit) in mag.  If none, msb_pos = -1.
-    msb_pos = -1;
-    for (i = 0; i < SUM_W; i = i + 1) begin
-      if (mag[i] && (msb_pos < $signed(i))) msb_pos = i;
-    end
-
-    // New exponent = base_exp + (msb_pos - ref_pos).  Keep significand in mag
-    // untouched; downstream stage 5 will shift based on (msb_pos, exp).
-    if (s4_zero_comb) begin
-      exp = '0;
-      s4_norm_mag_comb = '0;
-    end else begin
-      exp = s4_base_exp + 13'(msb_pos - ref_pos);
-      s4_norm_mag_comb = mag;
-    end
-
-    s4_norm_exp_comb = exp;
-    s4_res_sign_comb = sign;
+    s4_zero_comb = (s4_mag_comb == '0);
   end
 
-  // MSB position captured for stage 5.  Recompute from mag in stage 5 via
-  // another LZC pass; but to avoid re-doing the loop there, propagate it.
-  logic [8:0] s4_msb_pos_comb;
+  // Stage 4 -> Stage 4b register
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      s4b_valid          <= 1'b0;
+      s4b_special        <= 1'b0;
+      s4b_special_result <= '0;
+      s4b_special_flags  <= '0;
+      s4b_fmt_d          <= 1'b0;
+      s4b_rm             <= '0;
+      s4b_res_sign       <= 1'b0;
+      s4b_zero           <= 1'b0;
+      s4b_base_exp       <= '0;
+      s4b_mag            <= '0;
+      s4b_eff_sub        <= 1'b0;
+      s4b_prod_sign      <= 1'b0;
+      s4b_tag            <= '0;
+    end else begin
+      s4b_valid          <= flush_i ? 1'b0 : s4_valid;
+      s4b_special        <= s4_special;
+      s4b_special_result <= s4_special_result;
+      s4b_special_flags  <= s4_special_flags;
+      s4b_fmt_d          <= s4_fmt_d;
+      s4b_rm             <= s4_rm;
+      s4b_res_sign       <= s4_res_sign_comb;
+      s4b_zero           <= s4_zero_comb;
+      s4b_base_exp       <= s4_base_exp;
+      s4b_mag            <= s4_mag_comb;
+      s4b_eff_sub        <= s4_eff_sub;
+      s4b_prod_sign      <= s4_prod_sign;
+      s4b_tag            <= s4_tag;
+    end
+  end
+
+  // ---------------------------------------------------------------------------
+  // Stage 4b: leading-zero count on registered 160-bit magnitude
+  // ---------------------------------------------------------------------------
+  logic [8:0]          s4b_msb_pos_comb;
+  logic signed [12:0]  s4b_norm_exp_comb;
+
   always_comb begin
     int        i;
     int        m;
-    i = 0;
-    m = -1;
+    logic signed [12:0] ref_pos_s;
+
+    i         = 0;
+    m         = -1;
+    ref_pos_s = 13'(SUM_W - 3);  // 157
+
+    s4b_msb_pos_comb  = 9'd0;
+    s4b_norm_exp_comb = '0;
+
     for (i = 0; i < SUM_W; i = i + 1) begin
-      if (s4_norm_mag_comb[i] && (m < $signed(i))) m = i;
+      if (s4b_mag[i] && (m < $signed(i))) m = i;
     end
-    if (m < 0) s4_msb_pos_comb = 9'd0;
-    else       s4_msb_pos_comb = m[8:0];
+
+    if (m < 0) begin
+      s4b_msb_pos_comb  = 9'd0;
+      s4b_norm_exp_comb = '0;
+    end else begin
+      s4b_msb_pos_comb  = m[8:0];
+      s4b_norm_exp_comb = s4b_base_exp + 13'(m) - ref_pos_s;
+    end
   end
 
-  // Stage 4 -> Stage 5 register
+  // Stage 4b -> Stage 5 register
   logic              s5_valid;
   logic              s5_special;
   logic [63:0]       s5_special_result;
@@ -603,6 +639,30 @@ module kronos_fpu_fma
   logic              s5_prod_sign;
   logic [8:0]        s5_msb_pos;
   fpu_tag_t          s5_tag;
+
+  // ---------------------------------------------------------------------------
+  // Stage 5 → 5b register (after barrel shift, before round)
+  // ---------------------------------------------------------------------------
+  logic              s5b_valid;
+  logic              s5b_special;
+  logic [63:0]       s5b_special_result;
+  logic [4:0]        s5b_special_flags;
+  logic              s5b_fmt_d;
+  logic [2:0]        s5b_rm;
+  logic              s5b_res_sign;
+  logic              s5b_zero;
+  logic              s5b_eff_sub;
+  logic              s5b_prod_sign;
+  logic signed [12:0] s5b_exp;
+  logic signed [12:0] s5b_exp_pre_tiny;
+  logic [52:0]        s5b_raw_sig;
+  logic               s5b_guard;
+  logic               s5b_round_b;
+  logic               s5b_sticky;
+  logic               s5b_tiny;
+  logic [SUM_W-1:0]  s5b_mag;
+  logic [31:0]        s5b_normal_shift;
+  fpu_tag_t           s5b_tag;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -621,150 +681,90 @@ module kronos_fpu_fma
       s5_msb_pos        <= '0;
       s5_tag            <= '0;
     end else begin
-      s5_valid          <= flush_i ? 1'b0 : s4_valid;
-      s5_special        <= s4_special;
-      s5_special_result <= s4_special_result;
-      s5_special_flags  <= s4_special_flags;
-      s5_fmt_d          <= s4_fmt_d;
-      s5_rm             <= s4_rm;
-      s5_res_sign       <= s4_res_sign_comb;
-      s5_zero           <= s4_zero_comb;
-      s5_norm_exp       <= s4_norm_exp_comb;
-      s5_norm_mag       <= s4_norm_mag_comb;
-      s5_eff_sub        <= s4_eff_sub;
-      s5_prod_sign      <= s4_prod_sign;
-      s5_msb_pos        <= s4_msb_pos_comb;
-      s5_tag            <= s4_tag;
+      s5_valid          <= flush_i ? 1'b0 : s4b_valid;
+      s5_special        <= s4b_special;
+      s5_special_result <= s4b_special_result;
+      s5_special_flags  <= s4b_special_flags;
+      s5_fmt_d          <= s4b_fmt_d;
+      s5_rm             <= s4b_rm;
+      s5_res_sign       <= s4b_res_sign;
+      s5_zero           <= s4b_zero;
+      s5_norm_exp       <= s4b_norm_exp_comb;
+      s5_norm_mag       <= s4b_mag;
+      s5_eff_sub        <= s4b_eff_sub;
+      s5_prod_sign      <= s4b_prod_sign;
+      s5_msb_pos        <= s4b_msb_pos_comb;
+      s5_tag            <= s4b_tag;
     end
   end
 
   // ---------------------------------------------------------------------------
-  // Stage 5: round and pack
+  // Stage 5: barrel shift + GRS extraction (round moves to s5b stage)
   // ---------------------------------------------------------------------------
-  logic [63:0] s5_result_comb;
-  logic [4:0]  s5_flags_comb;
+  logic [52:0]        s5_raw_sig_comb;
+  logic               s5_guard_comb;
+  logic               s5_round_b_comb;
+  logic               s5_sticky_comb;
+  logic signed [12:0] s5_exp_comb;
+  logic signed [12:0] s5_exp_pre_tiny_comb;
+  logic               s5_tiny_comb;
+  logic [31:0]        s5_normal_shift_comb;
 
   always_comb begin
     int unsigned        frac_w;
     int signed          bias;
     logic signed [12:0] emin;
-    logic signed [12:0] emax;
-    logic [52:0]        raw_sig;
     logic [SUM_W-1:0]   mag;
     logic signed [12:0] exp;
     logic signed [12:0] exp_pre_tiny;
-    logic               guard;
-    logic               round_b;
-    logic               sticky;
-    logic               round_up;
-    logic [53:0]        rounded_sig; // 54 bits so carry-out of rounding survives
-    logic               inexact;
-    logic               overflow_ovf;
     logic               tiny;
     int unsigned        shift_right_amt;
     int unsigned        normal_shift;
     int unsigned        i;
     logic [SUM_W-1:0]   pre_mag;
-    logic [52:0]        final_sig;
-    logic signed [12:0] final_exp;
-    logic [10:0]        exp_field_d;
-    logic [7:0]         exp_field_s;
-    // IEEE 754(b) normal-scale rounding (for UF detection):
-    //   "tininess after rounding" uses rounding with unbounded exponent
-    //   range.  If normal-scale rounding carries from all-1s mantissa up
-    //   to 2.0, the rounded value sits at exactly 2^emin and is NOT tiny.
-    logic [52:0]        raw_sig_n;
-    logic               guard_n, round_n, sticky_n;
-    logic               round_up_n;
-    logic               carry_n;
-    logic [SUM_W-1:0]   pre_mag_n;
 
-    frac_w        = 0;
-    bias          = 0;
-    emin          = '0;
-    emax          = '0;
-    raw_sig       = '0;
-    mag           = '0;
-    exp           = '0;
-    exp_pre_tiny  = '0;
-    guard         = 1'b0;
-    round_b       = 1'b0;
-    sticky        = 1'b0;
-    round_up      = 1'b0;
-    rounded_sig   = '0;
-    inexact       = 1'b0;
-    overflow_ovf  = 1'b0;
-    tiny          = 1'b0;
-    shift_right_amt = 0;
-    normal_shift  = 0;
-    i             = 0;
-    pre_mag       = '0;
-    final_sig     = '0;
-    final_exp     = '0;
-    exp_field_d   = '0;
-    exp_field_s   = '0;
-    raw_sig_n     = '0;
-    guard_n       = 1'b0;
-    round_n       = 1'b0;
-    sticky_n      = 1'b0;
-    round_up_n    = 1'b0;
-    carry_n       = 1'b0;
-    pre_mag_n     = '0;
+    frac_w           = 0;
+    bias             = 0;
+    emin             = '0;
+    mag              = '0;
+    exp              = '0;
+    exp_pre_tiny     = '0;
+    tiny             = 1'b0;
+    shift_right_amt  = 0;
+    normal_shift     = 0;
+    i                = 0;
+    pre_mag          = '0;
 
-    s5_result_comb = '0;
-    s5_flags_comb  = s5_special_flags;
+    s5_raw_sig_comb       = '0;
+    s5_guard_comb         = 1'b0;
+    s5_round_b_comb       = 1'b0;
+    s5_sticky_comb        = 1'b0;
+    s5_exp_comb           = '0;
+    s5_exp_pre_tiny_comb  = '0;
+    s5_tiny_comb          = 1'b0;
+    s5_normal_shift_comb  = '0;
 
-    if (s5_special) begin
-      s5_result_comb = s5_special_result;
-    end else if (s5_zero) begin
-      // Exact zero result. Sign rules:
-      //   - same-sign add: sign = prod_sign (== addend_sign)
-      //   - exact cancellation (eff_sub): +0 in all modes except RDN which is -0
-      if (s5_eff_sub) begin
-        if (s5_rm == FP_RM_RDN) begin
-          s5_result_comb = s5_fmt_d ? {1'b1, 63'd0}
-                                    : {FP_NANBOX_UPPER, 1'b1, 31'd0};
-        end else begin
-          s5_result_comb = s5_fmt_d ? 64'd0
-                                    : {FP_NANBOX_UPPER, 32'd0};
-        end
-      end else begin
-        // Both lanes zero or same-sign add of zeros: sign = prod_sign
-        if (s5_prod_sign) begin
-          s5_result_comb = s5_fmt_d ? {1'b1, 63'd0}
-                                    : {FP_NANBOX_UPPER, 1'b1, 31'd0};
-        end else begin
-          s5_result_comb = s5_fmt_d ? 64'd0
-                                    : {FP_NANBOX_UPPER, 32'd0};
-        end
-      end
-    end else begin
-      // Format-dependent parameters
+    if (!s5_special && !s5_zero) begin
       if (s5_fmt_d) begin
         frac_w = 52;
         bias   = D_BIAS;
-        emax   = 13'sd2046; // largest finite biased exp
       end else begin
         frac_w = 23;
         bias   = S_BIAS;
-        emax   = 13'sd254;
       end
       emin = 13'sd1;
 
       mag = s5_norm_mag;
       exp = s5_norm_exp;
 
-      // Hidden bit (MSB of mag) is at index s5_msb_pos.  Shift it down to
-      // position frac_w: shift_right_amt = msb_pos - frac_w.  For subnormal
-      // outputs (exp < emin), shift by an extra (emin - exp) and force exp=0.
       if ({1'b0, s5_msb_pos} >= 10'(frac_w))
         normal_shift = {23'd0, s5_msb_pos} - frac_w;
       else
         normal_shift = 0;
       shift_right_amt = normal_shift;
 
-      tiny = 1'b0;
       exp_pre_tiny = exp;
+      tiny = 1'b0;
       if (exp < emin) begin
         shift_right_amt = shift_right_amt + 32'(emin - exp);
         exp  = 0;
@@ -772,203 +772,311 @@ module kronos_fpu_fma
       end
 
       if (shift_right_amt >= SUM_W) begin
-        // Entire mag is sub-ulp sticky.
-        raw_sig = '0;
-        guard   = 1'b0;
-        round_b = 1'b0;
-        sticky  = (mag != '0);
+        s5_raw_sig_comb  = '0;
+        s5_guard_comb    = 1'b0;
+        s5_round_b_comb  = 1'b0;
+        s5_sticky_comb   = (mag != '0);
       end else begin
-        // raw_sig = mag[shift_right_amt + frac_w : shift_right_amt]
-        // guard   = mag[shift_right_amt - 1]
-        // round_b = mag[shift_right_amt - 2]
-        // sticky  = OR(mag[shift_right_amt-3 : 0])
         pre_mag = mag >> shift_right_amt;
-        raw_sig = pre_mag[52:0];
+        s5_raw_sig_comb = pre_mag[52:0];
 
         if (shift_right_amt == 0) begin
-          guard  = 1'b0;
-          round_b = 1'b0;
-          sticky = 1'b0;
+          s5_guard_comb   = 1'b0;
+          s5_round_b_comb = 1'b0;
+          s5_sticky_comb  = 1'b0;
         end else if (shift_right_amt == 1) begin
-          guard  = mag[0];
-          round_b = 1'b0;
-          sticky = 1'b0;
+          s5_guard_comb   = mag[0];
+          s5_round_b_comb = 1'b0;
+          s5_sticky_comb  = 1'b0;
         end else if (shift_right_amt == 2) begin
-          guard  = mag[1];
-          round_b = mag[0];
-          sticky = 1'b0;
+          s5_guard_comb   = mag[1];
+          s5_round_b_comb = mag[0];
+          s5_sticky_comb  = 1'b0;
         end else begin
-          guard  = mag[shift_right_amt - 1];
-          round_b = mag[shift_right_amt - 2];
-          sticky = 1'b0;
+          s5_guard_comb   = mag[shift_right_amt - 1];
+          s5_round_b_comb = mag[shift_right_amt - 2];
+          s5_sticky_comb  = 1'b0;
           for (i = 0; i < SUM_W; i = i + 1) begin
             if (i + 2 < shift_right_amt) begin
-              sticky = sticky | mag[i];
+              s5_sticky_comb = s5_sticky_comb | mag[i];
             end
           end
         end
       end
 
-      // Round decision
-      inexact = guard | round_b | sticky;
+      s5_exp_comb          = exp;
+      s5_exp_pre_tiny_comb = exp_pre_tiny;
+      s5_tiny_comb         = tiny;
+      s5_normal_shift_comb = normal_shift;
+    end
+  end
+
+  // Stage 5 -> Stage 5b register
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      s5b_valid          <= 1'b0;
+      s5b_special        <= 1'b0;
+      s5b_special_result <= '0;
+      s5b_special_flags  <= '0;
+      s5b_fmt_d          <= 1'b0;
+      s5b_rm             <= '0;
+      s5b_res_sign       <= 1'b0;
+      s5b_zero           <= 1'b0;
+      s5b_eff_sub        <= 1'b0;
+      s5b_prod_sign      <= 1'b0;
+      s5b_exp            <= '0;
+      s5b_exp_pre_tiny   <= '0;
+      s5b_raw_sig        <= '0;
+      s5b_guard          <= 1'b0;
+      s5b_round_b        <= 1'b0;
+      s5b_sticky         <= 1'b0;
+      s5b_tiny           <= 1'b0;
+      s5b_mag            <= '0;
+      s5b_normal_shift   <= '0;
+      s5b_tag            <= '0;
+    end else begin
+      s5b_valid          <= flush_i ? 1'b0 : s5_valid;
+      s5b_special        <= s5_special;
+      s5b_special_result <= s5_special_result;
+      s5b_special_flags  <= s5_special_flags;
+      s5b_fmt_d          <= s5_fmt_d;
+      s5b_rm             <= s5_rm;
+      s5b_res_sign       <= s5_res_sign;
+      s5b_zero           <= s5_zero;
+      s5b_eff_sub        <= s5_eff_sub;
+      s5b_prod_sign      <= s5_prod_sign;
+      s5b_exp            <= s5_exp_comb;
+      s5b_exp_pre_tiny   <= s5_exp_pre_tiny_comb;
+      s5b_raw_sig        <= s5_raw_sig_comb;
+      s5b_guard          <= s5_guard_comb;
+      s5b_round_b        <= s5_round_b_comb;
+      s5b_sticky         <= s5_sticky_comb;
+      s5b_tiny           <= s5_tiny_comb;
+      s5b_mag            <= s5_norm_mag;
+      s5b_normal_shift   <= s5_normal_shift_comb;
+      s5b_tag            <= s5_tag;
+    end
+  end
+
+  // ---------------------------------------------------------------------------
+  // Stage 5b: round, pack, overflow/underflow (old stage 5 second half)
+  // ---------------------------------------------------------------------------
+  logic [63:0] s5b_result_comb;
+  logic [4:0]  s5b_flags_comb;
+
+  always_comb begin
+    int unsigned        frac_w;
+    int signed          bias;
+    logic signed [12:0] emin;
+    logic signed [12:0] emax;
+    logic [53:0]        rounded_sig;
+    logic               inexact;
+    logic               overflow_ovf;
+    logic               round_up;
+    logic signed [12:0] final_exp;
+    logic [52:0]        final_sig;
+    logic [10:0]        exp_field_d;
+    logic [7:0]         exp_field_s;
+    // tininess-after-rounding
+    logic [52:0]        raw_sig_n;
+    logic               guard_n, round_n, sticky_n;
+    logic               round_up_n;
+    logic               carry_n;
+    logic [SUM_W-1:0]   pre_mag_n;
+    int unsigned        normal_shift;
+
+    frac_w       = 0;
+    bias         = 0;
+    emin         = '0;
+    emax         = '0;
+    rounded_sig  = '0;
+    inexact      = 1'b0;
+    overflow_ovf = 1'b0;
+    round_up     = 1'b0;
+    final_exp    = '0;
+    final_sig    = '0;
+    exp_field_d  = '0;
+    exp_field_s  = '0;
+    raw_sig_n    = '0;
+    guard_n      = 1'b0;
+    round_n      = 1'b0;
+    sticky_n     = 1'b0;
+    round_up_n   = 1'b0;
+    carry_n      = 1'b0;
+    pre_mag_n    = '0;
+    normal_shift = 0;
+
+    s5b_result_comb = '0;
+    s5b_flags_comb  = s5b_special_flags;
+
+    if (s5b_special) begin
+      s5b_result_comb = s5b_special_result;
+    end else if (s5b_zero) begin
+      if (s5b_eff_sub) begin
+        if (s5b_rm == FP_RM_RDN) begin
+          s5b_result_comb = s5b_fmt_d ? {1'b1, 63'd0}
+                                      : {FP_NANBOX_UPPER, 1'b1, 31'd0};
+        end else begin
+          s5b_result_comb = s5b_fmt_d ? 64'd0
+                                      : {FP_NANBOX_UPPER, 32'd0};
+        end
+      end else begin
+        if (s5b_prod_sign) begin
+          s5b_result_comb = s5b_fmt_d ? {1'b1, 63'd0}
+                                      : {FP_NANBOX_UPPER, 1'b1, 31'd0};
+        end else begin
+          s5b_result_comb = s5b_fmt_d ? 64'd0
+                                      : {FP_NANBOX_UPPER, 32'd0};
+        end
+      end
+    end else begin
+      if (s5b_fmt_d) begin
+        frac_w = 52;
+        bias   = D_BIAS;
+        emax   = 13'sd2046;
+      end else begin
+        frac_w = 23;
+        bias   = S_BIAS;
+        emax   = 13'sd254;
+      end
+      emin = 13'sd1;
+
+      inexact = s5b_guard | s5b_round_b | s5b_sticky;
       round_up = 1'b0;
-      unique case (s5_rm)
-        FP_RM_RNE: round_up = guard & (round_b | sticky | raw_sig[0]);
+      unique case (s5b_rm)
+        FP_RM_RNE: round_up = s5b_guard & (s5b_round_b | s5b_sticky | s5b_raw_sig[0]);
         FP_RM_RTZ: round_up = 1'b0;
-        FP_RM_RDN: round_up = inexact & s5_res_sign;
-        FP_RM_RUP: round_up = inexact & ~s5_res_sign;
-        FP_RM_RMM: round_up = guard; // round to nearest, ties away
+        FP_RM_RDN: round_up = inexact & s5b_res_sign;
+        FP_RM_RUP: round_up = inexact & ~s5b_res_sign;
+        FP_RM_RMM: round_up = s5b_guard;
         default: round_up = 1'b0;
       endcase
 
-      rounded_sig = {1'b0, raw_sig} + (round_up ? 54'd1 : 54'd0);
-      final_exp   = exp;
+      rounded_sig = {1'b0, s5b_raw_sig} + (round_up ? 54'd1 : 54'd0);
+      final_exp   = s5b_exp;
       final_sig   = rounded_sig[52:0];
 
-      // If rounding overflowed the significand (now has bit frac_w+1),
-      // shift right by 1 and bump exponent.
       if (rounded_sig[frac_w + 1]) begin
         final_sig = rounded_sig[53:1];
-        final_exp = exp + 1;
+        final_exp = s5b_exp + 1;
       end
 
-      // If subnormal rounded up to a normal number, the hidden bit will now
-      // be set at position frac_w and exponent should become emin.
-      if (tiny && final_sig[frac_w]) begin
+      if (s5b_tiny && final_sig[frac_w]) begin
         final_exp = emin;
       end
 
-      // Overflow: final_exp >= emax+1 (i.e. all-ones field)
       overflow_ovf = 1'b0;
       if (final_exp >= (emax + 13'sd1)) begin
         overflow_ovf = 1'b1;
       end
 
-      // Underflow flag: RISC-V uses "tininess after rounding" (IEEE 754
-      // alternative (b) -- round with the format precision but unbounded
-      // exponent range, then check if the rounded magnitude is strictly
-      // below 2^emin).  When the subnormal-scale rounding differs from
-      // the normal-scale rounding (i.e. when the 24/53-bit normal-scale
-      // mantissa is all ones and rounds up, carrying to 2.0), the
-      // unbounded-exponent rounded value lands exactly at 2^emin and is
-      // NOT tiny -- even though the subnormal encoding bumps to the
-      // smallest normal.
-      if (tiny && inexact) begin
-        // Extract normal-scale round bits from mag at normal_shift.
+      // Tininess-after-rounding using carried s5b_mag and s5b_normal_shift
+      if (s5b_tiny && inexact) begin
+        normal_shift = s5b_normal_shift;
         if (normal_shift >= SUM_W) begin
           raw_sig_n = '0;
           guard_n   = 1'b0;
           round_n   = 1'b0;
-          sticky_n  = (mag != '0);
+          sticky_n  = (s5b_mag != '0);
         end else begin
-          pre_mag_n = mag >> normal_shift;
+          pre_mag_n = s5b_mag >> normal_shift;
           raw_sig_n = pre_mag_n[52:0];
           if (normal_shift == 0) begin
             guard_n  = 1'b0;
             round_n  = 1'b0;
             sticky_n = 1'b0;
           end else if (normal_shift == 1) begin
-            guard_n  = mag[0];
+            guard_n  = s5b_mag[0];
             round_n  = 1'b0;
             sticky_n = 1'b0;
           end else if (normal_shift == 2) begin
-            guard_n  = mag[1];
-            round_n  = mag[0];
+            guard_n  = s5b_mag[1];
+            round_n  = s5b_mag[0];
             sticky_n = 1'b0;
           end else begin
-            guard_n  = mag[normal_shift - 1];
-            round_n  = mag[normal_shift - 2];
+            int unsigned i;
+            i = 0;
+            guard_n  = s5b_mag[normal_shift - 1];
+            round_n  = s5b_mag[normal_shift - 2];
             sticky_n = 1'b0;
             for (i = 0; i < SUM_W; i = i + 1) begin
               if (i + 2 < normal_shift) begin
-                sticky_n = sticky_n | mag[i];
+                sticky_n = sticky_n | s5b_mag[i];
               end
             end
           end
         end
 
-        unique case (s5_rm)
+        unique case (s5b_rm)
           FP_RM_RNE: round_up_n = guard_n & (round_n | sticky_n | raw_sig_n[0]);
           FP_RM_RTZ: round_up_n = 1'b0;
-          FP_RM_RDN: round_up_n = (guard_n | round_n | sticky_n) &  s5_res_sign;
-          FP_RM_RUP: round_up_n = (guard_n | round_n | sticky_n) & ~s5_res_sign;
+          FP_RM_RDN: round_up_n = (guard_n | round_n | sticky_n) &  s5b_res_sign;
+          FP_RM_RUP: round_up_n = (guard_n | round_n | sticky_n) & ~s5b_res_sign;
           FP_RM_RMM: round_up_n = guard_n;
           default:   round_up_n = 1'b0;
         endcase
 
-        // Carry-out: mantissa (hidden+fraction) is all ones and rounds up.
-        if (s5_fmt_d)
+        if (s5b_fmt_d)
           carry_n = round_up_n & (&raw_sig_n[52:0]);
         else
           carry_n = round_up_n & (&raw_sig_n[23:0]);
 
-        // Tiny after rounding iff exp_pre_tiny + carry_n < emin.
-        // `tiny` means exp_pre_tiny < emin already, so this collapses to
-        // "NOT (carry_n AND exp_pre_tiny == emin - 1)".
-        if (!(carry_n && (exp_pre_tiny + 13'sd1 == emin))) begin
-          s5_flags_comb[FP_FFLAG_UF] = 1'b1;
+        if (!(carry_n && (s5b_exp_pre_tiny + 13'sd1 == emin))) begin
+          s5b_flags_comb[FP_FFLAG_UF] = 1'b1;
         end
       end
 
-      if (inexact) s5_flags_comb[FP_FFLAG_NX] = 1'b1;
+      if (inexact) s5b_flags_comb[FP_FFLAG_NX] = 1'b1;
 
       if (overflow_ovf) begin
-        s5_flags_comb[FP_FFLAG_OF] = 1'b1;
-        s5_flags_comb[FP_FFLAG_NX] = 1'b1;
-        // Round-to-nearest and RMM: +/-inf
-        // RTZ: +/-max
-        // RDN: -inf for negative, +max for positive
-        // RUP: +inf for positive, -max for negative
-        unique case (s5_rm)
+        s5b_flags_comb[FP_FFLAG_OF] = 1'b1;
+        s5b_flags_comb[FP_FFLAG_NX] = 1'b1;
+        unique case (s5b_rm)
           FP_RM_RTZ: begin
-            if (s5_fmt_d) s5_result_comb = {s5_res_sign, 11'd2046, {52{1'b1}}};
-            else          s5_result_comb = {FP_NANBOX_UPPER,
-                                            s5_res_sign, 8'd254, {23{1'b1}}};
+            if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, 11'd2046, {52{1'b1}}};
+            else           s5b_result_comb = {FP_NANBOX_UPPER,
+                                              s5b_res_sign, 8'd254, {23{1'b1}}};
           end
           FP_RM_RDN: begin
-            if (s5_res_sign) begin
-              if (s5_fmt_d) s5_result_comb = {1'b1, 11'h7FF, 52'd0};
-              else          s5_result_comb = {FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0};
+            if (s5b_res_sign) begin
+              if (s5b_fmt_d) s5b_result_comb = {1'b1, 11'h7FF, 52'd0};
+              else           s5b_result_comb = {FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0};
             end else begin
-              if (s5_fmt_d) s5_result_comb = {1'b0, 11'd2046, {52{1'b1}}};
-              else          s5_result_comb = {FP_NANBOX_UPPER,
-                                              1'b0, 8'd254, {23{1'b1}}};
+              if (s5b_fmt_d) s5b_result_comb = {1'b0, 11'd2046, {52{1'b1}}};
+              else           s5b_result_comb = {FP_NANBOX_UPPER,
+                                               1'b0, 8'd254, {23{1'b1}}};
             end
           end
           FP_RM_RUP: begin
-            if (s5_res_sign) begin
-              if (s5_fmt_d) s5_result_comb = {1'b1, 11'd2046, {52{1'b1}}};
-              else          s5_result_comb = {FP_NANBOX_UPPER,
-                                              1'b1, 8'd254, {23{1'b1}}};
+            if (s5b_res_sign) begin
+              if (s5b_fmt_d) s5b_result_comb = {1'b1, 11'd2046, {52{1'b1}}};
+              else           s5b_result_comb = {FP_NANBOX_UPPER,
+                                               1'b1, 8'd254, {23{1'b1}}};
             end else begin
-              if (s5_fmt_d) s5_result_comb = {1'b0, 11'h7FF, 52'd0};
-              else          s5_result_comb = {FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
+              if (s5b_fmt_d) s5b_result_comb = {1'b0, 11'h7FF, 52'd0};
+              else           s5b_result_comb = {FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
             end
           end
           default: begin
-            // RNE, RMM, reserved: +/-inf
-            if (s5_fmt_d) s5_result_comb = {s5_res_sign, 11'h7FF, 52'd0};
-            else          s5_result_comb = {FP_NANBOX_UPPER,
-                                            s5_res_sign, 8'hFF, 23'd0};
+            if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, 11'h7FF, 52'd0};
+            else           s5b_result_comb = {FP_NANBOX_UPPER,
+                                             s5b_res_sign, 8'hFF, 23'd0};
           end
         endcase
       end else begin
-        // Normal encoding
-        if (s5_fmt_d) begin
+        if (s5b_fmt_d) begin
           exp_field_d = final_exp[10:0];
-          s5_result_comb = {s5_res_sign, exp_field_d, final_sig[51:0]};
+          s5b_result_comb = {s5b_res_sign, exp_field_d, final_sig[51:0]};
         end else begin
           exp_field_s = final_exp[7:0];
-          s5_result_comb = {FP_NANBOX_UPPER, s5_res_sign, exp_field_s,
-                            final_sig[22:0]};
+          s5b_result_comb = {FP_NANBOX_UPPER, s5b_res_sign, exp_field_s,
+                             final_sig[22:0]};
         end
       end
     end
   end
 
-  // ---------------------------------------------------------------------------
-  // Stage 5 register -> outputs
-  // ---------------------------------------------------------------------------
+  // Stage 5b register -> outputs
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       out_valid_o <= 1'b0;
@@ -976,10 +1084,10 @@ module kronos_fpu_fma
       fflags_o    <= '0;
       tag_o       <= '0;
     end else begin
-      out_valid_o <= flush_i ? 1'b0 : s5_valid;
-      result_o    <= s5_result_comb;
-      fflags_o    <= s5_flags_comb;
-      tag_o       <= s5_tag;
+      out_valid_o <= flush_i ? 1'b0 : s5b_valid;
+      result_o    <= s5b_result_comb;
+      fflags_o    <= s5b_flags_comb;
+      tag_o       <= s5b_tag;
     end
   end
 

--- a/rtl/stage5/fpu/kronos_fpu_fmul.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fmul.sv
@@ -2,16 +2,19 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// 4-stage pipelined IEEE 754 floating-point multiplier (single and double).
+// 6-stage pipelined IEEE 754 floating-point multiplier (single and double).
 //
 // Pipeline:
 //   S1: NaN-unbox single, decompose operands, classify specials, precompute
 //       sign / unbiased exponent sum / extended significands.
 //   S2: Multiply significands (wide multiply registered at stage boundary for
 //       DSP inference).
-//   S3: Normalize product (1x.x vs 01.x), compute guard/round/sticky, shift
-//       right for subnormals if the result exponent is non-positive.
-//   S4: Round, handle overflow/underflow, pack, NaN-box single. Register.
+//   S3: LZC only — compute 7-bit leading-zero count and normalized exponent
+//       from the 106-bit product. Carry full product forward.
+//   S3b: Normalize barrel shift — use registered LZC to shift product and
+//        extract mantissa + GRS bits.
+//   S4: Subnormal shift — apply right-shift if exp_norm <= 0, refine GRS.
+//   S5: Round, handle overflow/underflow, pack, NaN-box single. Register.
 
 module kronos_fpu_fmul
   import kronos_pkg::*;
@@ -282,40 +285,6 @@ module kronos_fpu_fmul
     end
   end
 
-  // -------------------------------------------------------------------------
-  // S3 combinational: normalize, form guard/round/sticky, subnormal shift
-  //
-  // After an SIG_W x SIG_W unsigned multiply, the product is in [0, 2^(2*SIG_W))
-  // with the leading 1 at bit [2*SIG_W-1] ("1x.xxx...") or bit [2*SIG_W-2]
-  // ("01.xxx..."). We target a normalized mantissa of the form 1.f, so:
-  //   - bit[105] = 1: shift right by (SIG_W-1) = 52. Exponent += 1.
-  //   - bit[104] = 1: shift right by (SIG_W-2) = 51. Exponent += 0.
-  // After that, we then need to collapse the low bits into GRS.
-  //
-  // We capture a normalized quantity of width SIG_W + 3 (hidden + fraction +
-  // G + R + S) = 56 bits for double, and use the upper portion for single.
-  // -------------------------------------------------------------------------
-
-  // For readability alias sizes: normalized mantissa uses top SIG_W bits of
-  // prod as {hidden, frac[D_SIG_W-1:0]} (for double) or {hidden, frac[S_SIG_W-1:0], 29 zeros}
-  // (for single). To unify, we always produce a 53-bit {hidden, frac52} plus GRS.
-
-  logic [PROD_W-1:0] s3_prod;
-  logic signed [EXP_EXT_W-1:0] s3_exp_norm_c;
-  logic [SIG_W-1:0] s3_mant_c;       // 53 bits: {1, frac52}
-  logic             s3_guard_c;
-  logic             s3_round_c;
-  logic             s3_sticky_c;
-
-  // After initial normalization (to "1.f" form across 53 bits), we may still
-  // need to right-shift for subnormals if exp <= 0.
-  logic [SIG_W-1:0] s3_mant_post_c;
-  logic             s3_guard_post_c;
-  logic             s3_round_post_c;
-  logic             s3_sticky_post_c;
-  logic signed [EXP_EXT_W-1:0] s3_exp_post_c;
-  logic             s3_is_subnormal_c;
-
   // Leading-zero count for the 106-bit product. Used to normalize products
   // whose leading 1 sits below bit 104 (subnormal input operands).
   function automatic logic [6:0] lzc106(input logic [PROD_W-1:0] x);
@@ -328,125 +297,24 @@ module kronos_fpu_fmul
     return 7'd106; // all-zero product
   endfunction
 
+  // -------------------------------------------------------------------------
+  // S3 combinational: LZC only
+  // -------------------------------------------------------------------------
+  logic [6:0] s3_lz_comb;
+  logic signed [EXP_EXT_W-1:0] s3_exp_norm_comb;
+
   always_comb begin
-    logic [6:0]  lz;
-    logic signed [EXP_EXT_W-1:0] exp_adj;
-    // Wide product, left-shifted to bring the leading 1 to bit PROD_W-2.
-    // After left-shifting by (lz-1), all products have their hidden bit at bit 104.
-    logic [PROD_W-1:0] prod_norm;
-    // Hoisted from subnormal sub-blocks
-    logic signed [EXP_EXT_W-1:0] shift_amt;
-    logic [SIG_W-1:0] mant_fullw;
-    logic g_in, r_in, s_in;
-    int unsigned sh;
-    logic [63:0] tail;
-    logic [63:0] shifted;
-    logic [63:0] lost_mask;
-
-    // Defaults
-    lz         = '0;
-    exp_adj    = '0;
-    prod_norm  = '0;
-    shift_amt  = '0;
-    mant_fullw = '0;
-    g_in       = 1'b0;
-    r_in       = 1'b0;
-    s_in       = 1'b0;
-    sh         = 0;
-    tail       = '0;
-    shifted    = '0;
-    lost_mask  = '0;
-
-    // Start from the wide product.
-    s3_prod = s2_prod_q;
-
-    // General normalization: find leading 1 and shift so that
-    // bit[PROD_W-2] (= bit 104) becomes the hidden bit.
-    // For normal*normal products the leading 1 is at bit 104 or 105.
-    // For subnormal inputs the leading 1 can be lower.
-    //
-    // lzc106 counts zeros from the MSB (bit 105).  The leading 1 is at
-    // bit (PROD_W-1-lz).  We want it at bit (PROD_W-2), so:
-    //   left shift by (lz - 1)  and  exponent -= (lz - 1).
-    // When lz == 0: leading 1 is at bit 105, left_shift = -1 → right shift by 1.
-    //   Handled as the existing "top bit" case, exp += 1.
-    // When lz == 1: leading 1 already at bit 104, no shift, exp unchanged.
-    // When lz >= 2: left shift by (lz-1), exp -= (lz-1).
-
-    lz = lzc106(s3_prod); // leading zeros from MSB (bit 105)
-
-    if (lz == 7'd0) begin
-      // leading 1 at bit 105: extract directly without using prod_norm shift.
-      // prod_norm is unused in this path; assign a don't-care.
-      prod_norm     = '0;
-      s3_mant_c     = s3_prod[PROD_W-1 -: SIG_W];           // prod[105:53]
-      s3_guard_c    = s3_prod[PROD_W-1 - SIG_W];             // prod[52]
-      s3_round_c    = s3_prod[PROD_W-1 - SIG_W - 1];         // prod[51]
-      s3_sticky_c   = |s3_prod[PROD_W-1 - SIG_W - 2 : 0];   // prod[50:0]
-      s3_exp_norm_c = s2_exp_sum_q + 13'sd1;
-    end else begin
-      // leading 1 at bit (PROD_W-1-lz); left shift by (lz-1) to reach bit 104.
-      prod_norm     = s3_prod << (lz - 7'd1);
-      s3_mant_c     = prod_norm[PROD_W-2 -: SIG_W];
-      s3_guard_c    = prod_norm[PROD_W-2 - SIG_W];
-      s3_round_c    = prod_norm[PROD_W-2 - SIG_W - 1];
-      s3_sticky_c   = |prod_norm[PROD_W-2 - SIG_W - 2 : 0];
-      exp_adj       = 13'sd1 - {6'b0, lz};
-      s3_exp_norm_c = s2_exp_sum_q + exp_adj;
-    end
-
-    // Now, for single-precision, the mantissa layout is {1, frac23, 29 zeros}
-    // (since we left-padded the multiplicands with 29 zeros). The guard/round/
-    // sticky must therefore be recomputed from the low 29 bits of the 53-bit
-    // mantissa, OR'd with the previous sticky tail. We handle S/D uniformly
-    // in the rounding stage by carrying a "trailing" width-adjusted GRS.
-    //
-    // Subnormal handling: if s3_exp_norm_c <= 0, shift the mantissa right by
-    // (1 - s3_exp_norm_c) to denormalize, accumulating into sticky.
-    begin
-      mant_fullw = s3_mant_c;
-      g_in = s3_guard_c;
-      r_in = s3_round_c;
-      s_in = s3_sticky_c;
-
-      if (s3_exp_norm_c <= 13'sd0) begin
-        shift_amt = 13'sd1 - s3_exp_norm_c;
-        // clamp shift to avoid runaway; sh must hold values 0..64
-        if (shift_amt >= 13'sd64) sh = 64;
-        else                       sh = {25'd0, shift_amt[6:0]};
-
-        // Build a 64-bit tail to simplify sticky computation:
-        // [mant (53)] [g (1)] [r (1)] [s (1)] ...
-        begin
-          tail = {mant_fullw, g_in, r_in, s_in, 8'd0};
-          if (sh >= 64) begin
-            shifted   = 64'd0;
-            lost_mask = 64'hFFFF_FFFF_FFFF_FFFF;
-          end else begin
-            shifted   = tail >> sh;
-            lost_mask = ~(64'hFFFF_FFFF_FFFF_FFFF << sh);
-          end
-          s3_mant_post_c  = shifted[63:11];
-          s3_guard_post_c = shifted[10];
-          s3_round_post_c = shifted[9];
-          s3_sticky_post_c = |shifted[8:0] | (|(tail & lost_mask));
-          s3_exp_post_c   = 13'sd0;
-          s3_is_subnormal_c = 1'b1;
-        end
-      end else begin
-        s3_mant_post_c  = mant_fullw;
-        s3_guard_post_c = g_in;
-        s3_round_post_c = r_in;
-        s3_sticky_post_c = s_in;
-        s3_exp_post_c   = s3_exp_norm_c;
-        s3_is_subnormal_c = 1'b0;
-      end
-    end
+    logic [6:0] lz;
+    s3_lz_comb       = '0;
+    s3_exp_norm_comb = '0;
+    lz = '0;
+    lz = lzc106(s2_prod_q);
+    s3_lz_comb = lz;
+    if (lz == 7'd0)
+      s3_exp_norm_comb = s2_exp_sum_q + 13'sd1;
+    else
+      s3_exp_norm_comb = s2_exp_sum_q + 13'sd1 - {6'b0, lz};
   end
-
-  // For single-precision, we need to fold the 29 low bits of the 53-bit
-  // mantissa into sticky *after* the subnormal shift. This is done in S4
-  // when we pick the format-specific fraction width.
 
   // -------------------------------------------------------------------------
   // S3 registers
@@ -456,10 +324,9 @@ module kronos_fpu_fmul
   logic [2:0]  s3_rm_q;
   fpu_tag_t    s3_tag_q;
   logic        s3_sign_q;
-  logic signed [EXP_EXT_W-1:0] s3_exp_q;
-  logic [SIG_W-1:0] s3_mant_q;
-  logic s3_g_q, s3_r_q, s3_s_q;
-  logic s3_is_subnormal_q;
+  logic [6:0]  s3_lz_q;
+  logic signed [EXP_EXT_W-1:0] s3_exp_norm_q;
+  logic [PROD_W-1:0] s3_prod_q;
   logic s3_any_snan_q, s3_any_nan_q, s3_inf_times_zero_q;
   logic s3_res_is_inf_q, s3_res_is_zero_q;
 
@@ -470,12 +337,9 @@ module kronos_fpu_fmul
       s3_rm_q             <= 3'd0;
       s3_tag_q            <= '0;
       s3_sign_q           <= 1'b0;
-      s3_exp_q            <= '0;
-      s3_mant_q           <= '0;
-      s3_g_q              <= 1'b0;
-      s3_r_q              <= 1'b0;
-      s3_s_q              <= 1'b0;
-      s3_is_subnormal_q   <= 1'b0;
+      s3_lz_q             <= '0;
+      s3_exp_norm_q       <= '0;
+      s3_prod_q           <= '0;
       s3_any_snan_q       <= 1'b0;
       s3_any_nan_q        <= 1'b0;
       s3_inf_times_zero_q <= 1'b0;
@@ -487,12 +351,9 @@ module kronos_fpu_fmul
       s3_rm_q             <= s2_rm_q;
       s3_tag_q            <= s2_tag_q;
       s3_sign_q           <= s2_sign_q;
-      s3_exp_q            <= s3_exp_post_c;
-      s3_mant_q           <= s3_mant_post_c;
-      s3_g_q              <= s3_guard_post_c;
-      s3_r_q              <= s3_round_post_c;
-      s3_s_q              <= s3_sticky_post_c;
-      s3_is_subnormal_q   <= s3_is_subnormal_c;
+      s3_lz_q             <= s3_lz_comb;
+      s3_exp_norm_q       <= s3_exp_norm_comb;
+      s3_prod_q           <= s2_prod_q;
       s3_any_snan_q       <= s2_any_snan_q;
       s3_any_nan_q        <= s2_any_nan_q;
       s3_inf_times_zero_q <= s2_inf_times_zero_q;
@@ -502,10 +363,209 @@ module kronos_fpu_fmul
   end
 
   // -------------------------------------------------------------------------
-  // S4 combinational: round, overflow/underflow, pack, NaN-box
+  // S3b combinational: normalize barrel shift using registered LZC
   // -------------------------------------------------------------------------
-  logic [63:0] s4_result_c;
-  logic [4:0]  s4_fflags_c;
+  logic [SIG_W-1:0] s3b_mant_comb;
+  logic             s3b_guard_comb;
+  logic             s3b_round_comb;
+  logic             s3b_sticky_comb;
+  logic             s3b_is_subnormal_comb;
+  logic signed [EXP_EXT_W-1:0] s3b_exp_comb;
+
+  always_comb begin
+    logic [PROD_W-1:0] prod_norm;
+    logic [6:0]        lz;
+
+    prod_norm             = '0;
+    s3b_mant_comb         = '0;
+    s3b_guard_comb        = 1'b0;
+    s3b_round_comb        = 1'b0;
+    s3b_sticky_comb       = 1'b0;
+    s3b_is_subnormal_comb = 1'b0;
+    s3b_exp_comb          = s3_exp_norm_q;
+
+    lz = s3_lz_q;
+
+    if (lz == 7'd0) begin
+      s3b_mant_comb   = s3_prod_q[PROD_W-1 -: SIG_W];
+      s3b_guard_comb  = s3_prod_q[PROD_W-1 - SIG_W];
+      s3b_round_comb  = s3_prod_q[PROD_W-1 - SIG_W - 1];
+      s3b_sticky_comb = |s3_prod_q[PROD_W-1 - SIG_W - 2 : 0];
+    end else begin
+      prod_norm       = s3_prod_q << (lz - 7'd1);
+      s3b_mant_comb   = prod_norm[PROD_W-2 -: SIG_W];
+      s3b_guard_comb  = prod_norm[PROD_W-2 - SIG_W];
+      s3b_round_comb  = prod_norm[PROD_W-2 - SIG_W - 1];
+      s3b_sticky_comb = |prod_norm[PROD_W-2 - SIG_W - 2 : 0];
+    end
+
+    s3b_is_subnormal_comb = (s3_exp_norm_q <= 13'sd0);
+  end
+
+  // -------------------------------------------------------------------------
+  // S3b registers
+  // -------------------------------------------------------------------------
+  logic        s3b_valid_q;
+  logic        s3b_fmt_d_q;
+  logic [2:0]  s3b_rm_q;
+  fpu_tag_t    s3b_tag_q;
+  logic        s3b_sign_q;
+  logic signed [EXP_EXT_W-1:0] s3b_exp_q;
+  logic [SIG_W-1:0] s3b_mant_q;
+  logic s3b_g_q, s3b_r_q, s3b_s_q;
+  logic s3b_is_subnormal_q;
+  logic s3b_any_snan_q, s3b_any_nan_q, s3b_inf_times_zero_q;
+  logic s3b_res_is_inf_q, s3b_res_is_zero_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      s3b_valid_q          <= 1'b0;
+      s3b_fmt_d_q          <= 1'b0;
+      s3b_rm_q             <= 3'd0;
+      s3b_tag_q            <= '0;
+      s3b_sign_q           <= 1'b0;
+      s3b_exp_q            <= '0;
+      s3b_mant_q           <= '0;
+      s3b_g_q              <= 1'b0;
+      s3b_r_q              <= 1'b0;
+      s3b_s_q              <= 1'b0;
+      s3b_is_subnormal_q   <= 1'b0;
+      s3b_any_snan_q       <= 1'b0;
+      s3b_any_nan_q        <= 1'b0;
+      s3b_inf_times_zero_q <= 1'b0;
+      s3b_res_is_inf_q     <= 1'b0;
+      s3b_res_is_zero_q    <= 1'b0;
+    end else begin
+      s3b_valid_q          <= flush_i ? 1'b0 : s3_valid_q;
+      s3b_fmt_d_q          <= s3_fmt_d_q;
+      s3b_rm_q             <= s3_rm_q;
+      s3b_tag_q            <= s3_tag_q;
+      s3b_sign_q           <= s3_sign_q;
+      s3b_exp_q            <= s3_exp_norm_q;
+      s3b_mant_q           <= s3b_mant_comb;
+      s3b_g_q              <= s3b_guard_comb;
+      s3b_r_q              <= s3b_round_comb;
+      s3b_s_q              <= s3b_sticky_comb;
+      s3b_is_subnormal_q   <= s3b_is_subnormal_comb;
+      s3b_any_snan_q       <= s3_any_snan_q;
+      s3b_any_nan_q        <= s3_any_nan_q;
+      s3b_inf_times_zero_q <= s3_inf_times_zero_q;
+      s3b_res_is_inf_q     <= s3_res_is_inf_q;
+      s3b_res_is_zero_q    <= s3_res_is_zero_q;
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // S4 combinational: subnormal shift (if exp_norm <= 0)
+  // -------------------------------------------------------------------------
+  logic [SIG_W-1:0] s4_mant_comb;
+  logic             s4_g_comb, s4_r_comb, s4_s_comb;
+  logic signed [EXP_EXT_W-1:0] s4_exp_comb;
+
+  always_comb begin
+    logic signed [EXP_EXT_W-1:0] shift_amt;
+    logic [SIG_W-1:0] mant_fullw;
+    logic g_in, r_in, s_in;
+    int unsigned sh;
+    logic [63:0] tail;
+    logic [63:0] shifted;
+    logic [63:0] lost_mask;
+
+    shift_amt  = '0;
+    mant_fullw = s3b_mant_q;
+    g_in       = s3b_g_q;
+    r_in       = s3b_r_q;
+    s_in       = s3b_s_q;
+    sh         = 0;
+    tail       = '0;
+    shifted    = '0;
+    lost_mask  = '0;
+
+    s4_mant_comb = s3b_mant_q;
+    s4_g_comb    = s3b_g_q;
+    s4_r_comb    = s3b_r_q;
+    s4_s_comb    = s3b_s_q;
+    s4_exp_comb  = s3b_exp_q;
+
+    if (s3b_is_subnormal_q) begin
+      shift_amt = 13'sd1 - s3b_exp_q;
+      if (shift_amt >= 13'sd64) sh = 64;
+      else                       sh = {25'd0, shift_amt[6:0]};
+
+      tail = {mant_fullw, g_in, r_in, s_in, 8'd0};
+      if (sh >= 64) begin
+        shifted   = 64'd0;
+        lost_mask = 64'hFFFF_FFFF_FFFF_FFFF;
+      end else begin
+        shifted   = tail >> sh;
+        lost_mask = ~(64'hFFFF_FFFF_FFFF_FFFF << sh);
+      end
+      s4_mant_comb = shifted[63:11];
+      s4_g_comb    = shifted[10];
+      s4_r_comb    = shifted[9];
+      s4_s_comb    = |shifted[8:0] | (|(tail & lost_mask));
+      s4_exp_comb  = 13'sd0;
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // S4 registers
+  // -------------------------------------------------------------------------
+  logic        s4_valid_q;
+  logic        s4_fmt_d_q;
+  logic [2:0]  s4_rm_q;
+  fpu_tag_t    s4_tag_q;
+  logic        s4_sign_q;
+  logic signed [EXP_EXT_W-1:0] s4_exp_q;
+  logic [SIG_W-1:0] s4_mant_q;
+  logic s4_g_q, s4_r_q, s4_s_q;
+  logic s4_is_subnormal_q;
+  logic s4_any_snan_q, s4_any_nan_q, s4_inf_times_zero_q;
+  logic s4_res_is_inf_q, s4_res_is_zero_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      s4_valid_q          <= 1'b0;
+      s4_fmt_d_q          <= 1'b0;
+      s4_rm_q             <= 3'd0;
+      s4_tag_q            <= '0;
+      s4_sign_q           <= 1'b0;
+      s4_exp_q            <= '0;
+      s4_mant_q           <= '0;
+      s4_g_q              <= 1'b0;
+      s4_r_q              <= 1'b0;
+      s4_s_q              <= 1'b0;
+      s4_is_subnormal_q   <= 1'b0;
+      s4_any_snan_q       <= 1'b0;
+      s4_any_nan_q        <= 1'b0;
+      s4_inf_times_zero_q <= 1'b0;
+      s4_res_is_inf_q     <= 1'b0;
+      s4_res_is_zero_q    <= 1'b0;
+    end else begin
+      s4_valid_q          <= flush_i ? 1'b0 : s3b_valid_q;
+      s4_fmt_d_q          <= s3b_fmt_d_q;
+      s4_rm_q             <= s3b_rm_q;
+      s4_tag_q            <= s3b_tag_q;
+      s4_sign_q           <= s3b_sign_q;
+      s4_exp_q            <= s4_exp_comb;
+      s4_mant_q           <= s4_mant_comb;
+      s4_g_q              <= s4_g_comb;
+      s4_r_q              <= s4_r_comb;
+      s4_s_q              <= s4_s_comb;
+      s4_is_subnormal_q   <= s3b_is_subnormal_q;
+      s4_any_snan_q       <= s3b_any_snan_q;
+      s4_any_nan_q        <= s3b_any_nan_q;
+      s4_inf_times_zero_q <= s3b_inf_times_zero_q;
+      s4_res_is_inf_q     <= s3b_res_is_inf_q;
+      s4_res_is_zero_q    <= s3b_res_is_zero_q;
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // S5 combinational: round, overflow/underflow, pack, NaN-box
+  // -------------------------------------------------------------------------
+  logic [63:0] s5_result_c;
+  logic [4:0]  s5_fflags_c;
 
   // Rounding helper
   function automatic logic round_up(
@@ -553,19 +613,19 @@ module kronos_fpu_fmul
     logic [S_SIG_W-1:0] pack_frac_s;
     logic [D_SIG_W-1:0] pack_frac_d;
 
-    s4_result_c = '0;
-    s4_fflags_c = '0;
+    s5_result_c = '0;
+    s5_fflags_c = '0;
 
-    exp_in  = s3_exp_q;
-    mant_in = s3_mant_q;
-    g_in    = s3_g_q;
-    r_in    = s3_r_q;
-    s_in    = s3_s_q;
+    exp_in  = s4_exp_q;
+    mant_in = s4_mant_q;
+    g_in    = s4_g_q;
+    r_in    = s4_r_q;
+    s_in    = s4_s_q;
 
     // Extract kept mantissa + per-format GRS.
     // For single, kept fraction is bits [51:29] of mant_in, and [28:0] must
     // be folded into sticky along with g_in/r_in/s_in.
-    if (s3_fmt_d_q) begin
+    if (s4_fmt_d_q) begin
       mant_kept = mant_in;       // 53 bits already
       g_eff = g_in;
       r_eff = r_in;
@@ -579,7 +639,7 @@ module kronos_fpu_fmul
     end
 
     // Determine if rounding increments mantissa
-    round_inc = round_up(s3_rm_q, s3_sign_q, mant_kept[0], g_eff, r_eff, s_eff);
+    round_inc = round_up(s4_rm_q, s4_sign_q, mant_kept[0], g_eff, r_eff, s_eff);
     mant_rnd  = {1'b0, mant_kept} + {{SIG_W{1'b0}}, round_inc};
     exp_rnd   = exp_in;
     inexact   = g_eff | r_eff | s_eff;
@@ -590,7 +650,7 @@ module kronos_fpu_fmul
     // We also need to handle the subnormal→normal transition: when the
     // subnormal mantissa rounds up to 1.0 in the hidden-bit position, the
     // exponent becomes 1 (normal).
-    if (s3_fmt_d_q) begin
+    if (s4_fmt_d_q) begin
       if (mant_rnd[SIG_W]) begin
         // carry out of double's 53-bit field
         mant_rnd = mant_rnd >> 1;
@@ -613,56 +673,56 @@ module kronos_fpu_fmul
       end
     end
 
-    underflow_tiny = s3_is_subnormal_q;
+    underflow_tiny = s4_is_subnormal_q;
 
     // -------- Build result --------
-    if (s3_any_snan_q) begin
+    if (s4_any_snan_q) begin
       // sNaN operand → invalid, canonical qNaN
-      s4_fflags_c[FP_FFLAG_NV] = 1'b1;
-      s4_result_c = s3_fmt_d_q ? FP_CANON_QNAN_D
+      s5_fflags_c[FP_FFLAG_NV] = 1'b1;
+      s5_result_c = s4_fmt_d_q ? FP_CANON_QNAN_D
                                 : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-    end else if (s3_inf_times_zero_q) begin
+    end else if (s4_inf_times_zero_q) begin
       // inf * 0 → invalid, canonical qNaN
-      s4_fflags_c[FP_FFLAG_NV] = 1'b1;
-      s4_result_c = s3_fmt_d_q ? FP_CANON_QNAN_D
+      s5_fflags_c[FP_FFLAG_NV] = 1'b1;
+      s5_result_c = s4_fmt_d_q ? FP_CANON_QNAN_D
                                 : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-    end else if (s3_any_nan_q) begin
+    end else if (s4_any_nan_q) begin
       // qNaN propagation → canonical qNaN, no flag
-      s4_result_c = s3_fmt_d_q ? FP_CANON_QNAN_D
+      s5_result_c = s4_fmt_d_q ? FP_CANON_QNAN_D
                                 : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-    end else if (s3_res_is_inf_q) begin
+    end else if (s4_res_is_inf_q) begin
       // inf * finite(non-zero) → signed infinity, no flag
-      if (s3_fmt_d_q) begin
-        s4_result_c = {s3_sign_q, 11'h7FF, 52'd0};
+      if (s4_fmt_d_q) begin
+        s5_result_c = {s4_sign_q, 11'h7FF, 52'd0};
       end else begin
-        s4_result_c = {FP_NANBOX_UPPER, s3_sign_q, 8'hFF, 23'd0};
+        s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 8'hFF, 23'd0};
       end
-    end else if (s3_res_is_zero_q) begin
+    end else if (s4_res_is_zero_q) begin
       // zero * finite → signed zero, no flag
-      if (s3_fmt_d_q) begin
-        s4_result_c = {s3_sign_q, 63'd0};
+      if (s4_fmt_d_q) begin
+        s5_result_c = {s4_sign_q, 63'd0};
       end else begin
-        s4_result_c = {FP_NANBOX_UPPER, s3_sign_q, 31'd0};
+        s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 31'd0};
       end
     end else begin
       // Normal numeric path — check overflow/underflow against format range.
-      if (s3_fmt_d_q) begin
+      if (s4_fmt_d_q) begin
         overflow = (exp_rnd >= 13'sd2047);
         if (overflow) begin
-          s4_fflags_c[FP_FFLAG_OF] = 1'b1;
-          s4_fflags_c[FP_FFLAG_NX] = 1'b1;
+          s5_fflags_c[FP_FFLAG_OF] = 1'b1;
+          s5_fflags_c[FP_FFLAG_NX] = 1'b1;
           // Rounding mode controls whether we produce inf or max-finite.
-          unique case (s3_rm_q)
+          unique case (s4_rm_q)
             3'b001: // RTZ → max-finite
-              s4_result_c = {s3_sign_q, 11'h7FE, {D_SIG_W{1'b1}}};
+              s5_result_c = {s4_sign_q, 11'h7FE, {D_SIG_W{1'b1}}};
             3'b010: // RDN
-              s4_result_c = s3_sign_q ? {1'b1, 11'h7FF, 52'd0}
+              s5_result_c = s4_sign_q ? {1'b1, 11'h7FF, 52'd0}
                                        : {1'b0, 11'h7FE, {D_SIG_W{1'b1}}};
             3'b011: // RUP
-              s4_result_c = s3_sign_q ? {1'b1, 11'h7FE, {D_SIG_W{1'b1}}}
+              s5_result_c = s4_sign_q ? {1'b1, 11'h7FE, {D_SIG_W{1'b1}}}
                                        : {1'b0, 11'h7FF, 52'd0};
             default: // RNE, RMM → inf
-              s4_result_c = {s3_sign_q, 11'h7FF, 52'd0};
+              s5_result_c = {s4_sign_q, 11'h7FF, 52'd0};
           endcase
         end else begin
           // Pack exponent and fraction
@@ -672,30 +732,30 @@ module kronos_fpu_fmul
             pack_exp_d = exp_rnd[D_EXP_W-1:0];
           end
           pack_frac_d = mant_rnd[D_SIG_W-1:0];
-          s4_result_c = {s3_sign_q, pack_exp_d, pack_frac_d};
-          s4_fflags_c[FP_FFLAG_NX] = inexact;
+          s5_result_c = {s4_sign_q, pack_exp_d, pack_frac_d};
+          s5_fflags_c[FP_FFLAG_NX] = inexact;
           // Underflow: tiny before rounding AND inexact after rounding
           // (IEEE 754 "after rounding" underflow flag semantics).
-          s4_fflags_c[FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_d == 11'd0);
+          s5_fflags_c[FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_d == 11'd0);
         end
       end else begin
         overflow = (exp_rnd >= 13'sd255);
         if (overflow) begin
-          s4_fflags_c[FP_FFLAG_OF] = 1'b1;
-          s4_fflags_c[FP_FFLAG_NX] = 1'b1;
-          unique case (s3_rm_q)
+          s5_fflags_c[FP_FFLAG_OF] = 1'b1;
+          s5_fflags_c[FP_FFLAG_NX] = 1'b1;
+          unique case (s4_rm_q)
             3'b001:
-              s4_result_c = {FP_NANBOX_UPPER, s3_sign_q, 8'hFE, {S_SIG_W{1'b1}}};
+              s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 8'hFE, {S_SIG_W{1'b1}}};
             3'b010:
-              s4_result_c = s3_sign_q
+              s5_result_c = s4_sign_q
                 ? {FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0}
                 : {FP_NANBOX_UPPER, 1'b0, 8'hFE, {S_SIG_W{1'b1}}};
             3'b011:
-              s4_result_c = s3_sign_q
+              s5_result_c = s4_sign_q
                 ? {FP_NANBOX_UPPER, 1'b1, 8'hFE, {S_SIG_W{1'b1}}}
                 : {FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
             default:
-              s4_result_c = {FP_NANBOX_UPPER, s3_sign_q, 8'hFF, 23'd0};
+              s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 8'hFF, 23'd0};
           endcase
         end else begin
           if (exp_rnd <= 13'sd0) begin
@@ -704,16 +764,16 @@ module kronos_fpu_fmul
             pack_exp_s = exp_rnd[S_EXP_W-1:0];
           end
           pack_frac_s = mant_rnd[S_SIG_W-1:0];
-          s4_result_c = {FP_NANBOX_UPPER, s3_sign_q, pack_exp_s, pack_frac_s};
-          s4_fflags_c[FP_FFLAG_NX] = inexact;
-          s4_fflags_c[FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_s == 8'd0);
+          s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, pack_exp_s, pack_frac_s};
+          s5_fflags_c[FP_FFLAG_NX] = inexact;
+          s5_fflags_c[FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_s == 8'd0);
         end
       end
     end
   end
 
   // -------------------------------------------------------------------------
-  // S4 output registers
+  // S5 output registers
   // -------------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -722,10 +782,10 @@ module kronos_fpu_fmul
       fflags_o    <= '0;
       tag_o       <= '0;
     end else begin
-      out_valid_o <= flush_i ? 1'b0 : s3_valid_q;
-      result_o    <= s4_result_c;
-      fflags_o    <= s4_fflags_c;
-      tag_o       <= s3_tag_q;
+      out_valid_o <= flush_i ? 1'b0 : s4_valid_q;
+      result_o    <= s5_result_c;
+      fflags_o    <= s5_fflags_c;
+      tag_o       <= s4_tag_q;
     end
   end
 

--- a/rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
@@ -11,7 +11,10 @@
 //   - Runs total = n + 26 iterations (82 for D, 53 for S).
 //   - Output: n-bit root Q = q >> 26, sticky = |q[25:0] | |r.
 //
-// Cycle count: total + 1 (83 for D, 54 for S).
+// Cycle count: 2*total + 1 (165 for D, 107 for S).
+// Each iteration is split into two clock cycles:
+//   ST_CMP (phase A): compute r_shifted, trial, ge — register results
+//   ST_UPD (phase B): use registered results to update r_q and q_q
 
 module kronos_fpu_fsqrt_core (
   input  logic        clk_i,
@@ -30,8 +33,9 @@ module kronos_fpu_fsqrt_core (
   // -------------------------------------------------------------------------
   typedef enum logic [1:0] {
     ST_IDLE = 2'b00,
-    ST_RUN  = 2'b01,
-    ST_DONE = 2'b10
+    ST_CMP  = 2'b01,
+    ST_UPD  = 2'b10,
+    ST_DONE = 2'b11
   } state_e;
 
   // -------------------------------------------------------------------------
@@ -46,11 +50,14 @@ module kronos_fpu_fsqrt_core (
   // State registers
   // -------------------------------------------------------------------------
   state_e           state_q;
-  logic [R_W-1:0]   r_q;       // partial remainder
-  logic [Q_W-1:0]   q_q;       // running root
-  logic [53:0]       a_q;       // latched input significand
-  logic [6:0]        ctr_q;     // iteration counter (0..81)
-  logic              fmt_d_q;   // latched format
+  logic [R_W-1:0]   r_q;         // partial remainder
+  logic [Q_W-1:0]   q_q;         // running root
+  logic [53:0]       a_q;         // latched input significand
+  logic [6:0]        ctr_q;       // iteration counter (0..81)
+  logic              fmt_d_q;     // latched format
+  logic [R_W-1:0]   r_shifted_q; // registered shift result from ST_CMP
+  logic [R_W-1:0]   trial_q;     // registered trial value from ST_CMP
+  logic              ge_q;        // registered comparison result from ST_CMP
 
   // -------------------------------------------------------------------------
   // Combinational signals
@@ -59,11 +66,11 @@ module kronos_fpu_fsqrt_core (
   logic [R_W-1:0]   r_n;
   logic [Q_W-1:0]   q_n;
   logic [6:0]        ctr_n;
-  logic [1:0]        pair;      // 2-bit input pair for current iteration
-  logic [R_W-1:0]   r_shifted; // r << 2 | pair
-  logic [R_W-1:0]   trial;     // (q << 2) | 1
-  logic              ge;        // r_shifted >= trial
-  logic [6:0]        target;    // total iterations for current format
+  logic [1:0]        pair;        // 2-bit input pair for current iteration
+  logic [R_W-1:0]   r_shifted;   // r << 2 | pair
+  logic [R_W-1:0]   trial;       // (q << 2) | 1
+  logic              ge;          // r_shifted >= trial
+  logic [6:0]        target;      // total iterations for current format
 
   // -------------------------------------------------------------------------
   // Target selection
@@ -131,41 +138,36 @@ module kronos_fpu_fsqrt_core (
 
     unique case (state_q)
       ST_IDLE: begin
-        if (start_i) begin
-          state_n = ST_RUN;
-        end
+        if (start_i) state_n = ST_CMP;
       end
 
-      ST_RUN: begin
-        // r_shifted = (r << 2) | pair
+      ST_CMP: begin
+        // Phase A: compute shift, trial, and comparison — results registered
         r_shifted = {r_q[R_W-3:0], pair};
+        trial     = {q_q, 2'b01} & {R_W{1'b1}};
+        ge        = (r_shifted >= trial);
+        state_n   = ST_UPD;
+      end
 
-        // trial = (q << 2) | 1
-        trial = {q_q, 2'b01} & {R_W{1'b1}};
-
-        ge = (r_shifted >= trial);
-
-        if (ge) begin
-          r_n = r_shifted - trial;
+      ST_UPD: begin
+        // Phase B: use registered phase-A results to update r_q and q_q
+        if (ge_q) begin
+          r_n = r_shifted_q - trial_q;
           q_n = {q_q[Q_W-2:0], 1'b1};
         end else begin
-          r_n = r_shifted;
+          r_n = r_shifted_q;
           q_n = {q_q[Q_W-2:0], 1'b0};
         end
-
         ctr_n = ctr_q + 7'd1;
-        if (ctr_n == target) begin
-          state_n = ST_DONE;
-        end
+        if (ctr_n == target) state_n = ST_DONE;
+        else                  state_n = ST_CMP;
       end
 
       ST_DONE: begin
         state_n = ST_IDLE;
       end
 
-      default: begin
-        state_n = ST_IDLE;
-      end
+      default: state_n = ST_IDLE;
     endcase
 
     if (flush_i) begin
@@ -178,14 +180,25 @@ module kronos_fpu_fsqrt_core (
   // -------------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      state_q <= ST_IDLE;
-      r_q     <= '0;
-      q_q     <= '0;
-      a_q     <= '0;
-      ctr_q   <= '0;
-      fmt_d_q <= 1'b0;
+      state_q     <= ST_IDLE;
+      r_q         <= '0;
+      q_q         <= '0;
+      a_q         <= '0;
+      ctr_q       <= '0;
+      fmt_d_q     <= 1'b0;
+      r_shifted_q <= '0;
+      trial_q     <= '0;
+      ge_q        <= 1'b0;
     end else begin
       state_q <= state_n;
+
+      // Capture phase-A results at end of ST_CMP cycle
+      if (state_q == ST_CMP) begin
+        r_shifted_q <= r_shifted;
+        trial_q     <= trial;
+        ge_q        <= ge;
+      end
+
       // Latch inputs and clear scratch state on start; otherwise advance the
       // datapath registers from the combinational next-state.
       if (start_i && (state_q == ST_IDLE)) begin
@@ -195,9 +208,9 @@ module kronos_fpu_fsqrt_core (
         q_q     <= '0;
         ctr_q   <= '0;
       end else begin
-        r_q     <= r_n;
-        q_q     <= q_n;
-        ctr_q   <= ctr_n;
+        r_q   <= r_n;
+        q_q   <= q_n;
+        ctr_q <= ctr_n;
       end
     end
   end

--- a/rtl/stage5/fpu/kronos_fpu_top.sv
+++ b/rtl/stage5/fpu/kronos_fpu_top.sv
@@ -10,8 +10,8 @@
 //   FMISC  1  (FSGNJ*, FMIN, FMAX, FCLASS, FEQ, FLT, FLE, FMV.*)
 //   FCVT   2  (FCVT.*.* integer↔FP conversions)
 //   FADD   6  (FADD, FSUB — extra S3b stage for timing closure at 148 MHz)
-//   FMUL   4  (FMUL)
-//   FMA    5  (FMADD, FMSUB, FNMADD, FNMSUB)
+//   FMUL   6  (FMUL — split to 6 stages for high-Fmax)
+//   FMA    7  (FMADD, FMSUB, FNMADD, FNMSUB — split to 7 stages)
 //   ITER   variable (FDIV, FSQRT) — late-reservation via scoreboard
 //
 // busy_o is asserted when in_valid_i is high and the scoreboard detects a
@@ -76,11 +76,11 @@ module kronos_fpu_top
       end
       FP_FMUL: begin
         sel_fmul         = 1'b1;
-        dispatch_latency = 3'd4;
+        dispatch_latency = 3'd6;
       end
       FP_FMADD, FP_FMSUB, FP_FNMADD, FP_FNMSUB: begin
         sel_fma          = 1'b1;
-        dispatch_latency = 3'd5;
+        dispatch_latency = 3'd7;
       end
       FP_FDIV, FP_FSQRT: begin
         sel_iter         = 1'b1;
@@ -103,7 +103,7 @@ module kronos_fpu_top
   logic iter_late_req, iter_late_fp_dest, iter_late_grant;
   logic iter_busy;
 
-  kronos_fpu_scoreboard #(.DEPTH(6)) u_scoreboard (
+  kronos_fpu_scoreboard #(.DEPTH(8)) u_scoreboard (
     .clk_i             (clk_i),
     .rst_ni            (rst_ni),
     .flush_i           (flush_i),


### PR DESCRIPTION
## Summary
- `kronos_fpu_fma`: 5→7 stages — insert `s4b` register after 160-bit add (LZC becomes its own stage), `s5b` register after barrel shift (round+pack becomes its own stage)
- `kronos_fpu_fmul`: 4→6 stages — split S3 into LZC-only (S3), normalize barrel-shift (S3b), and subnormal right-shift (S4); round+pack becomes S5
- `kronos_fpu_fdiv_core`: 2-cycle SRT step — `ST_CMP` (shift+compare, register result) + `ST_UPD` (conditional subtract using registered `ge_q`/`p_shift_q`); eliminates 54-bit feedback critical path
- `kronos_fpu_fsqrt_core`: same 2-cycle SRT pattern — `ST_CMP` + `ST_UPD`, eliminates 84-bit partial-remainder feedback path
- `kronos_fpu_top`: update dispatch latencies (FMUL 4→6, FMA 5→7) and scoreboard `DEPTH` 6→8 to accommodate 7-cycle FMA

## Test plan
- [x] Lint: `fusesoc --cores-root=. run --target=lint opensoc:ip:kronos_riscv` — zero errors
- [x] `make -C sim sim-all` — 16/16 unit and integration tests pass
- [x] ACT4 compliance: 303/303 RV64IMAFDC tests pass (using pre-built ELFs)
- [ ] Synthesis at 200 MHz with `AggressiveExplore` (in progress, running on self-hosted runner)