### PR TITLE
fix(timing): timing closure for KV260 @ 220 MHz + FPU unit test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 build/
+!vendor/softfloat/build/
+vendor/softfloat/build/*.o
+vendor/softfloat/build/*.a
 obj_dir/
 *.vcd
 *.fst

--- a/rtl/stage3/kronos_bpred.sv
+++ b/rtl/stage3/kronos_bpred.sv
@@ -14,7 +14,9 @@
 //   Hit:    entry.valid && (entry.tag == pc[31:BTB_BITS+2])
 //
 // Prediction: pred_taken = BTB hit AND counter MSB=1.
-// Updates happen one cycle after EX (registered write).
+// Updates happen two cycles after EX: update inputs are pipelined through a
+// one-stage register (_q suffix) inside this module to break the long
+// mem_wb -> WB->EX forwarding cone feeding upd_target_i.
 module kronos_bpred
   import kronos_pkg::*;
 #(
@@ -28,7 +30,7 @@ module kronos_bpred
   input  logic [31:0] pc_i,
   output logic        pred_taken_o,
   output logic [31:0] pred_target_o,
-  // Update port (registered — fires when a branch resolves)
+  // Update port (2-cycle registered path — fires when a branch resolves)
   input  logic        upd_valid_i,
   input  logic [31:0] upd_pc_i,
   input  logic        upd_taken_i,
@@ -58,27 +60,55 @@ module kronos_bpred
   // BTB lookup result
   logic btb_hit;
 
+  // -----------------------------------------------------------------------
+  // Update-port pipeline register (timing fix: breaks the
+  // mem_wb_q -> WB->EX forwarding -> ex_pc_next -> btb write cone).
+  // Updates now fire 2 cycles after EX instead of 1 -- no correctness
+  // impact (predictor only).
+  // -----------------------------------------------------------------------
+  logic        upd_valid_q;
+  logic [31:0] upd_pc_q;
+  logic        upd_taken_q;
+  logic [31:0] upd_target_q;
+  logic        upd_is_jal_q;
+
   assign lookup_idx     = pc_i[BPRED_BITS+1:2];
   assign lookup_btb_idx = pc_i[BTB_BITS+1:2];
   assign lookup_tag     = pc_i[31:BTB_BITS+2];
 
-  assign update_idx     = upd_pc_i[BPRED_BITS+1:2];
-  assign update_btb_idx = upd_pc_i[BTB_BITS+1:2];
-  assign update_tag     = upd_pc_i[31:BTB_BITS+2];
+  assign update_idx     = upd_pc_q[BPRED_BITS+1:2];
+  assign update_btb_idx = upd_pc_q[BTB_BITS+1:2];
+  assign update_tag     = upd_pc_q[31:BTB_BITS+2];
 
   assign btb_hit       = btb[lookup_btb_idx].valid &&
                          (btb[lookup_btb_idx].tag == BTB_TAG_BITS'(lookup_tag));
   assign pred_taken_o  = btb_hit && counters[lookup_idx][1];
   assign pred_target_o = btb[lookup_btb_idx].target;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_upd_pipe
+    if (!rst_ni) begin
+      upd_valid_q  <= 1'b0;
+      upd_pc_q     <= '0;
+      upd_taken_q  <= 1'b0;
+      upd_target_q <= '0;
+      upd_is_jal_q <= 1'b0;
+    end else begin
+      upd_valid_q  <= upd_valid_i;
+      upd_pc_q     <= upd_pc_i;
+      upd_taken_q  <= upd_taken_i;
+      upd_target_q <= upd_target_i;
+      upd_is_jal_q <= upd_is_jal_i;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_update
     if (!rst_ni) begin
       for (int i = 0; i < BPRED_ENTRIES; i++) counters[i] <= 2'b01; // weak NT
       for (int i = 0; i < BTB_ENTRIES;   i++) btb[i]      <= '0;
-    end else if (upd_valid_i) begin
+    end else if (upd_valid_q) begin
       // Update 2-bit saturating counter — only for conditional branches, not JAL
-      if (!upd_is_jal_i) begin
-        if (upd_taken_i) begin
+      if (!upd_is_jal_q) begin
+        if (upd_taken_q) begin
           if (counters[update_idx] != 2'b11)
             counters[update_idx] <= counters[update_idx] + 2'd1;
         end else begin
@@ -88,10 +118,10 @@ module kronos_bpred
       end
 
       // Update BTB: write on taken or JAL; clear only when counter saturates at 00
-      if (upd_taken_i || upd_is_jal_i) begin
+      if (upd_taken_q || upd_is_jal_q) begin
         btb[update_btb_idx].valid  <= 1'b1;
         btb[update_btb_idx].tag    <= BTB_TAG_BITS'(update_tag);
-        btb[update_btb_idx].target <= upd_target_i;
+        btb[update_btb_idx].target <= upd_target_q;
       end else begin
         // Not-taken conditional branch: counter will decrement to 00 — invalidate BTB entry
         if (counters[update_idx] == 2'b01) begin

--- a/rtl/stage5/fpu/kronos_fpu_fma.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fma.sv
@@ -4,9 +4,15 @@
 
 // Single-rounded fused multiply-add for binary32 and binary64.
 // Computes +/-(a*b) +/- c with a single rounding step applied after the
-// full-precision multiply-add.  Pipelined over 7 cycles:
-// S1(decompose) → S2(align+DSP) → S3(product reg) →
-//   S4(add) → S4b(LZC) → S5(shift) → S5b(round+pack) → output
+// full-precision multiply-add.  Pipelined over 8 cycles:
+// S1(decompose) → S2(mul operand reg) → S2b(mul operand re-latch) →
+//   S3(product reg + alignment prep) → S4(add) → S4b(LZC) →
+//   S5(shift) → S5b(round+pack) → output
+//
+// S2 and S2b together give Vivado two flops between the S2 multiplicand
+// source and the DSP cascade output, letting retiming
+// (global_retiming on) place one in the DSP48 internal MREG. This breaks
+// the 53x53 multiply critical path at 200/220 MHz.
 //
 // Subnormal inputs are treated like normals with zero leading bit and the
 // biased exponent bumped to the subnormal emin.  Subnormal outputs fall out of
@@ -248,7 +254,7 @@ module kronos_fpu_fma
   logic              s2_c_zero;
   fpu_tag_t          s2_tag;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s2_regs
     if (!rst_ni) begin
       s2_valid          <= 1'b0;
       s2_special        <= 1'b0;
@@ -287,15 +293,75 @@ module kronos_fpu_fma
   end
 
   // ---------------------------------------------------------------------------
-  // Stage 2: multiply significands
+  // Stage 2b: re-latch all S2 signals. This is the pure-pipelining stage that
+  // gives Vivado retiming room inside the 53x53 DSP cascade. No new functional
+  // content.
+  // ---------------------------------------------------------------------------
+  logic              s2b_valid;
+  logic              s2b_special;
+  logic [63:0]       s2b_special_result;
+  logic [4:0]        s2b_special_flags;
+  logic              s2b_fmt_d;
+  logic [2:0]        s2b_rm;
+  logic              s2b_prod_sign;
+  logic              s2b_addend_sign;
+  logic signed [12:0] s2b_prod_exp;
+  logic signed [12:0] s2b_c_exp;
+  logic [52:0]       s2b_a_sig;
+  logic [52:0]       s2b_b_sig;
+  logic [52:0]       s2b_c_sig;
+  logic              s2b_prod_zero;
+  logic              s2b_c_zero;
+  fpu_tag_t          s2b_tag;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s2b_regs
+    if (!rst_ni) begin
+      s2b_valid          <= 1'b0;
+      s2b_special        <= 1'b0;
+      s2b_special_result <= '0;
+      s2b_special_flags  <= '0;
+      s2b_fmt_d          <= 1'b0;
+      s2b_rm             <= '0;
+      s2b_prod_sign      <= 1'b0;
+      s2b_addend_sign    <= 1'b0;
+      s2b_prod_exp       <= '0;
+      s2b_c_exp          <= '0;
+      s2b_a_sig          <= '0;
+      s2b_b_sig          <= '0;
+      s2b_c_sig          <= '0;
+      s2b_prod_zero      <= 1'b0;
+      s2b_c_zero         <= 1'b0;
+      s2b_tag            <= '0;
+    end else begin
+      s2b_valid          <= flush_i ? 1'b0 : s2_valid;
+      s2b_special        <= s2_special;
+      s2b_special_result <= s2_special_result;
+      s2b_special_flags  <= s2_special_flags;
+      s2b_fmt_d          <= s2_fmt_d;
+      s2b_rm             <= s2_rm;
+      s2b_prod_sign      <= s2_prod_sign;
+      s2b_addend_sign    <= s2_addend_sign;
+      s2b_prod_exp       <= s2_prod_exp;
+      s2b_c_exp          <= s2_c_exp;
+      s2b_a_sig          <= s2_a_sig;
+      s2b_b_sig          <= s2_b_sig;
+      s2b_c_sig          <= s2_c_sig;
+      s2b_prod_zero      <= s2_prod_zero;
+      s2b_c_zero         <= s2_c_zero;
+      s2b_tag            <= s2_tag;
+    end
+  end
+
+  // ---------------------------------------------------------------------------
+  // Stage 2b: multiply significands (reads from s2b to break DSP cascade path)
   // ---------------------------------------------------------------------------
   logic [PROD_W-1:0] s2_product_comb;
 
   always_comb begin
-    s2_product_comb = s2_a_sig * s2_b_sig;
+    s2_product_comb = s2b_a_sig * s2b_b_sig;
   end
 
-  // Stage 2 -> Stage 3 register
+  // Stage 2b -> Stage 3 register
   logic              s3_valid;
   logic              s3_special;
   logic [63:0]       s3_special_result;
@@ -312,7 +378,7 @@ module kronos_fpu_fma
   logic              s3_c_zero;
   fpu_tag_t          s3_tag;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s3_regs
     if (!rst_ni) begin
       s3_valid          <= 1'b0;
       s3_special        <= 1'b0;
@@ -330,21 +396,21 @@ module kronos_fpu_fma
       s3_c_zero         <= 1'b0;
       s3_tag            <= '0;
     end else begin
-      s3_valid          <= flush_i ? 1'b0 : s2_valid;
-      s3_special        <= s2_special;
-      s3_special_result <= s2_special_result;
-      s3_special_flags  <= s2_special_flags;
-      s3_fmt_d          <= s2_fmt_d;
-      s3_rm             <= s2_rm;
-      s3_prod_sign      <= s2_prod_sign;
-      s3_addend_sign    <= s2_addend_sign;
-      s3_prod_exp       <= s2_prod_exp;
-      s3_c_exp          <= s2_c_exp;
+      s3_valid          <= flush_i ? 1'b0 : s2b_valid;
+      s3_special        <= s2b_special;
+      s3_special_result <= s2b_special_result;
+      s3_special_flags  <= s2b_special_flags;
+      s3_fmt_d          <= s2b_fmt_d;
+      s3_rm             <= s2b_rm;
+      s3_prod_sign      <= s2b_prod_sign;
+      s3_addend_sign    <= s2b_addend_sign;
+      s3_prod_exp       <= s2b_prod_exp;
+      s3_c_exp          <= s2b_c_exp;
       s3_product        <= s2_product_comb;
-      s3_c_sig          <= s2_c_sig;
-      s3_prod_zero      <= s2_prod_zero;
-      s3_c_zero         <= s2_c_zero;
-      s3_tag            <= s2_tag;
+      s3_c_sig          <= s2b_c_sig;
+      s3_prod_zero      <= s2b_prod_zero;
+      s3_c_zero         <= s2b_c_zero;
+      s3_tag            <= s2b_tag;
     end
   end
 
@@ -766,7 +832,7 @@ module kronos_fpu_fma
       exp_pre_tiny = exp;
       tiny = 1'b0;
       if (exp < emin) begin
-        shift_right_amt = shift_right_amt + 32'(emin - exp);
+        shift_right_amt = shift_right_amt + (32'($signed(emin)) - 32'($signed(exp)));
         exp  = 0;
         tiny = 1'b1;
       end

--- a/rtl/stage5/fpu/kronos_fpu_fmul.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fmul.sv
@@ -2,19 +2,23 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// 6-stage pipelined IEEE 754 floating-point multiplier (single and double).
+// 7-stage pipelined IEEE 754 floating-point multiplier (single and double).
 //
 // Pipeline:
-//   S1: NaN-unbox single, decompose operands, classify specials, precompute
-//       sign / unbiased exponent sum / extended significands.
-//   S2: Multiply significands (wide multiply registered at stage boundary for
-//       DSP inference).
-//   S3: LZC only — compute 7-bit leading-zero count and normalized exponent
-//       from the 106-bit product. Carry full product forward.
+//   S1:  NaN-unbox single, decompose operands, classify specials, precompute
+//        sign / unbiased exponent sum / extended significands.
+//   S1b: Re-latch multiplicands into s1b_*_q. Gives Vivado two flops between
+//        the multiplicand source and the DSP cascade output, letting retiming
+//        (global_retiming on) place one in the DSP48 internal MREG. Breaks the
+//        53×53 DSP-chain critical path at 200/220 MHz.
+//   S2:  Multiply significands (wide multiply registered at stage boundary for
+//        DSP inference).
+//   S3:  LZC only — compute 7-bit leading-zero count and normalized exponent
+//        from the 106-bit product. Carry full product forward.
 //   S3b: Normalize barrel shift — use registered LZC to shift product and
 //        extract mantissa + GRS bits.
-//   S4: Subnormal shift — apply right-shift if exp_norm <= 0, refine GRS.
-//   S5: Round, handle overflow/underflow, pack, NaN-box single. Register.
+//   S4:  Subnormal shift — apply right-shift if exp_norm <= 0, refine GRS.
+//   S5:  Round, handle overflow/underflow, pack, NaN-box single. Register.
 
 module kronos_fpu_fmul
   import kronos_pkg::*;
@@ -234,12 +238,58 @@ module kronos_fpu_fmul
   end
 
   // -------------------------------------------------------------------------
+  // S1b registers: re-latch multiplicands to give Vivado retiming room inside
+  // the 53×53 DSP cascade. No new functional content — pure pipeline depth.
+  // -------------------------------------------------------------------------
+  logic        s1b_valid_q;
+  logic        s1b_fmt_d_q;
+  logic [2:0]  s1b_rm_q;
+  fpu_tag_t    s1b_tag_q;
+  logic        s1b_sign_q;
+  logic signed [EXP_EXT_W-1:0] s1b_exp_sum_q;
+  logic [SIG_W-1:0] s1b_siga_q, s1b_sigb_q;
+  logic        s1b_any_snan_q, s1b_any_nan_q, s1b_inf_times_zero_q;
+  logic        s1b_res_is_inf_q, s1b_res_is_zero_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s1b_regs
+    if (!rst_ni) begin
+      s1b_valid_q          <= 1'b0;
+      s1b_fmt_d_q          <= 1'b0;
+      s1b_rm_q             <= 3'd0;
+      s1b_tag_q            <= '0;
+      s1b_sign_q           <= 1'b0;
+      s1b_exp_sum_q        <= '0;
+      s1b_siga_q           <= '0;
+      s1b_sigb_q           <= '0;
+      s1b_any_snan_q       <= 1'b0;
+      s1b_any_nan_q        <= 1'b0;
+      s1b_inf_times_zero_q <= 1'b0;
+      s1b_res_is_inf_q     <= 1'b0;
+      s1b_res_is_zero_q    <= 1'b0;
+    end else begin
+      s1b_valid_q          <= flush_i ? 1'b0 : s1_valid_q;
+      s1b_fmt_d_q          <= s1_fmt_d_q;
+      s1b_rm_q             <= s1_rm_q;
+      s1b_tag_q            <= s1_tag_q;
+      s1b_sign_q           <= s1_sign_q;
+      s1b_exp_sum_q        <= s1_exp_sum_q;
+      s1b_siga_q           <= s1_siga_q;
+      s1b_sigb_q           <= s1_sigb_q;
+      s1b_any_snan_q       <= s1_any_snan_q;
+      s1b_any_nan_q        <= s1_any_nan_q;
+      s1b_inf_times_zero_q <= s1_inf_times_zero_q;
+      s1b_res_is_inf_q     <= s1_res_is_inf_q;
+      s1b_res_is_zero_q    <= s1_res_is_zero_q;
+    end
+  end
+
+  // -------------------------------------------------------------------------
   // S2 combinational: multiply
   // -------------------------------------------------------------------------
   logic [PROD_W-1:0] s2_prod_c;
 
   always_comb begin
-    s2_prod_c = s1_siga_q * s1_sigb_q;
+    s2_prod_c = s1b_siga_q * s1b_sigb_q;
   end
 
   // -------------------------------------------------------------------------
@@ -255,7 +305,7 @@ module kronos_fpu_fmul
   logic        s2_any_snan_q, s2_any_nan_q, s2_inf_times_zero_q;
   logic        s2_res_is_inf_q, s2_res_is_zero_q;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s2_regs
     if (!rst_ni) begin
       s2_valid_q          <= 1'b0;
       s2_fmt_d_q          <= 1'b0;
@@ -270,18 +320,18 @@ module kronos_fpu_fmul
       s2_res_is_inf_q     <= 1'b0;
       s2_res_is_zero_q    <= 1'b0;
     end else begin
-      s2_valid_q          <= flush_i ? 1'b0 : s1_valid_q;
-      s2_fmt_d_q          <= s1_fmt_d_q;
-      s2_rm_q             <= s1_rm_q;
-      s2_tag_q            <= s1_tag_q;
-      s2_sign_q           <= s1_sign_q;
-      s2_exp_sum_q        <= s1_exp_sum_q;
+      s2_valid_q          <= flush_i ? 1'b0 : s1b_valid_q;
+      s2_fmt_d_q          <= s1b_fmt_d_q;
+      s2_rm_q             <= s1b_rm_q;
+      s2_tag_q            <= s1b_tag_q;
+      s2_sign_q           <= s1b_sign_q;
+      s2_exp_sum_q        <= s1b_exp_sum_q;
       s2_prod_q           <= s2_prod_c;
-      s2_any_snan_q       <= s1_any_snan_q;
-      s2_any_nan_q        <= s1_any_nan_q;
-      s2_inf_times_zero_q <= s1_inf_times_zero_q;
-      s2_res_is_inf_q     <= s1_res_is_inf_q;
-      s2_res_is_zero_q    <= s1_res_is_zero_q;
+      s2_any_snan_q       <= s1b_any_snan_q;
+      s2_any_nan_q        <= s1b_any_nan_q;
+      s2_inf_times_zero_q <= s1b_inf_times_zero_q;
+      s2_res_is_inf_q     <= s1b_res_is_inf_q;
+      s2_res_is_zero_q    <= s1b_res_is_zero_q;
     end
   end
 

--- a/rtl/stage5/fpu/kronos_fpu_iter.sv
+++ b/rtl/stage5/fpu/kronos_fpu_iter.sv
@@ -4,15 +4,20 @@
 
 // Iterative FPU wrapper for FDIV and FSQRT.
 //
-// FSM: IDLE -> UNPACK -> ITER -> ROUND -> PACK -> IDLE
+// FSM: IDLE -> UNPACK1 -> UNPACK2 -> ITER -> ROUND1 -> ROUND2 -> PACK -> IDLE
 //
-// IDLE:   Latch raw inputs on in_valid_i.
-// UNPACK: Classify operands, detect specials (bypass to PACK),
-//         normalize subnormals, compute result exponent, start cores.
-// ITER:   Wait for fdiv/fsqrt core done signal.
-// ROUND:  One cycle of round/pack prep; reserves the writeback slot via the
-//         scoreboard's late-grant interface and stalls until granted.
-// PACK:   Drive out_valid_o, hand result/fflags/tag to the output mux.
+// IDLE:    Latch raw inputs on in_valid_i.
+// UNPACK1: Classify operands (CLZ, NaN/inf/subnorm flags), normalize
+//          significands, compute unbiased true exponents and specials.
+// UNPACK2: Compute biased result exponent (FDIV: a_true - b_true + bias;
+//          FSQRT: asr(a_true) + bias). Specials bypass to PACK.
+// ITER:    Wait for fdiv/fsqrt core done signal.
+// ROUND1:  Post-norm shift + mantissa/GRS extract + tininess detect +
+//          subnormal right-shift.
+// ROUND2:  Rounding decision + 53-bit rounding adder + overflow detect +
+//          pack into result_q/fflags_q. Reserves the writeback slot via
+//          the scoreboard's late-grant interface and stalls until granted.
+// PACK:    Drive out_valid_o, hand result/fflags/tag to the output mux.
 
 module kronos_fpu_iter
   import kronos_pkg::*;
@@ -45,11 +50,13 @@ module kronos_fpu_iter
   // FSM states
   // -----------------------------------------------------------------------
   typedef enum logic [2:0] {
-    IDLE   = 3'd0,
-    UNPACK = 3'd1,
-    ITER   = 3'd2,
-    ROUND  = 3'd3,
-    PACK   = 3'd4
+    IDLE    = 3'd0,
+    UNPACK1 = 3'd1,
+    UNPACK2 = 3'd2,
+    ITER    = 3'd3,
+    ROUND1  = 3'd4,
+    ROUND2  = 3'd5,
+    PACK    = 3'd6
   } state_e;
 
   // -----------------------------------------------------------------------
@@ -82,26 +89,44 @@ module kronos_fpu_iter
   // State registers
   // -----------------------------------------------------------------------
   state_e    state_q;
+  logic      iter_busy_q;  // look-ahead flop of (state_d != IDLE); breaks deep busy_o cone
 
-  // Latched raw inputs (IDLE -> UNPACK)
+  // Latched raw inputs (IDLE -> UNPACK1)
   fp_op_e    op_q;
   logic      fmt_d_q;
   logic [2:0] rm_q;
   fpu_tag_t  tag_q;
   logic [63:0] a_raw_q, b_raw_q;
 
-  // Classified operands (registered in UNPACK -> ITER transition)
+  // Classified operands (registered in UNPACK1 -> UNPACK2 transition)
   fp_class_t a_class_q, b_class_q;
 
-  // Normalized operands and result exponent (latched UNPACK -> ITER)
+  // Normalized operands (latched UNPACK1 -> UNPACK2)
   logic [52:0]       a_norm_q, b_norm_q;   // fdiv: 53-bit normalized sigs
   logic [53:0]       a_sqrt_q;             // fsqrt: 54-bit normalized sig
+
+  // Unbiased true exponents (latched UNPACK1 -> UNPACK2)
+  logic signed [12:0] a_true_exp_q, b_true_exp_q;
+
+  // Specials result/flags latched in UNPACK1, consumed in UNPACK2
+  logic               is_special_q;
+  logic [63:0]        special_result_q;
+  logic [4:0]         special_fflags_q;
+
+  // Final biased result exponent + sign (computed in UNPACK2 combinationally,
+  // latched UNPACK2 -> ITER into result_sign_q / result_exp_q)
   logic              result_sign_q;
   logic signed [12:0] result_exp_q;        // signed intermediate exponent
 
   // Raw quotient from core (latched on core_done)
   logic [55:0] raw_q_q;
   logic        raw_sticky_q;
+
+  // ROUND1 -> ROUND2 latches (timing-closure split: see proc_round1_latch)
+  logic [51:0]        rnd_mant_shifted_q;
+  logic               rnd_new_lsb_q, rnd_new_g_q, rnd_new_r_q, rnd_new_s_q;
+  logic signed [12:0] rnd_final_exp_q;
+  logic               rnd_tiny_q;
 
   // -----------------------------------------------------------------------
   // Combinational signals
@@ -110,7 +135,7 @@ module kronos_fpu_iter
   fp_class_t a_class, b_class;
 
   // -----------------------------------------------------------------------
-  // Operand classify (combinational, used in UNPACK)
+  // Operand classify (combinational, used in UNPACK1)
   // Reads from a_raw_q / b_raw_q (latched in IDLE)
   // -----------------------------------------------------------------------
   always_comb begin : proc_classify_a
@@ -234,7 +259,7 @@ module kronos_fpu_iter
   end
 
   // -----------------------------------------------------------------------
-  // Specials short-circuit (combinational, used in UNPACK)
+  // Specials short-circuit (combinational, used in UNPACK1)
   // -----------------------------------------------------------------------
   logic        is_special;
   logic [63:0] special_result;
@@ -365,12 +390,10 @@ module kronos_fpu_iter
   end
 
   // -----------------------------------------------------------------------
-  // Normalization logic (combinational, used in UNPACK -> ITER transition)
+  // Normalization logic (combinational, used in UNPACK1)
   // -----------------------------------------------------------------------
   logic [52:0]       a_norm, b_norm;      // fdiv normalized significands
   logic [53:0]       a_sqrt;              // fsqrt normalized significand
-  logic signed [12:0] result_exp_comb;    // intermediate result exponent
-  logic              result_sign_comb;
   logic signed [12:0] a_true_exp, b_true_exp;
   logic signed [12:0] bias;
 
@@ -378,31 +401,21 @@ module kronos_fpu_iter
     a_norm     = '0;
     b_norm     = '0;
     a_sqrt     = '0;
-    result_exp_comb = '0;
-    result_sign_comb = '0;
     a_true_exp = '0;
     b_true_exp = '0;
 
     bias = fmt_d_q ? 13'sd1023 : 13'sd127;
 
-    // Result sign: FDIV = sign_a ^ sign_b, FSQRT = 0 (negative caught
-    // as special)
-    result_sign_comb = (op_q == FP_FDIV) ? (a_class.sign ^ b_class.sign)
-                                         : 1'b0;
-
     // --- Operand A normalization ---
     if (a_class.is_subnorm) begin
-      // Subnormal: true exponent = 1 - bias - clz
-      // Shift {0, sig} left by clz to place leading 1 at bit 52
       a_true_exp = 13'sd1 - bias - 13'(a_class.clz);
       a_norm     = {1'b0, a_class.sig} << a_class.clz;
     end else begin
-      // Normal: true exponent = biased_exp - bias
       a_true_exp = 13'(a_class.exp) - bias;
       a_norm     = {1'b1, a_class.sig};
     end
 
-    // --- Operand B normalization (FDIV only) ---
+    // --- Operand B normalization (FDIV only; harmless for FSQRT) ---
     if (b_class.is_subnorm) begin
       b_true_exp = 13'sd1 - bias - 13'(b_class.clz);
       b_norm     = {1'b0, b_class.sig} << b_class.clz;
@@ -411,36 +424,42 @@ module kronos_fpu_iter
       b_norm     = {1'b1, b_class.sig};
     end
 
-    // --- Result exponent computation ---
-    if (op_q == FP_FDIV) begin
-      // FDIV: result_exp (biased) = (a_true - b_true) + bias
-      // Quotient normalization adjustment handled in ROUND.
-      result_exp_comb = a_true_exp - b_true_exp + bias;
-    end else begin
-      // FSQRT: result_exp (biased) = floor(a_true / 2) + bias
-      // If a_true is odd, pre-shift significand left by 1 (handled below).
-      // Use arithmetic right shift for floor division of signed value.
-      // floor(a_true / 2): for negative odd, e.g. -3 => floor(-1.5) = -2
-      // (a_true_exp - (a_true_exp < 0 && a_true_exp[0])) >>> 1
-      // Actually: (a_true_exp >> 1) works for even. For odd negative:
-      // a_true_exp = -3: we want floor(-3/2) = -2. (-3)>>>1 = -2. OK.
-      // a_true_exp = -1: we want floor(-1/2) = -1. (-1)>>>1 = -1. OK.
-      // a_true_exp = 3:  we want floor(3/2) = 1.  3>>>1 = 1. OK.
-      // So arithmetic right shift by 1 gives floor(x/2) for signed x.
-      result_exp_comb = (a_true_exp >>> 1) + bias;
-    end
-
     // --- FSQRT significand preparation ---
-    // For fsqrt, the core expects a 54-bit input:
-    //   Even exponent: {1'b0, normalized_sig[52:0]} (bit 52 set)
-    //   Odd exponent:  {normalized_sig[52:0], 1'b0} (bit 53 set)
-    // "Odd" means a_true_exp[0] == 1.
+    // Even true exponent: {1'b0, normalized_sig[52:0]} (bit 52 set)
+    // Odd true exponent:  {normalized_sig[52:0], 1'b0} (bit 53 set)
     if (a_true_exp[0]) begin
-      // Odd true exponent: shift left by 1
       a_sqrt = {a_norm, 1'b0};
     end else begin
-      // Even true exponent
       a_sqrt = {1'b0, a_norm};
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // proc_result_exp: computes result_exp_comb / result_sign_comb from the
+  // REGISTERED a_true_exp_q / b_true_exp_q in UNPACK2. Breaking the combined
+  // classify+normalize+exp-compute cone into two cycles is the C4 fix.
+  // -----------------------------------------------------------------------
+  logic signed [12:0] result_exp_comb;    // biased result exponent (UNPACK2)
+  logic               result_sign_comb;   // result sign (UNPACK2)
+
+  always_comb begin : proc_result_exp
+    result_exp_comb  = '0;
+    result_sign_comb = 1'b0;
+
+    // Result sign: FDIV = sign_a ^ sign_b, FSQRT = 0 (negative caught as special).
+    result_sign_comb = (op_q == FP_FDIV)
+                       ? (a_class_q.sign ^ b_class_q.sign)
+                       : 1'b0;
+
+    if (op_q == FP_FDIV) begin
+      // FDIV: result_exp (biased) = (a_true - b_true) + bias
+      result_exp_comb = a_true_exp_q - b_true_exp_q
+                        + (fmt_d_q ? 13'sd1023 : 13'sd127);
+    end else begin
+      // FSQRT: result_exp (biased) = floor(a_true / 2) + bias
+      // arithmetic right shift by 1 gives floor(x/2) for signed x
+      result_exp_comb = (a_true_exp_q >>> 1)
+                        + (fmt_d_q ? 13'sd1023 : 13'sd127);
     end
   end
 
@@ -487,10 +506,8 @@ module kronos_fpu_iter
   // FDIV normalization helper
   logic        rnd_need_shift;
 
-  always_comb begin : proc_round
+  always_comb begin : proc_round1
     // Defaults
-    round_result   = '0;
-    round_fflags   = '0;
     rnd_shifted    = '0;
     rnd_adj_exp    = '0;
     rnd_sticky_shift = 1'b0;
@@ -513,23 +530,10 @@ module kronos_fpu_iter
     rnd_combined_s = '0;
     rnd_shifted_out_s = '0;
     rnd_combined_shifted_s = '0;
-    rnd_round_up   = 1'b0;
-    rnd_inexact    = 1'b0;
-    rnd_rounded_mant = '0;
-    rnd_carry      = 1'b0;
-    rnd_overflow   = 1'b0;
-    rnd_overflow_to_inf = 1'b0;
-    rnd_to_max     = 1'b0;
-    rnd_uf         = 1'b0;
-    rnd_of         = 1'b0;
-    rnd_nx         = 1'b0;
 
     // ------------------------------------------------------------------
     // 1. Post-normalization shift (FDIV only: if integer bit is 0)
     // ------------------------------------------------------------------
-    // For FDIV: the core emits n bits where bit[n-1] is the integer bit.
-    // For D (n=56): integer bit at [55]. For S (n=27): at [26].
-    // If the integer bit is 0, shift left by 1 and decrement exponent.
     rnd_need_shift = 1'b0;
     if (op_q == FP_FDIV) begin
       rnd_need_shift = fmt_d_q ? !raw_q_q[55] : !raw_q_q[26];
@@ -543,7 +547,6 @@ module kronos_fpu_iter
         rnd_sticky_shift = raw_sticky_q;
       end
     end else begin
-      // FSQRT: MSB always 1, no shift needed
       rnd_shifted = raw_q_q;
       rnd_adj_exp = result_exp_q;
       rnd_sticky_shift = raw_sticky_q;
@@ -552,9 +555,6 @@ module kronos_fpu_iter
     // ------------------------------------------------------------------
     // 2. Extract mantissa, G, R, S
     // ------------------------------------------------------------------
-    // After normalization, bit [n-1] = 1 (implicit). With n+1 quotient bits:
-    // D: [55]=implicit, [54:3]=mantissa, [2]=G, [1]=R, [0]=extra→S.
-    // S: [26]=implicit, [25:3]=mantissa, [2]=G, [1]=R, [0]=extra→S.
     if (fmt_d_q) begin
       rnd_mantissa = rnd_shifted[54:3];
       rnd_lsb      = rnd_shifted[3];
@@ -575,8 +575,6 @@ module kronos_fpu_iter
     rnd_tiny = (rnd_adj_exp <= 13'sd0);
 
     if (rnd_tiny) begin
-      // Compute shift in full width to avoid 7-bit truncation overflow.
-      // rnd_adj_exp <= 0 here, so (1 - rnd_adj_exp) >= 1.
       if (fmt_d_q) begin
         rnd_shift_amt = ((13'sd1 - rnd_adj_exp) > 13'sd56)
                         ? 7'd56 : 7'(13'sd1 - rnd_adj_exp);
@@ -585,8 +583,6 @@ module kronos_fpu_iter
                         ? 7'd27 : 7'(13'sd1 - rnd_adj_exp);
       end
 
-      // Include implicit 1 bit in the combined vector for correct
-      // denormalization: D = {1, mantissa[51:0], G, R, extra} = rnd_shifted.
       if (fmt_d_q) begin
         rnd_combined_d = rnd_shifted;
         rnd_shifted_out_d = rnd_combined_d & ((56'd1 << rnd_shift_amt) - 56'd1);
@@ -616,18 +612,60 @@ module kronos_fpu_iter
       rnd_new_s   = rnd_s;
       rnd_final_exp = rnd_adj_exp;
     end
+  end
+
+  // -----------------------------------------------------------------------
+  // ROUND1 -> ROUND2 register (latches outputs of proc_round1)
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_round1_latch
+    if (!rst_ni) begin
+      rnd_mant_shifted_q <= '0;
+      rnd_new_lsb_q      <= 1'b0;
+      rnd_new_g_q        <= 1'b0;
+      rnd_new_r_q        <= 1'b0;
+      rnd_new_s_q        <= 1'b0;
+      rnd_final_exp_q    <= '0;
+      rnd_tiny_q         <= 1'b0;
+    end else if (state_q == ROUND1) begin
+      rnd_mant_shifted_q <= rnd_mant_shifted;
+      rnd_new_lsb_q      <= rnd_new_lsb;
+      rnd_new_g_q        <= rnd_new_g;
+      rnd_new_r_q        <= rnd_new_r;
+      rnd_new_s_q        <= rnd_new_s;
+      rnd_final_exp_q    <= rnd_final_exp;
+      rnd_tiny_q         <= rnd_tiny;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // ROUND2 state - rounding decision, 53-bit add, overflow detect, pack
+  // Reads ROUND1 latches; writes round_result / round_fflags
+  // -----------------------------------------------------------------------
+  always_comb begin : proc_round2
+    round_result        = '0;
+    round_fflags        = '0;
+    rnd_round_up        = 1'b0;
+    rnd_inexact         = 1'b0;
+    rnd_rounded_mant    = '0;
+    rnd_carry           = 1'b0;
+    rnd_overflow        = 1'b0;
+    rnd_overflow_to_inf = 1'b0;
+    rnd_to_max          = 1'b0;
+    rnd_uf              = 1'b0;
+    rnd_of              = 1'b0;
+    rnd_nx              = 1'b0;
 
     // ------------------------------------------------------------------
     // 4. Rounding decision
     // ------------------------------------------------------------------
-    rnd_inexact = rnd_new_g | rnd_new_r | rnd_new_s;
+    rnd_inexact = rnd_new_g_q | rnd_new_r_q | rnd_new_s_q;
 
     unique case (rm_q)
-      3'b000:  rnd_round_up = rnd_new_g & (rnd_new_lsb | rnd_new_r | rnd_new_s);
+      3'b000:  rnd_round_up = rnd_new_g_q & (rnd_new_lsb_q | rnd_new_r_q | rnd_new_s_q);
       3'b001:  rnd_round_up = 1'b0;
       3'b010:  rnd_round_up = result_sign_q & rnd_inexact;
       3'b011:  rnd_round_up = ~result_sign_q & rnd_inexact;
-      3'b100:  rnd_round_up = rnd_new_g;
+      3'b100:  rnd_round_up = rnd_new_g_q;
       default: rnd_round_up = 1'b0;
     endcase
 
@@ -635,66 +673,69 @@ module kronos_fpu_iter
     // 5. Add rounding increment
     // ------------------------------------------------------------------
     if (fmt_d_q)
-      rnd_rounded_mant = {1'b0, rnd_mant_shifted} + {52'b0, rnd_round_up};
+      rnd_rounded_mant = {1'b0, rnd_mant_shifted_q} + {52'b0, rnd_round_up};
     else
-      rnd_rounded_mant = {30'b0, rnd_mant_shifted[22:0]} + {52'b0, rnd_round_up};
+      rnd_rounded_mant = {30'b0, rnd_mant_shifted_q[22:0]} + {52'b0, rnd_round_up};
 
     rnd_carry = fmt_d_q ? rnd_rounded_mant[52] : rnd_rounded_mant[23];
 
-    if (rnd_carry) begin
-      rnd_final_exp = rnd_final_exp + 13'sd1;
-      rnd_rounded_mant = '0;
-    end
+    // Local exponent value - rnd_final_exp_q possibly +1 on carry
+    begin : proc_r2_pack
+      logic signed [12:0] exp_pack;
+      logic [52:0]        mant_pack;
+      exp_pack  = rnd_final_exp_q;
+      mant_pack = rnd_rounded_mant;
+      if (rnd_carry) begin
+        exp_pack  = rnd_final_exp_q + 13'sd1;
+        mant_pack = '0;
+      end
 
-    // ------------------------------------------------------------------
-    // 6. Overflow detection
-    // ------------------------------------------------------------------
-    rnd_overflow = fmt_d_q ? (rnd_final_exp >= 13'sd2047)
-                           : (rnd_final_exp >= 13'sd255);
+      // ----------------------------------------------------------------
+      // 6. Overflow detection
+      // ----------------------------------------------------------------
+      rnd_overflow = fmt_d_q ? (exp_pack >= 13'sd2047)
+                             : (exp_pack >= 13'sd255);
 
-    // Overflow rounding: RTZ or directed toward zero -> max finite
-    rnd_to_max = 1'b0;
-    if (rnd_overflow) begin
-      unique case (rm_q)
-        3'b001:  rnd_to_max = 1'b1;
-        3'b010:  rnd_to_max = ~result_sign_q;
-        3'b011:  rnd_to_max = result_sign_q;
-        default: rnd_to_max = 1'b0;
-      endcase
-    end
-    rnd_overflow_to_inf = rnd_overflow & ~rnd_to_max;
+      rnd_to_max = 1'b0;
+      if (rnd_overflow) begin
+        unique case (rm_q)
+          3'b001:  rnd_to_max = 1'b1;
+          3'b010:  rnd_to_max = ~result_sign_q;
+          3'b011:  rnd_to_max = result_sign_q;
+          default: rnd_to_max = 1'b0;
+        endcase
+      end
+      rnd_overflow_to_inf = rnd_overflow & ~rnd_to_max;
 
-    // ------------------------------------------------------------------
-    // 7. Flag generation
-    // ------------------------------------------------------------------
-    rnd_nx = rnd_inexact | rnd_overflow;
-    rnd_uf = rnd_tiny & rnd_inexact;
-    rnd_of = rnd_overflow;
+      // ----------------------------------------------------------------
+      // 7. Flag generation
+      // ----------------------------------------------------------------
+      rnd_nx = rnd_inexact | rnd_overflow;
+      rnd_uf = rnd_tiny_q & rnd_inexact;
+      rnd_of = rnd_overflow;
+      round_fflags = {1'b0, 1'b0, rnd_of, rnd_uf, rnd_nx};
 
-    round_fflags = {1'b0, 1'b0, rnd_of, rnd_uf, rnd_nx};
-
-    // ------------------------------------------------------------------
-    // 8. Pack result
-    // ------------------------------------------------------------------
-    if (rnd_overflow) begin
-      if (rnd_overflow_to_inf) begin
-        if (fmt_d_q)
-          round_result = {result_sign_q, 11'h7FF, 52'b0};
-        else
-          round_result = {32'hFFFF_FFFF, result_sign_q, 8'hFF, 23'b0};
+      // ----------------------------------------------------------------
+      // 8. Pack result
+      // ----------------------------------------------------------------
+      if (rnd_overflow) begin
+        if (rnd_overflow_to_inf) begin
+          if (fmt_d_q)
+            round_result = {result_sign_q, 11'h7FF, 52'b0};
+          else
+            round_result = {32'hFFFF_FFFF, result_sign_q, 8'hFF, 23'b0};
+        end else begin
+          if (fmt_d_q)
+            round_result = {result_sign_q, 11'h7FE, {52{1'b1}}};
+          else
+            round_result = {32'hFFFF_FFFF, result_sign_q, 8'hFE, {23{1'b1}}};
+        end
       end else begin
         if (fmt_d_q)
-          round_result = {result_sign_q, 11'h7FE, {52{1'b1}}};
+          round_result = {result_sign_q, exp_pack[10:0], mant_pack[51:0]};
         else
-          round_result = {32'hFFFF_FFFF, result_sign_q, 8'hFE, {23{1'b1}}};
+          round_result = {32'hFFFF_FFFF, result_sign_q, exp_pack[7:0], mant_pack[22:0]};
       end
-    end else begin
-      if (fmt_d_q)
-        round_result = {result_sign_q, rnd_final_exp[10:0],
-                        rnd_rounded_mant[51:0]};
-      else
-        round_result = {32'hFFFF_FFFF, result_sign_q, rnd_final_exp[7:0],
-                        rnd_rounded_mant[22:0]};
     end
   end
 
@@ -746,14 +787,14 @@ module kronos_fpu_iter
   assign raw_sticky = (op_q == FP_FDIV) ? rem_nz_div : rem_nz_sqrt;
   assign core_done  = (op_q == FP_FDIV) ? core_done_div : core_done_sqrt;
 
-  // core_start: delayed by one cycle from UNPACK -> ITER so that
+  // core_start: delayed by one cycle from UNPACK2 -> ITER so that
   // a_norm_q / b_norm_q / a_sqrt_q are already latched when the core
   // samples start_i.  High for exactly one clock in the first ITER cycle.
   logic core_start_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_core_start
     if (!rst_ni)        core_start_q <= 1'b0;
     else if (flush_i)   core_start_q <= 1'b0;
-    else                core_start_q <= (state_q == UNPACK) && !is_special;
+    else                core_start_q <= (state_q == UNPACK2) && !is_special_q;
   end
   assign core_start = core_start_q;
 
@@ -763,11 +804,13 @@ module kronos_fpu_iter
   always_comb begin : proc_fsm_next
     state_d = state_q;
     unique case (state_q)
-      IDLE:   if (in_valid_i) state_d = UNPACK;
-      UNPACK: state_d = is_special ? PACK : ITER;
-      ITER:   if (core_done) state_d = ROUND;
-      ROUND:  if (sb_late_grant_i) state_d = PACK;  // hold if scoreboard denies the slot
-      PACK:   state_d = IDLE;
+      IDLE:    if (in_valid_i) state_d = UNPACK1;
+      UNPACK1: state_d = UNPACK2;
+      UNPACK2: state_d = is_special_q ? PACK : ITER;
+      ITER:    if (core_done) state_d = ROUND1;
+      ROUND1:  state_d = ROUND2;
+      ROUND2:  if (sb_late_grant_i) state_d = PACK;  // hold if scoreboard denies the slot
+      PACK:    state_d = IDLE;
       default: state_d = IDLE;
     endcase
   end
@@ -785,7 +828,18 @@ module kronos_fpu_iter
   end
 
   // -----------------------------------------------------------------------
-  // Input latch (IDLE -> UNPACK transition)
+  // iter_busy_q: look-ahead flop so busy_o is driven from an FF Q pin.
+  // state_d is the next-state value, so iter_busy_q asserts on the same
+  // clock edge that state_q transitions out of IDLE.
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_iter_busy
+    if (!rst_ni)       iter_busy_q <= 1'b0;
+    else if (flush_i)  iter_busy_q <= 1'b0;
+    else               iter_busy_q <= (state_d != IDLE);
+  end
+
+  // -----------------------------------------------------------------------
+  // Input latch (IDLE -> UNPACK1 transition)
   // -----------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_input_latch
     if (!rst_ni) begin
@@ -806,32 +860,51 @@ module kronos_fpu_iter
   end
 
   // -----------------------------------------------------------------------
-  // Classify latch (UNPACK -> ITER transition)
+  // Classify latch (UNPACK1 -> UNPACK2 transition)
   // -----------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_class_latch
     if (!rst_ni) begin
       a_class_q <= '0;
       b_class_q <= '0;
-    end else if (state_q == UNPACK) begin
+    end else if (state_q == UNPACK1) begin
       a_class_q <= a_class;
       b_class_q <= b_class;
     end
   end
 
   // -----------------------------------------------------------------------
-  // Normalization latch (UNPACK -> ITER transition, non-special path)
+  // UNPACK1 latch: normalized sigs + unbiased true exponents + specials
   // -----------------------------------------------------------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_norm_latch
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_unpack1_latch
     if (!rst_ni) begin
-      a_norm_q      <= '0;
-      b_norm_q      <= '0;
-      a_sqrt_q      <= '0;
+      a_norm_q         <= '0;
+      b_norm_q         <= '0;
+      a_sqrt_q         <= '0;
+      a_true_exp_q     <= '0;
+      b_true_exp_q     <= '0;
+      is_special_q     <= 1'b0;
+      special_result_q <= '0;
+      special_fflags_q <= '0;
+    end else if (state_q == UNPACK1) begin
+      a_norm_q         <= a_norm;
+      b_norm_q         <= b_norm;
+      a_sqrt_q         <= a_sqrt;
+      a_true_exp_q     <= a_true_exp;
+      b_true_exp_q     <= b_true_exp;
+      is_special_q     <= is_special;
+      special_result_q <= special_result;
+      special_fflags_q <= special_fflags;
+    end
+  end
+
+  // -----------------------------------------------------------------------
+  // UNPACK2 latch: biased result exponent + result sign (from _q inputs)
+  // -----------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_unpack2_latch
+    if (!rst_ni) begin
       result_sign_q <= 1'b0;
       result_exp_q  <= '0;
-    end else if (state_q == UNPACK && !is_special) begin
-      a_norm_q      <= a_norm;
-      b_norm_q      <= b_norm;
-      a_sqrt_q      <= a_sqrt;
+    end else if (state_q == UNPACK2 && !is_special_q) begin
       result_sign_q <= result_sign_comb;
       result_exp_q  <= result_exp_comb;
     end
@@ -857,10 +930,10 @@ module kronos_fpu_iter
     if (!rst_ni) begin
       result_q <= '0;
       fflags_q <= '0;
-    end else if (state_q == UNPACK && is_special) begin
-      result_q <= special_result;
-      fflags_q <= special_fflags;
-    end else if (state_q == ROUND) begin
+    end else if (state_q == UNPACK2 && is_special_q) begin
+      result_q <= special_result_q;
+      fflags_q <= special_fflags_q;
+    end else if (state_q == ROUND2) begin
       result_q <= round_result;
       fflags_q <= round_fflags;
     end
@@ -869,7 +942,7 @@ module kronos_fpu_iter
   // -----------------------------------------------------------------------
   // Output assignments
   // -----------------------------------------------------------------------
-  assign busy_o      = (state_q != IDLE);
+  assign busy_o      = iter_busy_q;
   assign out_valid_o = (state_q == PACK);
   assign result_o    = result_q;
   assign fflags_o    = fflags_q;
@@ -879,7 +952,7 @@ module kronos_fpu_iter
   // ROUND lasts one or more cycles: request the slot every cycle, advance to
   // PACK on grant. Latency=1 means the scoreboard reserves the slot that fires
   // next cycle.
-  assign sb_late_req_o     = (state_q == ROUND);
+  assign sb_late_req_o     = (state_q == ROUND2);
   assign sb_late_fp_dest_o = tag_q.fp_dest;
 
 endmodule

--- a/rtl/stage5/fpu/kronos_fpu_scoreboard.sv
+++ b/rtl/stage5/fpu/kronos_fpu_scoreboard.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module kronos_fpu_scoreboard #(
-  parameter int unsigned DEPTH = 6  // max FPU latency (FADD=6, FMA=5)
+  parameter int unsigned DEPTH = 8  // max FPU latency (FMA=8)
 ) (
   input  logic       clk_i,
   input  logic       rst_ni,
@@ -12,13 +12,13 @@ module kronos_fpu_scoreboard #(
   input  logic       req_i,
   input  logic       fp_dest_i,   // instruction writes FP regfile
   input  logic       int_dest_i,  // instruction writes integer regfile
-  input  logic [2:0] latency_i,   // 1..DEPTH
+  input  logic [3:0] latency_i,   // 1..DEPTH
   output logic       grant_comb_o, // combinational grant (for dispatch gating)
   output logic       grant_o,      // registered grant (stable post-posedge)
   // Late probe — iterative unit reserves a writeback slot at ROUND time
   input  logic       late_req_i,
   input  logic       late_fp_dest_i,
-  input  logic [2:0] late_latency_i,
+  input  logic [3:0] late_latency_i,
   output logic       late_grant_comb_o
 );
   typedef struct packed {
@@ -57,12 +57,14 @@ module kronos_fpu_scoreboard #(
     target_fp   = 1'b0;
     target_intr = 1'b0;
     unique case (latency_i)
-      3'd1:    begin target_fp = slots_q[0].fp; target_intr = slots_q[0].intr; end
-      3'd2:    begin target_fp = slots_q[1].fp; target_intr = slots_q[1].intr; end
-      3'd3:    begin target_fp = slots_q[2].fp; target_intr = slots_q[2].intr; end
-      3'd4:    begin target_fp = slots_q[3].fp; target_intr = slots_q[3].intr; end
-      3'd5:    begin target_fp = slots_q[4].fp; target_intr = slots_q[4].intr; end
-      3'd6:    begin target_fp = slots_q[5].fp; target_intr = slots_q[5].intr; end
+      4'd1:    begin target_fp = slots_q[0].fp; target_intr = slots_q[0].intr; end
+      4'd2:    begin target_fp = slots_q[1].fp; target_intr = slots_q[1].intr; end
+      4'd3:    begin target_fp = slots_q[2].fp; target_intr = slots_q[2].intr; end
+      4'd4:    begin target_fp = slots_q[3].fp; target_intr = slots_q[3].intr; end
+      4'd5:    begin target_fp = slots_q[4].fp; target_intr = slots_q[4].intr; end
+      4'd6:    begin target_fp = slots_q[5].fp; target_intr = slots_q[5].intr; end
+      4'd7:    begin target_fp = slots_q[6].fp; target_intr = slots_q[6].intr; end
+      4'd8:    begin target_fp = slots_q[7].fp; target_intr = slots_q[7].intr; end
       default: begin target_fp = 1'b0;          target_intr = 1'b0;            end
     endcase
 
@@ -82,18 +84,22 @@ module kronos_fpu_scoreboard #(
     // for that index, preserving it one more cycle and allowing time to elapse).
     if (grant_comb) begin
       unique case (latency_i)
-        3'd1:    begin slots_n[0].fp = slots_n[0].fp | fp_dest_i;
+        4'd1:    begin slots_n[0].fp = slots_n[0].fp | fp_dest_i;
                        slots_n[0].intr = slots_n[0].intr | int_dest_i; end
-        3'd2:    begin slots_n[1].fp = slots_n[1].fp | fp_dest_i;
+        4'd2:    begin slots_n[1].fp = slots_n[1].fp | fp_dest_i;
                        slots_n[1].intr = slots_n[1].intr | int_dest_i; end
-        3'd3:    begin slots_n[2].fp = slots_n[2].fp | fp_dest_i;
+        4'd3:    begin slots_n[2].fp = slots_n[2].fp | fp_dest_i;
                        slots_n[2].intr = slots_n[2].intr | int_dest_i; end
-        3'd4:    begin slots_n[3].fp = slots_n[3].fp | fp_dest_i;
+        4'd4:    begin slots_n[3].fp = slots_n[3].fp | fp_dest_i;
                        slots_n[3].intr = slots_n[3].intr | int_dest_i; end
-        3'd5:    begin slots_n[4].fp = slots_n[4].fp | fp_dest_i;
+        4'd5:    begin slots_n[4].fp = slots_n[4].fp | fp_dest_i;
                        slots_n[4].intr = slots_n[4].intr | int_dest_i; end
-        3'd6:    begin slots_n[5].fp = slots_n[5].fp | fp_dest_i;
+        4'd6:    begin slots_n[5].fp = slots_n[5].fp | fp_dest_i;
                        slots_n[5].intr = slots_n[5].intr | int_dest_i; end
+        4'd7:    begin slots_n[6].fp = slots_n[6].fp | fp_dest_i;
+                       slots_n[6].intr = slots_n[6].intr | int_dest_i; end
+        4'd8:    begin slots_n[7].fp = slots_n[7].fp | fp_dest_i;
+                       slots_n[7].intr = slots_n[7].intr | int_dest_i; end
         default: ; // latency out of range, do nothing
       endcase
     end
@@ -102,12 +108,14 @@ module kronos_fpu_scoreboard #(
     // Collision check is FP-only (iterative unit always writes FP regfile).
     late_target_fp = 1'b0;
     unique case (late_latency_i)
-      3'd1:    late_target_fp = slots_q[0].fp;
-      3'd2:    late_target_fp = slots_q[1].fp;
-      3'd3:    late_target_fp = slots_q[2].fp;
-      3'd4:    late_target_fp = slots_q[3].fp;
-      3'd5:    late_target_fp = slots_q[4].fp;
-      3'd6:    late_target_fp = slots_q[5].fp;
+      4'd1:    late_target_fp = slots_q[0].fp;
+      4'd2:    late_target_fp = slots_q[1].fp;
+      4'd3:    late_target_fp = slots_q[2].fp;
+      4'd4:    late_target_fp = slots_q[3].fp;
+      4'd5:    late_target_fp = slots_q[4].fp;
+      4'd6:    late_target_fp = slots_q[5].fp;
+      4'd7:    late_target_fp = slots_q[6].fp;
+      4'd8:    late_target_fp = slots_q[7].fp;
       default: late_target_fp = 1'b0;
     endcase
 
@@ -118,12 +126,14 @@ module kronos_fpu_scoreboard #(
     // at the system level, but structurally OR'd for safety).
     if (late_grant_comb) begin
       unique case (late_latency_i)
-        3'd1:    slots_n[0].fp = slots_n[0].fp | late_fp_dest_i;
-        3'd2:    slots_n[1].fp = slots_n[1].fp | late_fp_dest_i;
-        3'd3:    slots_n[2].fp = slots_n[2].fp | late_fp_dest_i;
-        3'd4:    slots_n[3].fp = slots_n[3].fp | late_fp_dest_i;
-        3'd5:    slots_n[4].fp = slots_n[4].fp | late_fp_dest_i;
-        3'd6:    slots_n[5].fp = slots_n[5].fp | late_fp_dest_i;
+        4'd1:    slots_n[0].fp = slots_n[0].fp | late_fp_dest_i;
+        4'd2:    slots_n[1].fp = slots_n[1].fp | late_fp_dest_i;
+        4'd3:    slots_n[2].fp = slots_n[2].fp | late_fp_dest_i;
+        4'd4:    slots_n[3].fp = slots_n[3].fp | late_fp_dest_i;
+        4'd5:    slots_n[4].fp = slots_n[4].fp | late_fp_dest_i;
+        4'd6:    slots_n[5].fp = slots_n[5].fp | late_fp_dest_i;
+        4'd7:    slots_n[6].fp = slots_n[6].fp | late_fp_dest_i;
+        4'd8:    slots_n[7].fp = slots_n[7].fp | late_fp_dest_i;
         default: ; // latency out of range, do nothing
       endcase
     end

--- a/rtl/stage5/fpu/kronos_fpu_top.sv
+++ b/rtl/stage5/fpu/kronos_fpu_top.sv
@@ -11,7 +11,7 @@
 //   FCVT   3  (FCVT.*.* integer↔FP conversions)
 //   FADD   6  (FADD, FSUB — extra S3b stage for timing closure at 148 MHz)
 //   FMUL   7  (FMUL — s1b pipeline stage added for DSP timing closure)
-//   FMA    7  (FMADD, FMSUB, FNMADD, FNMSUB — split to 7 stages)
+//   FMA    8  (FMADD, FMSUB, FNMADD, FNMSUB — s2b re-latch for DSP timing closure)
 //   ITER   variable (FDIV, FSQRT) — late-reservation via scoreboard
 //
 // busy_o is asserted when in_valid_i is high and the scoreboard detects a
@@ -43,7 +43,7 @@ module kronos_fpu_top
   // ---------------------------------------------------------------------------
   // Dispatch routing: determine unit and latency from op_i
   // ---------------------------------------------------------------------------
-  logic [2:0] dispatch_latency;
+  logic [3:0] dispatch_latency;
   logic       sel_fmisc, sel_fcvt, sel_fadd, sel_fmul, sel_fma, sel_iter;
 
   always_comb begin
@@ -53,7 +53,7 @@ module kronos_fpu_top
     sel_fmul         = 1'b0;
     sel_fma          = 1'b0;
     sel_iter         = 1'b0;
-    dispatch_latency = 3'd0;
+    dispatch_latency = 4'd0;
 
     unique case (op_i)
       FP_FSGNJ, FP_FSGNJN, FP_FSGNJX,
@@ -62,34 +62,34 @@ module kronos_fpu_top
       FP_FEQ,   FP_FLT,   FP_FLE,
       FP_FMV_X_W, FP_FMV_W_X, FP_FMV_X_D, FP_FMV_D_X: begin
         sel_fmisc        = 1'b1;
-        dispatch_latency = 3'd1;
+        dispatch_latency = 4'd1;
       end
       FP_FCVT_W_F, FP_FCVT_WU_F, FP_FCVT_L_F, FP_FCVT_LU_F,
       FP_FCVT_F_W, FP_FCVT_F_WU, FP_FCVT_F_L, FP_FCVT_F_LU,
       FP_FCVT_S_D, FP_FCVT_D_S: begin
         sel_fcvt         = 1'b1;
-        dispatch_latency = 3'd3;
+        dispatch_latency = 4'd3;
       end
       FP_FADD, FP_FSUB: begin
         sel_fadd         = 1'b1;
-        dispatch_latency = 3'd6;
+        dispatch_latency = 4'd6;
       end
       FP_FMUL: begin
         sel_fmul         = 1'b1;
-        dispatch_latency = 3'd7;
+        dispatch_latency = 4'd7;
       end
       FP_FMADD, FP_FMSUB, FP_FNMADD, FP_FNMSUB: begin
         sel_fma          = 1'b1;
-        dispatch_latency = 3'd7;
+        dispatch_latency = 4'd8;
       end
       FP_FDIV, FP_FSQRT: begin
         sel_iter         = 1'b1;
-        dispatch_latency = 3'd0;  // not registered at dispatch (late-reservation)
+        dispatch_latency = 4'd0;  // not registered at dispatch (late-reservation)
       end
       default: begin
         // Unknown op: route nowhere, scoreboard will ignore (latency=0)
         sel_fmisc        = 1'b0;
-        dispatch_latency = 3'd0;
+        dispatch_latency = 4'd0;
       end
     endcase
   end
@@ -115,7 +115,7 @@ module kronos_fpu_top
     .grant_o           (grant),
     .late_req_i        (iter_late_req),
     .late_fp_dest_i    (iter_late_fp_dest),
-    .late_latency_i    (3'd1),
+    .late_latency_i    (4'd1),
     .late_grant_comb_o (iter_late_grant)
   );
 

--- a/rtl/stage5/fpu/kronos_fpu_top.sv
+++ b/rtl/stage5/fpu/kronos_fpu_top.sv
@@ -10,7 +10,7 @@
 //   FMISC  1  (FSGNJ*, FMIN, FMAX, FCLASS, FEQ, FLT, FLE, FMV.*)
 //   FCVT   3  (FCVT.*.* integer↔FP conversions)
 //   FADD   6  (FADD, FSUB — extra S3b stage for timing closure at 148 MHz)
-//   FMUL   6  (FMUL — split to 6 stages for high-Fmax)
+//   FMUL   7  (FMUL — s1b pipeline stage added for DSP timing closure)
 //   FMA    7  (FMADD, FMSUB, FNMADD, FNMSUB — split to 7 stages)
 //   ITER   variable (FDIV, FSQRT) — late-reservation via scoreboard
 //
@@ -76,7 +76,7 @@ module kronos_fpu_top
       end
       FP_FMUL: begin
         sel_fmul         = 1'b1;
-        dispatch_latency = 3'd6;
+        dispatch_latency = 3'd7;
       end
       FP_FMADD, FP_FMSUB, FP_FNMADD, FP_FNMSUB: begin
         sel_fma          = 1'b1;

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -504,7 +504,7 @@ SIM_UNITS := sim-alu sim-regfile sim-decode \
 
 SIM_REPORT_DIR := $(OBJ_DIR)/sim-results
 
-sim-all:
+sim-all: $(SF_LIB)
 	@rm -rf $(SIM_REPORT_DIR) && mkdir -p $(SIM_REPORT_DIR)
 	@pids=""; \
 	for t in $(SIM_UNITS); do \
@@ -894,7 +894,6 @@ TB_LSU_FP_FILES := $(AXI_PKG_SV) \
                    $(TB_DIR)/stage5/tb_lsu_fp.sv
 sim-lsu-fp:
 	$(VERILATOR) $(WAIVER) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
-	  --Wno-PROCASSINIT \
 	  --top-module tb_lsu_fp $(TB_LSU_FP_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/lsu_fp
 	$(OBJ_DIR)/lsu_fp/Vtb_lsu_fp

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -495,7 +495,12 @@ SIM_UNITS := sim-alu sim-regfile sim-decode \
              sim-lsu-s1 sim-forward sim-hazard \
              sim-muldiv \
              sim-decompress sim-align sim-lsu-s3 sim-bpred \
-             sim-alu-s4 sim-decode-s4 sim-muldiv-s4 sim-lsu-s4
+             sim-alu-s4 sim-decode-s4 sim-muldiv-s4 sim-lsu-s4 \
+             sim-pkg-fp sim-hf-smoke sim-sf-smoke \
+             sim-fpu-scoreboard sim-regfile-fp sim-csr-fp sim-decode-fp sim-lsu-fp \
+             sim-fpu-fdiv-core sim-fpu-fsqrt-core sim-fpu-fcvt \
+             sim-fpu-fadd sim-fpu-fmul sim-fpu-fma sim-fpu-fmisc \
+             sim-fpu-iter sim-fpu-top sim-fpu-top-iter
 
 SIM_REPORT_DIR := $(OBJ_DIR)/sim-results
 

--- a/tb/stage3/tb_bpred.sv
+++ b/tb/stage3/tb_bpred.sv
@@ -30,13 +30,16 @@ module tb_bpred;
   always #5 clk = ~clk;
   task tick; @(posedge clk); #1; endtask
 
-  // update task: is_jal=0 for conditional branch, is_jal=1 for JAL
+  // update task: is_jal=0 for conditional branch, is_jal=1 for JAL.
+  // Two ticks are needed: tick 1 registers inputs into _q; tick 2 commits
+  // the _q values into BTB/counters (one-cycle update pipeline in DUT).
   task update(input logic [31:0] upc, input logic taken,
               input logic [31:0] tgt, input logic is_jal);
     upd_valid = 1; upd_pc = upc; upd_taken = taken;
     upd_target = tgt; upd_is_jal = is_jal;
     tick;
     upd_valid = 0;
+    tick;  // wait for _q values to commit into BTB / counters
   endtask
 
   initial begin

--- a/tb/stage5/tb_csr_fp.sv
+++ b/tb/stage5/tb_csr_fp.sv
@@ -38,6 +38,7 @@ module tb_csr_fp;
     // New FP interface
     .fflags_delta_i(fflags_delta), .fflags_we_i(fflags_we),
     .fp_rd_we_i(1'b0),
+    .instret_retire_i(1'b0),
     .frm_o(frm)
   );
 

--- a/tb/stage5/tb_decode_fp.sv
+++ b/tb/stage5/tb_decode_fp.sv
@@ -115,16 +115,16 @@ module tb_decode_fp;
     check("fclass.d !rd_fp", !dec.rd_fp);
     check("fclass.d rd_wen", dec.rd_wen);
 
-    // FMV.W.X f1, x2  (funct7=1110100, funct3=000, rs2=00000, opcode=0x53)
-    instr = {7'b1110100, 5'd0, 5'd2, 3'b000, 5'd1, 7'b1010011};
+    // FMV.W.X f1, x2  (funct7=1111000, funct3=000, rs2=00000, opcode=0x53)
+    instr = {7'b1111000, 5'd0, 5'd2, 3'b000, 5'd1, 7'b1010011};
     #1;
     check("fmv.w.x op",      dec.fp_op === FP_FMV_W_X);
     check("fmv.w.x !rs1_fp", !dec.rs1_fp);
     check("fmv.w.x rd_fp",   dec.rd_fp);
 
-    // FCVT.D.S f1, f2  (funct7=0100000, rs2=00000, opcode=0x53)
-    // funct7[6:2]=01000, funct7[1:0]=00 → S→D conversion
-    instr = {7'b0100000, 5'd0, 5'd2, 3'b000, 5'd1, 7'b1010011};
+    // FCVT.D.S f1, f2  (funct7=0100001, rs2=00000, opcode=0x53)
+    // funct7[6:2]=01000, funct7[1:0]=01 → S→D conversion
+    instr = {7'b0100001, 5'd0, 5'd2, 3'b000, 5'd1, 7'b1010011};
     #1;
     check("fcvt.d.s op",     dec.fp_op === FP_FCVT_D_S);
     check("fcvt.d.s rs1_fp", dec.rs1_fp);
@@ -139,10 +139,10 @@ module tb_decode_fp;
     check("fnmadd.s rs3",    dec.rs3 === 5'd5);
     check("fnmadd.s !fmt_d", !dec.fmt_d);
 
-    // FDIV.S — must be illegal (Stage 5b only)
+    // FDIV.S — legal in Stage 5b (iterative SRT)
     instr = {7'b0001100, 5'd3, 5'd2, 3'b000, 5'd1, 7'b1010011};
     #1;
-    check("fdiv.s illegal", illegal);
+    check("fdiv.s legal", !illegal);
 
     $display("tb_decode_fp PASS");
     $finish;

--- a/tb/stage5/tb_fpu_fcvt.sv
+++ b/tb/stage5/tb_fpu_fcvt.sv
@@ -370,16 +370,18 @@ module tb_fpu_fcvt;
     begin : blk_rand_fcvt_d_s
       logic [31:0]     ra;
       longint unsigned sf_f64r;
+      byte unsigned    sf_f;
       for (int k = 0; k < 100; k++) begin
         ra      = $urandom;
         sf_reset();
         sf_f64r = sf_f32_to_f64(ra);
+        sf_f    = sf_exceptions();
         // fmt_d_i=1: output format is double
         apply_and_wait(FP_FCVT_D_S, 1'b1, 3'd0, {32'hFFFF_FFFF, ra});
         total++;
-        if (result !== sf_f64r || fflags !== 5'b0) begin
-          $error("[fcvt.d.s #%0d] a=%h dut=%h/%02h sf=%h/00",
-                 k, ra, result, fflags, sf_f64r);
+        if (result !== sf_f64r || fflags !== sf_f[4:0]) begin
+          $error("[fcvt.d.s #%0d] a=%h dut=%h/%02h sf=%h/%02h",
+                 k, ra, result, fflags, sf_f64r, sf_f);
           errors++;
         end
       end

--- a/tb/stage5/tb_fpu_fma.sv
+++ b/tb/stage5/tb_fpu_fma.sv
@@ -77,16 +77,16 @@ module tb_fpu_fma;
     sf_b = bs;
     sf_c = cs;
     unique case (o)
-      FP_FMADD:  begin sf_reset(); sf_r = sf_f32_mulAdd(sf_a, sf_b, sf_c, r); end
+      FP_FMADD:  begin sf_reset(); sf_r = sf_f32_mulAdd(sf_a, sf_b, sf_c, {5'b0, r}); end
       FP_FMSUB:  begin sf_reset();
-                       sf_r = sf_f32_mulAdd(sf_a, sf_b, {~sf_c[31], sf_c[30:0]}, r);
+                       sf_r = sf_f32_mulAdd(sf_a, sf_b, {~sf_c[31], sf_c[30:0]}, {5'b0, r});
                  end
       FP_FNMADD: begin sf_reset();
-                       sf_r = sf_f32_mulAdd({~sf_a[31], sf_a[30:0]}, sf_b, sf_c, r);
+                       sf_r = sf_f32_mulAdd({~sf_a[31], sf_a[30:0]}, sf_b,
+                                            {~sf_c[31], sf_c[30:0]}, {5'b0, r});
                  end
       FP_FNMSUB: begin sf_reset();
-                       sf_r = sf_f32_mulAdd({~sf_a[31], sf_a[30:0]}, sf_b,
-                                            {~sf_c[31], sf_c[30:0]}, r);
+                       sf_r = sf_f32_mulAdd({~sf_a[31], sf_a[30:0]}, sf_b, sf_c, {5'b0, r});
                  end
       default:   begin sf_r = '0; end
     endcase
@@ -107,16 +107,16 @@ module tb_fpu_fma;
     byte unsigned sf_f;
     apply5(o, 1'b1, r, ad, bd, cd);
     unique case (o)
-      FP_FMADD:  begin sf_reset(); sf_r = sf_f64_mulAdd(ad, bd, cd, r); end
+      FP_FMADD:  begin sf_reset(); sf_r = sf_f64_mulAdd(ad, bd, cd, {5'b0, r}); end
       FP_FMSUB:  begin sf_reset();
-                       sf_r = sf_f64_mulAdd(ad, bd, {~cd[63], cd[62:0]}, r);
+                       sf_r = sf_f64_mulAdd(ad, bd, {~cd[63], cd[62:0]}, {5'b0, r});
                  end
       FP_FNMADD: begin sf_reset();
-                       sf_r = sf_f64_mulAdd({~ad[63], ad[62:0]}, bd, cd, r);
+                       sf_r = sf_f64_mulAdd({~ad[63], ad[62:0]}, bd,
+                                            {~cd[63], cd[62:0]}, {5'b0, r});
                  end
       FP_FNMSUB: begin sf_reset();
-                       sf_r = sf_f64_mulAdd({~ad[63], ad[62:0]}, bd,
-                                            {~cd[63], cd[62:0]}, r);
+                       sf_r = sf_f64_mulAdd({~ad[63], ad[62:0]}, bd, cd, {5'b0, r});
                  end
       default:   begin sf_r = '0; end
     endcase
@@ -387,9 +387,9 @@ module tb_fpu_fma;
               FP_FMSUB:  sf_r32 = sf_f32_mulAdd(ra32, rb32,
                                     {~rc32[31], rc32[30:0]}, rm_i[7:0]);
               FP_FNMADD: sf_r32 = sf_f32_mulAdd({~ra32[31], ra32[30:0]}, rb32,
-                                    rc32, rm_i[7:0]);
-              FP_FNMSUB: sf_r32 = sf_f32_mulAdd({~ra32[31], ra32[30:0]}, rb32,
                                     {~rc32[31], rc32[30:0]}, rm_i[7:0]);
+              FP_FNMSUB: sf_r32 = sf_f32_mulAdd({~ra32[31], ra32[30:0]}, rb32,
+                                    rc32, rm_i[7:0]);
               default:   sf_r32 = '0;
             endcase
             sf_f   = sf_exceptions();
@@ -421,9 +421,9 @@ module tb_fpu_fma;
               FP_FMSUB:  sf_r64 = sf_f64_mulAdd(ra64, rb64,
                                     {~rc64[63], rc64[62:0]}, rm_i[7:0]);
               FP_FNMADD: sf_r64 = sf_f64_mulAdd({~ra64[63], ra64[62:0]}, rb64,
-                                    rc64, rm_i[7:0]);
-              FP_FNMSUB: sf_r64 = sf_f64_mulAdd({~ra64[63], ra64[62:0]}, rb64,
                                     {~rc64[63], rc64[62:0]}, rm_i[7:0]);
+              FP_FNMSUB: sf_r64 = sf_f64_mulAdd({~ra64[63], ra64[62:0]}, rb64,
+                                    rc64, rm_i[7:0]);
               default:   sf_r64 = '0;
             endcase
             sf_f   = sf_exceptions();

--- a/tb/stage5/tb_fpu_fma.sv
+++ b/tb/stage5/tb_fpu_fma.sv
@@ -59,8 +59,8 @@ module tb_fpu_fma;
       c        = cin;
     @(negedge clk);
       in_valid = 0;
-    // 5-deep pipeline + output reg
-    repeat (6) @(posedge clk);
+    // 7-deep pipeline + output reg (S2b re-latch added for DSP timing)
+    repeat (7) @(posedge clk);
     #1;
   endtask
 
@@ -368,13 +368,13 @@ module tb_fpu_fma;
           // a and b exponents in [0x50, 0xB4] so that ea+eb-127 in [1, 0xE9] (always normal).
           // c exponent in [0x01, 0xFE] (any normal).
           for (iter = 0; iter < 200; iter++) begin
-            e8    = 8'($urandom_range(8'hB4, 8'h50));
+            e8    = 8'($urandom_range(32'hB4, 32'h50));
             raw32 = $urandom();
             ra32  = {raw32[31], e8, raw32[22:0]};
-            e8    = 8'($urandom_range(8'hB4, 8'h50));
+            e8    = 8'($urandom_range(32'hB4, 32'h50));
             raw32 = $urandom();
             rb32  = {raw32[31], e8, raw32[22:0]};
-            e8    = 8'($urandom_range(8'hFE, 8'h01));
+            e8    = 8'($urandom_range(32'hFE, 32'h01));
             raw32 = $urandom();
             rc32  = {raw32[31], e8, raw32[22:0]};
             apply5(rand_op, 1'b0, rm_i[2:0],
@@ -405,13 +405,13 @@ module tb_fpu_fma;
           // a and b exponents in [0x200, 0x5FE] so ea+eb-1023 in [1, 0x7FB] (always normal).
           // c exponent in [0x001, 0x7FE] (any normal).
           for (iter = 0; iter < 200; iter++) begin
-            e11   = 11'($urandom_range(11'h5FE, 11'h200));
+            e11   = 11'($urandom_range(32'h5FE, 32'h200));
             raw64a = {32'($urandom()), 32'($urandom())};
             ra64  = {raw64a[63], e11, raw64a[51:0]};
-            e11   = 11'($urandom_range(11'h5FE, 11'h200));
+            e11   = 11'($urandom_range(32'h5FE, 32'h200));
             raw64b = {32'($urandom()), 32'($urandom())};
             rb64  = {raw64b[63], e11, raw64b[51:0]};
-            e11   = 11'($urandom_range(11'h7FE, 11'h001));
+            e11   = 11'($urandom_range(32'h7FE, 32'h001));
             raw64c = {32'($urandom()), 32'($urandom())};
             rc64  = {raw64c[63], e11, raw64c[51:0]};
             apply5(rand_op, 1'b1, rm_i[2:0], ra64, rb64, rc64);

--- a/tb/stage5/tb_fpu_fmisc.sv
+++ b/tb/stage5/tb_fpu_fmisc.sv
@@ -50,9 +50,9 @@ module tb_fpu_fmisc;
 
     // ── FCLASS.D — all ten number categories ─────────────────────────────
     apply(FP_FCLASS, 1'b1, 64'h7FF4_0000_0000_0000, 64'h0); // sNaN.D
-    if (result[9] !== 1'b1) $fatal(1, "fclass.d sNaN: %h", result);
+    if (result[8] !== 1'b1) $fatal(1, "fclass.d sNaN: %h", result);
     apply(FP_FCLASS, 1'b1, 64'h7FF8_0000_0000_0000, 64'h0); // qNaN.D
-    if (result[8] !== 1'b1) $fatal(1, "fclass.d qNaN: %h", result);
+    if (result[9] !== 1'b1) $fatal(1, "fclass.d qNaN: %h", result);
     apply(FP_FCLASS, 1'b1, 64'hFFF0_0000_0000_0000, 64'h0); // -inf.D
     if (result[0] !== 1'b1) $fatal(1, "fclass.d -inf: %h", result);
     apply(FP_FCLASS, 1'b1, 64'h7FF0_0000_0000_0000, 64'h0); // +inf.D
@@ -72,9 +72,9 @@ module tb_fpu_fmisc;
 
     // ── FCLASS.S — all ten number categories (NaN-boxed) ─────────────────
     apply(FP_FCLASS, 1'b0, 64'hFFFF_FFFF_7FA0_0000, 64'h0); // sNaN.S
-    if (result[9] !== 1'b1) $fatal(1, "fclass.s sNaN: %h", result);
+    if (result[8] !== 1'b1) $fatal(1, "fclass.s sNaN: %h", result);
     apply(FP_FCLASS, 1'b0, 64'hFFFF_FFFF_7FC0_0000, 64'h0); // qNaN.S
-    if (result[8] !== 1'b1) $fatal(1, "fclass.s qNaN: %h", result);
+    if (result[9] !== 1'b1) $fatal(1, "fclass.s qNaN: %h", result);
     apply(FP_FCLASS, 1'b0, 64'hFFFF_FFFF_FF80_0000, 64'h0); // -inf.S
     if (result[0] !== 1'b1) $fatal(1, "fclass.s -inf: %h", result);
     apply(FP_FCLASS, 1'b0, 64'hFFFF_FFFF_7F80_0000, 64'h0); // +inf.S
@@ -193,9 +193,9 @@ module tb_fpu_fmisc;
     // zero: min(+0D, -0D) = -0D
     apply(FP_FMIN, 1'b1, 64'h0000_0000_0000_0000, 64'h8000_0000_0000_0000);
     if (!out_valid || result !== 64'h8000_0000_0000_0000) $fatal(1, "fmin.d +0/-0: %h", result);
-    // sNaN → canonical qNaN.D + NV
+    // sNaN → non-NaN operand + NV (per RISC-V spec: "result is the non-NaN operand")
     apply(FP_FMIN, 1'b1, 64'h7FF4_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result !== 64'h7FF8_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b1)
+    if (!out_valid || result !== 64'h3FF0_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b1)
       $fatal(1, "fmin.d sNaN: %h/%b", result, fflags);
     // qNaN a, number b → return b
     apply(FP_FMIN, 1'b1, 64'h7FF8_0000_0000_0000, 64'h3FF0_0000_0000_0000);
@@ -211,9 +211,9 @@ module tb_fpu_fmisc;
     // zero: max(+0D, -0D) = +0D
     apply(FP_FMAX, 1'b1, 64'h0000_0000_0000_0000, 64'h8000_0000_0000_0000);
     if (!out_valid || result !== 64'h0000_0000_0000_0000) $fatal(1, "fmax.d +0/-0: %h", result);
-    // sNaN → canonical qNaN.D + NV
+    // sNaN → non-NaN operand + NV (per RISC-V spec: "result is the non-NaN operand")
     apply(FP_FMAX, 1'b1, 64'h7FF4_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result !== 64'h7FF8_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b1)
+    if (!out_valid || result !== 64'h3FF0_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b1)
       $fatal(1, "fmax.d sNaN: %h/%b", result, fflags);
     // qNaN a, number b → return b
     apply(FP_FMAX, 1'b1, 64'h7FF8_0000_0000_0000, 64'h3FF0_0000_0000_0000);
@@ -303,11 +303,11 @@ module tb_fpu_fmisc;
         // Reference FLE.S: a <= b  iff  a < b  or  a == b (feq semantics)
         ref_fle = ref_flt | ref_feq;
 
-        // Reference FMIN.S (DUT behaviour: sNaN → canonical qNaN + NV;
-        // qNaN-only → non-NaN operand; -0 < +0 per IEEE 754-2008 minNum)
-        if (a_snan || b_snan) begin
-          ref_fmin = 32'h7FC0_0000;  // sNaN input → canonical qNaN
-        end else if (a_nan && b_nan) begin
+        // Reference FMIN.S per RISC-V spec:
+        // - Both NaN (any combo) → canonical qNaN
+        // - One NaN → the non-NaN operand (even if the NaN is signaling)
+        // - sNaN → also raise NV
+        if (a_nan && b_nan) begin
           ref_fmin = 32'h7FC0_0000;
         end else if (a_nan) begin
           ref_fmin = rb32;
@@ -322,10 +322,8 @@ module tb_fpu_fmisc;
           ref_fmin = rb32;
         end
 
-        // Reference FMAX.S: sNaN → canonical qNaN + NV; qNaN-only → non-NaN; +0 > -0
-        if (a_snan || b_snan) begin
-          ref_fmax = 32'h7FC0_0000;  // sNaN input → canonical qNaN
-        end else if (a_nan && b_nan) begin
+        // Reference FMAX.S per RISC-V spec: same NaN rules as FMIN.S
+        if (a_nan && b_nan) begin
           ref_fmax = 32'h7FC0_0000;
         end else if (a_nan) begin
           ref_fmax = rb32;

--- a/tb/stage5/tb_fpu_fmul.sv
+++ b/tb/stage5/tb_fpu_fmul.sv
@@ -34,7 +34,7 @@ module tb_fpu_fmul;
                         input logic [63:0] ain, bin);
     @(negedge clk); in_valid=1; op=o; fmt_d=fmtd; rm=r; a=ain; b=bin;
     @(negedge clk); in_valid=0;
-    repeat(5) @(posedge clk); #1;
+    repeat(6) @(posedge clk); #1;
   endtask
 
   int errors = 0, total = 0;

--- a/tb/stage5/tb_fpu_fmul.sv
+++ b/tb/stage5/tb_fpu_fmul.sv
@@ -34,7 +34,7 @@ module tb_fpu_fmul;
                         input logic [63:0] ain, bin);
     @(negedge clk); in_valid=1; op=o; fmt_d=fmtd; rm=r; a=ain; b=bin;
     @(negedge clk); in_valid=0;
-    repeat(4) @(posedge clk); #1;
+    repeat(5) @(posedge clk); #1;
   endtask
 
   int errors = 0, total = 0;
@@ -60,7 +60,7 @@ module tb_fpu_fmul;
         sf_f = sf_exceptions();
         expected = {32'hFFFF_FFFF, sf_r};
         if (!two_way_check("f32_mul", v.a, v.b, 0, v.rm, result, expected,
-                           fflags, sf_f[4:0]))
+                           8'(fflags), 8'(sf_f[4:0])))
           errors++;
         total++;
       end
@@ -81,7 +81,7 @@ module tb_fpu_fmul;
         sf_r = sf_f64_mul(v.a, v.b, v.rm);
         sf_f = sf_exceptions();
         if (!two_way_check("f64_mul", v.a, v.b, 0, v.rm, result, sf_r,
-                           fflags, sf_f[4:0]))
+                           8'(fflags), 8'(sf_f[4:0])))
           errors++;
         total++;
       end
@@ -128,7 +128,7 @@ module tb_fpu_fmul;
       end
     end
 
-    if (errors) $fatal(1, "tb_fpu_fmul: %0d/%0d mismatches", errors, total);
+    if (errors != 0) $fatal(1, "tb_fpu_fmul: %0d/%0d mismatches", errors, total);
     $display("tb_fpu_fmul PASS (%0d vectors)", total);
     $finish;
   end

--- a/tb/stage5/tb_fpu_scoreboard.sv
+++ b/tb/stage5/tb_fpu_scoreboard.sv
@@ -5,13 +5,13 @@
 module tb_fpu_scoreboard;
   logic       clk = 0, rst_n = 0, flush = 0;
   logic       dispatch_req, dispatch_fp, dispatch_int;
-  logic [2:0] dispatch_latency;  // 1..5
+  logic [3:0] dispatch_latency;  // 1..DEPTH
   logic       dispatch_ok;
 
   logic dispatch_ok_comb;
 
   logic       late_req, late_fp;
-  logic [2:0] late_latency;
+  logic [3:0] late_latency;
   logic       late_grant_comb;
 
   kronos_fpu_scoreboard u_dut (
@@ -26,7 +26,7 @@ module tb_fpu_scoreboard;
   task automatic dispatch(input logic fp, input logic intw, input int lat,
                           input bit expect_ok);
     @(negedge clk) dispatch_req = 1; dispatch_fp = fp; dispatch_int = intw;
-                   dispatch_latency = lat[2:0];
+                   dispatch_latency = lat[3:0];
     @(posedge clk) #1;
     if (dispatch_ok !== expect_ok)
       $fatal(1, "lat=%0d fp=%b int=%b expect=%b got=%b",
@@ -66,7 +66,7 @@ module tb_fpu_scoreboard;
     @(negedge clk) rst_n = 0; @(negedge clk) rst_n = 1;
 
     // Test 1: late_req=1, target slot free → grant=1, reservation appears.
-    @(negedge clk) late_req = 1; late_fp = 1; late_latency = 3'd2;
+    @(negedge clk) late_req = 1; late_fp = 1; late_latency = 4'd2;
     #1;
     if (late_grant_comb !== 1'b1)
       $fatal(1, "late-probe free: expected grant=1, got=%b", late_grant_comb);
@@ -84,7 +84,7 @@ module tb_fpu_scoreboard;
     dispatch(1, 0, 2, 1'b1);
     // Now late-probe at lat=1: after the shift, the dispatch reservation that
     // was at slot[1] moved to slot[0]. Late probe at lat=1 targets slot[0].
-    @(negedge clk) late_req = 1; late_fp = 1; late_latency = 3'd1;
+    @(negedge clk) late_req = 1; late_fp = 1; late_latency = 4'd1;
     #1;
     if (late_grant_comb !== 1'b0)
       $fatal(1, "late-probe occupied: expected grant=0, got=%b", late_grant_comb);
@@ -92,7 +92,7 @@ module tb_fpu_scoreboard;
 
     // Test 3: late_req=0 → grant=0 always.
     @(negedge clk) rst_n = 0; @(negedge clk) rst_n = 1;
-    @(negedge clk) late_req = 0; late_fp = 1; late_latency = 3'd2;
+    @(negedge clk) late_req = 0; late_fp = 1; late_latency = 4'd2;
     #1;
     if (late_grant_comb !== 1'b0)
       $fatal(1, "late-probe no-req: expected grant=0, got=%b", late_grant_comb);

--- a/tb/stage5/tb_fpu_top_iter.sv
+++ b/tb/stage5/tb_fpu_top_iter.sv
@@ -144,7 +144,7 @@ module tb_fpu_top_iter;
       end
 
       // Collect both results (FADD arrives first at ~lat4, FDIV much later)
-      collect_valids(80, 2, collected, tags);
+      collect_valids(200, 2, collected, tags);
       if (collected < 2) begin
         $display("[blocking] FAIL: expected 2 out_valid pulses, got %0d", collected);
         errors++;
@@ -187,7 +187,7 @@ module tb_fpu_top_iter;
       dispatch(FP_FDIV, 1'b1, D_4_0, D_2_0, '0, tg_div);
 
       // Collect both results
-      collect_valids(80, 2, collected, tags);
+      collect_valids(200, 2, collected, tags);
       if (collected < 2) begin
         $display("[late-res] FAIL: expected 2 out_valid pulses, got %0d", collected);
         errors++;
@@ -231,7 +231,7 @@ module tb_fpu_top_iter;
       @(negedge clk); flush = 0;
 
       // Verify no writeback from the flushed FDIV
-      wait_out_valid(80, got);
+      wait_out_valid(200, got);
       if (got) begin
         $display("[flush] FAIL: out_valid fired after flush");
         errors++;
@@ -281,9 +281,9 @@ module tb_fpu_top_iter;
       dispatch(FP_FDIV, 1'b1, D_2_0, D_1_0, '0, tg1);
 
       // Wait for first to complete
-      wait_out_valid(80, got);
+      wait_out_valid(200, got);
       if (!got) begin
-        $display("[b2b] FAIL: first FDIV.D did not complete within 80 cycles");
+        $display("[b2b] FAIL: first FDIV.D did not complete within 200 cycles");
         errors++;
       end else begin
         if (tag_out.rd != tg1.rd) begin
@@ -300,9 +300,9 @@ module tb_fpu_top_iter;
         dispatch(FP_FDIV, 1'b1, D_4_0, D_2_0, '0, tg2);
 
         // Wait for second to complete
-        wait_out_valid(80, got);
+        wait_out_valid(200, got);
         if (!got) begin
-          $display("[b2b] FAIL: second FDIV.D did not complete within 80 cycles");
+          $display("[b2b] FAIL: second FDIV.D did not complete within 200 cycles");
           errors++;
         end else begin
           if (tag_out.rd != tg2.rd) begin

--- a/tb/stage5/tb_lsu_fp.sv
+++ b/tb/stage5/tb_lsu_fp.sv
@@ -11,7 +11,7 @@
 module tb_lsu_fp;
   import kronos_pkg::*;
 
-  logic             clk = 0, rst_n = 0;
+  logic             clk, rst_n;
   logic             req, we;
   logic [31:0]      addr;
   logic [63:0]      wdata;
@@ -108,6 +108,7 @@ module tb_lsu_fp;
   int errors = 0;
 
   initial begin
+    clk = 0; rst_n = 0;
     is_lr = 0; is_sc = 0; is_amo = 0; amo_funct5 = 0; amo_src = 0;
     fp_dest_req = 0; fp_store_data = '0;
     req = 0; we = 0;

--- a/tb/stage5/tb_lsu_fp.sv
+++ b/tb/stage5/tb_lsu_fp.sv
@@ -229,7 +229,7 @@ module tb_lsu_fp;
     end else
       $display("[FSW/FLW nanbox] OK: fp_rdata=%h", fp_rdata);
 
-    if (errors) $fatal(1, "tb_lsu_fp: %0d error(s)", errors);
+    if (errors != 0) $fatal(1, "tb_lsu_fp: %0d error(s)", errors);
     $display("tb_lsu_fp PASS");
     $finish;
   end

--- a/tb/stage5/tb_regfile_fp.sv
+++ b/tb/stage5/tb_regfile_fp.sv
@@ -40,9 +40,11 @@ module tb_regfile_fp;
     // (FP regfile has no internal bypass — the dispatch scoreboard + EX bypass
     // net handles this.)
     @(negedge clk) we = 1; wa = 7; wd = 64'h0000_0000_0000_0001; ra1 = 7;
-    @(posedge clk) #1;
+    // Check before posedge: write hasn't committed yet, old value must be visible.
+    #1;
     if (rd1 === 64'h0000_0000_0000_0001) $fatal(1,
       "FP regfile unexpectedly internally forwarded");
+    @(posedge clk); #1;
 
     // Next cycle the new value is visible
     @(negedge clk) we = 0;

--- a/vendor/softfloat/build/Makefile
+++ b/vendor/softfloat/build/Makefile
@@ -1,0 +1,397 @@
+
+#=============================================================================
+#
+# This Makefile is part of the SoftFloat IEEE Floating-Point Arithmetic
+# Package, Release 3e, by John R. Hauser.
+#
+# Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+# University of California.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions, and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions, and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the University nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+# DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#=============================================================================
+
+SOURCE_DIR ?= ../../source
+SPECIALIZE_TYPE ?= 8086-SSE
+
+SOFTFLOAT_OPTS ?= \
+  -DSOFTFLOAT_ROUND_ODD -DINLINE_LEVEL=5 -DSOFTFLOAT_FAST_DIV32TO16 \
+  -DSOFTFLOAT_FAST_DIV64TO32
+
+DELETE = rm -f
+C_INCLUDES = -I. -I$(SOURCE_DIR)/$(SPECIALIZE_TYPE) -I$(SOURCE_DIR)/include
+COMPILE_C = \
+  gcc -c -Werror-implicit-function-declaration -DSOFTFLOAT_FAST_INT64 \
+    $(SOFTFLOAT_OPTS) $(C_INCLUDES) -O2 -o $@
+MAKELIB = ar crs $@
+
+OBJ = .o
+LIB = .a
+
+OTHER_HEADERS = $(SOURCE_DIR)/include/opts-GCC.h
+
+.PHONY: all
+all: softfloat$(LIB)
+
+OBJS_PRIMITIVES = \
+  s_eq128$(OBJ) \
+  s_le128$(OBJ) \
+  s_lt128$(OBJ) \
+  s_shortShiftLeft128$(OBJ) \
+  s_shortShiftRight128$(OBJ) \
+  s_shortShiftRightJam64$(OBJ) \
+  s_shortShiftRightJam64Extra$(OBJ) \
+  s_shortShiftRightJam128$(OBJ) \
+  s_shortShiftRightJam128Extra$(OBJ) \
+  s_shiftRightJam32$(OBJ) \
+  s_shiftRightJam64$(OBJ) \
+  s_shiftRightJam64Extra$(OBJ) \
+  s_shiftRightJam128$(OBJ) \
+  s_shiftRightJam128Extra$(OBJ) \
+  s_shiftRightJam256M$(OBJ) \
+  s_countLeadingZeros8$(OBJ) \
+  s_countLeadingZeros16$(OBJ) \
+  s_countLeadingZeros32$(OBJ) \
+  s_countLeadingZeros64$(OBJ) \
+  s_add128$(OBJ) \
+  s_add256M$(OBJ) \
+  s_sub128$(OBJ) \
+  s_sub256M$(OBJ) \
+  s_mul64ByShifted32To128$(OBJ) \
+  s_mul64To128$(OBJ) \
+  s_mul128By32$(OBJ) \
+  s_mul128To256M$(OBJ) \
+  s_approxRecip_1Ks$(OBJ) \
+  s_approxRecip32_1$(OBJ) \
+  s_approxRecipSqrt_1Ks$(OBJ) \
+  s_approxRecipSqrt32_1$(OBJ) \
+
+OBJS_SPECIALIZE = \
+  softfloat_raiseFlags$(OBJ) \
+  s_f16UIToCommonNaN$(OBJ) \
+  s_commonNaNToF16UI$(OBJ) \
+  s_propagateNaNF16UI$(OBJ) \
+  s_bf16UIToCommonNaN$(OBJ) \
+  s_commonNaNToBF16UI$(OBJ) \
+  s_f32UIToCommonNaN$(OBJ) \
+  s_commonNaNToF32UI$(OBJ) \
+  s_propagateNaNF32UI$(OBJ) \
+  s_f64UIToCommonNaN$(OBJ) \
+  s_commonNaNToF64UI$(OBJ) \
+  s_propagateNaNF64UI$(OBJ) \
+  extF80M_isSignalingNaN$(OBJ) \
+  s_extF80UIToCommonNaN$(OBJ) \
+  s_commonNaNToExtF80UI$(OBJ) \
+  s_propagateNaNExtF80UI$(OBJ) \
+  f128M_isSignalingNaN$(OBJ) \
+  s_f128UIToCommonNaN$(OBJ) \
+  s_commonNaNToF128UI$(OBJ) \
+  s_propagateNaNF128UI$(OBJ) \
+
+OBJS_OTHERS = \
+  s_roundToUI32$(OBJ) \
+  s_roundToUI64$(OBJ) \
+  s_roundToI32$(OBJ) \
+  s_roundToI64$(OBJ) \
+  s_normSubnormalBF16Sig$(OBJ) \
+  s_roundPackToBF16$(OBJ) \
+  s_normSubnormalF16Sig$(OBJ) \
+  s_roundPackToF16$(OBJ) \
+  s_normRoundPackToF16$(OBJ) \
+  s_addMagsF16$(OBJ) \
+  s_subMagsF16$(OBJ) \
+  s_mulAddF16$(OBJ) \
+  s_normSubnormalF32Sig$(OBJ) \
+  s_roundPackToF32$(OBJ) \
+  s_normRoundPackToF32$(OBJ) \
+  s_addMagsF32$(OBJ) \
+  s_subMagsF32$(OBJ) \
+  s_mulAddF32$(OBJ) \
+  s_normSubnormalF64Sig$(OBJ) \
+  s_roundPackToF64$(OBJ) \
+  s_normRoundPackToF64$(OBJ) \
+  s_addMagsF64$(OBJ) \
+  s_subMagsF64$(OBJ) \
+  s_mulAddF64$(OBJ) \
+  s_normSubnormalExtF80Sig$(OBJ) \
+  s_roundPackToExtF80$(OBJ) \
+  s_normRoundPackToExtF80$(OBJ) \
+  s_addMagsExtF80$(OBJ) \
+  s_subMagsExtF80$(OBJ) \
+  s_normSubnormalF128Sig$(OBJ) \
+  s_roundPackToF128$(OBJ) \
+  s_normRoundPackToF128$(OBJ) \
+  s_addMagsF128$(OBJ) \
+  s_subMagsF128$(OBJ) \
+  s_mulAddF128$(OBJ) \
+  softfloat_state$(OBJ) \
+  ui32_to_f16$(OBJ) \
+  ui32_to_f32$(OBJ) \
+  ui32_to_f64$(OBJ) \
+  ui32_to_extF80$(OBJ) \
+  ui32_to_extF80M$(OBJ) \
+  ui32_to_f128$(OBJ) \
+  ui32_to_f128M$(OBJ) \
+  ui64_to_f16$(OBJ) \
+  ui64_to_f32$(OBJ) \
+  ui64_to_f64$(OBJ) \
+  ui64_to_extF80$(OBJ) \
+  ui64_to_extF80M$(OBJ) \
+  ui64_to_f128$(OBJ) \
+  ui64_to_f128M$(OBJ) \
+  i32_to_f16$(OBJ) \
+  i32_to_f32$(OBJ) \
+  i32_to_f64$(OBJ) \
+  i32_to_extF80$(OBJ) \
+  i32_to_extF80M$(OBJ) \
+  i32_to_f128$(OBJ) \
+  i32_to_f128M$(OBJ) \
+  i64_to_f16$(OBJ) \
+  i64_to_f32$(OBJ) \
+  i64_to_f64$(OBJ) \
+  i64_to_extF80$(OBJ) \
+  i64_to_extF80M$(OBJ) \
+  i64_to_f128$(OBJ) \
+  i64_to_f128M$(OBJ) \
+  bf16_isSignalingNaN$(OBJ) \
+  bf16_to_f32$(OBJ) \
+  f16_to_ui32$(OBJ) \
+  f16_to_ui64$(OBJ) \
+  f16_to_i32$(OBJ) \
+  f16_to_i64$(OBJ) \
+  f16_to_ui32_r_minMag$(OBJ) \
+  f16_to_ui64_r_minMag$(OBJ) \
+  f16_to_i32_r_minMag$(OBJ) \
+  f16_to_i64_r_minMag$(OBJ) \
+  f16_to_f32$(OBJ) \
+  f16_to_f64$(OBJ) \
+  f16_to_extF80$(OBJ) \
+  f16_to_extF80M$(OBJ) \
+  f16_to_f128$(OBJ) \
+  f16_to_f128M$(OBJ) \
+  f16_roundToInt$(OBJ) \
+  f16_add$(OBJ) \
+  f16_sub$(OBJ) \
+  f16_mul$(OBJ) \
+  f16_mulAdd$(OBJ) \
+  f16_div$(OBJ) \
+  f16_rem$(OBJ) \
+  f16_sqrt$(OBJ) \
+  f16_eq$(OBJ) \
+  f16_le$(OBJ) \
+  f16_lt$(OBJ) \
+  f16_eq_signaling$(OBJ) \
+  f16_le_quiet$(OBJ) \
+  f16_lt_quiet$(OBJ) \
+  f16_isSignalingNaN$(OBJ) \
+  f32_to_ui32$(OBJ) \
+  f32_to_ui64$(OBJ) \
+  f32_to_i32$(OBJ) \
+  f32_to_i64$(OBJ) \
+  f32_to_ui32_r_minMag$(OBJ) \
+  f32_to_ui64_r_minMag$(OBJ) \
+  f32_to_i32_r_minMag$(OBJ) \
+  f32_to_i64_r_minMag$(OBJ) \
+  f32_to_bf16$(OBJ) \
+  f32_to_f16$(OBJ) \
+  f32_to_f64$(OBJ) \
+  f32_to_extF80$(OBJ) \
+  f32_to_extF80M$(OBJ) \
+  f32_to_f128$(OBJ) \
+  f32_to_f128M$(OBJ) \
+  f32_roundToInt$(OBJ) \
+  f32_add$(OBJ) \
+  f32_sub$(OBJ) \
+  f32_mul$(OBJ) \
+  f32_mulAdd$(OBJ) \
+  f32_div$(OBJ) \
+  f32_rem$(OBJ) \
+  f32_sqrt$(OBJ) \
+  f32_eq$(OBJ) \
+  f32_le$(OBJ) \
+  f32_lt$(OBJ) \
+  f32_eq_signaling$(OBJ) \
+  f32_le_quiet$(OBJ) \
+  f32_lt_quiet$(OBJ) \
+  f32_isSignalingNaN$(OBJ) \
+  f64_to_ui32$(OBJ) \
+  f64_to_ui64$(OBJ) \
+  f64_to_i32$(OBJ) \
+  f64_to_i64$(OBJ) \
+  f64_to_ui32_r_minMag$(OBJ) \
+  f64_to_ui64_r_minMag$(OBJ) \
+  f64_to_i32_r_minMag$(OBJ) \
+  f64_to_i64_r_minMag$(OBJ) \
+  f64_to_f16$(OBJ) \
+  f64_to_f32$(OBJ) \
+  f64_to_extF80$(OBJ) \
+  f64_to_extF80M$(OBJ) \
+  f64_to_f128$(OBJ) \
+  f64_to_f128M$(OBJ) \
+  f64_roundToInt$(OBJ) \
+  f64_add$(OBJ) \
+  f64_sub$(OBJ) \
+  f64_mul$(OBJ) \
+  f64_mulAdd$(OBJ) \
+  f64_div$(OBJ) \
+  f64_rem$(OBJ) \
+  f64_sqrt$(OBJ) \
+  f64_eq$(OBJ) \
+  f64_le$(OBJ) \
+  f64_lt$(OBJ) \
+  f64_eq_signaling$(OBJ) \
+  f64_le_quiet$(OBJ) \
+  f64_lt_quiet$(OBJ) \
+  f64_isSignalingNaN$(OBJ) \
+  extF80_to_ui32$(OBJ) \
+  extF80_to_ui64$(OBJ) \
+  extF80_to_i32$(OBJ) \
+  extF80_to_i64$(OBJ) \
+  extF80_to_ui32_r_minMag$(OBJ) \
+  extF80_to_ui64_r_minMag$(OBJ) \
+  extF80_to_i32_r_minMag$(OBJ) \
+  extF80_to_i64_r_minMag$(OBJ) \
+  extF80_to_f16$(OBJ) \
+  extF80_to_f32$(OBJ) \
+  extF80_to_f64$(OBJ) \
+  extF80_to_f128$(OBJ) \
+  extF80_roundToInt$(OBJ) \
+  extF80_add$(OBJ) \
+  extF80_sub$(OBJ) \
+  extF80_mul$(OBJ) \
+  extF80_div$(OBJ) \
+  extF80_rem$(OBJ) \
+  extF80_sqrt$(OBJ) \
+  extF80_eq$(OBJ) \
+  extF80_le$(OBJ) \
+  extF80_lt$(OBJ) \
+  extF80_eq_signaling$(OBJ) \
+  extF80_le_quiet$(OBJ) \
+  extF80_lt_quiet$(OBJ) \
+  extF80_isSignalingNaN$(OBJ) \
+  extF80M_to_ui32$(OBJ) \
+  extF80M_to_ui64$(OBJ) \
+  extF80M_to_i32$(OBJ) \
+  extF80M_to_i64$(OBJ) \
+  extF80M_to_ui32_r_minMag$(OBJ) \
+  extF80M_to_ui64_r_minMag$(OBJ) \
+  extF80M_to_i32_r_minMag$(OBJ) \
+  extF80M_to_i64_r_minMag$(OBJ) \
+  extF80M_to_f16$(OBJ) \
+  extF80M_to_f32$(OBJ) \
+  extF80M_to_f64$(OBJ) \
+  extF80M_to_f128M$(OBJ) \
+  extF80M_roundToInt$(OBJ) \
+  extF80M_add$(OBJ) \
+  extF80M_sub$(OBJ) \
+  extF80M_mul$(OBJ) \
+  extF80M_div$(OBJ) \
+  extF80M_rem$(OBJ) \
+  extF80M_sqrt$(OBJ) \
+  extF80M_eq$(OBJ) \
+  extF80M_le$(OBJ) \
+  extF80M_lt$(OBJ) \
+  extF80M_eq_signaling$(OBJ) \
+  extF80M_le_quiet$(OBJ) \
+  extF80M_lt_quiet$(OBJ) \
+  f128_to_ui32$(OBJ) \
+  f128_to_ui64$(OBJ) \
+  f128_to_i32$(OBJ) \
+  f128_to_i64$(OBJ) \
+  f128_to_ui32_r_minMag$(OBJ) \
+  f128_to_ui64_r_minMag$(OBJ) \
+  f128_to_i32_r_minMag$(OBJ) \
+  f128_to_i64_r_minMag$(OBJ) \
+  f128_to_f16$(OBJ) \
+  f128_to_f32$(OBJ) \
+  f128_to_extF80$(OBJ) \
+  f128_to_f64$(OBJ) \
+  f128_roundToInt$(OBJ) \
+  f128_add$(OBJ) \
+  f128_sub$(OBJ) \
+  f128_mul$(OBJ) \
+  f128_mulAdd$(OBJ) \
+  f128_div$(OBJ) \
+  f128_rem$(OBJ) \
+  f128_sqrt$(OBJ) \
+  f128_eq$(OBJ) \
+  f128_le$(OBJ) \
+  f128_lt$(OBJ) \
+  f128_eq_signaling$(OBJ) \
+  f128_le_quiet$(OBJ) \
+  f128_lt_quiet$(OBJ) \
+  f128_isSignalingNaN$(OBJ) \
+  f128M_to_ui32$(OBJ) \
+  f128M_to_ui64$(OBJ) \
+  f128M_to_i32$(OBJ) \
+  f128M_to_i64$(OBJ) \
+  f128M_to_ui32_r_minMag$(OBJ) \
+  f128M_to_ui64_r_minMag$(OBJ) \
+  f128M_to_i32_r_minMag$(OBJ) \
+  f128M_to_i64_r_minMag$(OBJ) \
+  f128M_to_f16$(OBJ) \
+  f128M_to_f32$(OBJ) \
+  f128M_to_extF80M$(OBJ) \
+  f128M_to_f64$(OBJ) \
+  f128M_roundToInt$(OBJ) \
+  f128M_add$(OBJ) \
+  f128M_sub$(OBJ) \
+  f128M_mul$(OBJ) \
+  f128M_mulAdd$(OBJ) \
+  f128M_div$(OBJ) \
+  f128M_rem$(OBJ) \
+  f128M_sqrt$(OBJ) \
+  f128M_eq$(OBJ) \
+  f128M_le$(OBJ) \
+  f128M_lt$(OBJ) \
+  f128M_eq_signaling$(OBJ) \
+  f128M_le_quiet$(OBJ) \
+  f128M_lt_quiet$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+
+$(OBJS_ALL): \
+  $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
+  $(SOURCE_DIR)/include/primitives.h
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+  $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
+  $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
+  $(SOURCE_DIR)/include/softfloat.h
+
+$(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
+	$(COMPILE_C) $(SOURCE_DIR)/$*.c
+
+$(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
+	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+softfloat$(LIB): $(OBJS_ALL)
+	$(DELETE) $@
+	$(MAKELIB) $^
+
+.PHONY: clean
+clean:
+	$(DELETE) $(OBJS_ALL) softfloat$(LIB)
+

--- a/vendor/softfloat/build/platform.h
+++ b/vendor/softfloat/build/platform.h
@@ -1,0 +1,54 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define LITTLEENDIAN 1
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#ifdef __GNUC_STDC_INLINE__
+#define INLINE inline
+#else
+#define INLINE extern inline
+#endif
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define SOFTFLOAT_BUILTIN_CLZ 1
+#define SOFTFLOAT_INTRINSIC_INT128 1
+#include "opts-GCC.h"
+


### PR DESCRIPTION
## Summary

- Register `iter_busy`, split `ROUND` and `UNPACK` states in `kronos_fpu_iter` to meet 220 MHz timing on the KV260 FPGA
- Register the branch predictor update port to break the WB forwarding cone
- Add all 17 Stage 5 FPU unit testbenches to `SIM_UNITS` so `make sim-all` covers the full Stage 5 regression
- Fix all TB bugs discovered during integration (wrong encodings, swapped FMA reference formulas, pipeline timing, NaN-handling references)

## Test plan

- [ ] `make sim-all` passes (30 unit tests, 0 failures)
- [ ] `make sim-arch-test-s5` passes (303 ACT4 tests)