### PR TITLE
docs: record KV260 200 MHz closure and 220 MHz follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,31 +192,39 @@ cd sim && make sim-lsu-s1    # LSU OBI FSM
 
 ## FPGA Implementation (KV260)
 
-Requires Vivado 2024.x and a KV260 board support package. The flow targets
-`kronos_kv260_top` (a thin timing harness wrapping `kronos_top` with a Zynq PS
-clock) at 200 MHz on the XCK26 -2LV speed grade.
+Requires Vivado 2024.x or later and a KV260 board support package. The flow
+targets `kronos_kv260_top` (a thin timing harness wrapping `kronos_top` with
+a Zynq PS clock) on XCK26-SFVC784-2LV-c silicon.
+
+Post-route Fmax measured on this stage (Vivado 2025.2,
+xck26-sfvc784-2LV):
+
+| Target clock | WNS (ns) | Status |
+|--------------|----------|--------|
+| 200 MHz      | 0.000    | **Closes** (0 failing endpoints) |
+| 220 MHz      | ≈ −0.34  | Does not close — see issue #37 |
+
+The 220 MHz gap is dominated by DSP48 cascade intrinsic delays on the 53×53
+FPU multipliers; closing it requires a Karatsuba-style decomposition tracked
+in issue #37.
 
 ```bash
-# Full synthesis + place & route at 200 MHz
+# Full synthesis + place & route at 200 MHz (default)
 vivado -mode batch -source fpga/kv260/synth.tcl \
        -tclargs PULP_AXI_ROOT=/path/to/pulp/axi
 
-# Override target frequency (e.g. timing sweep at 180 MHz)
+# Sweep a different frequency
 vivado -mode batch -source fpga/kv260/synth.tcl \
        -tclargs SYNTH_FREQ_MHZ=180 PULP_AXI_ROOT=/path/to/pulp/axi
 ```
 
-Reports land in `build/vivado_kv260/`:
+Reports land in `build/vivado_kv260_<freq>/`:
 
 | File | Contents |
 |------|----------|
 | `post_route_timing.txt` | WNS, TNS, worst path |
 | `post_route_utilization.txt` | LUT / FF / DSP / BRAM counts |
 | `post_synth_timing.txt` | Estimated WNS after synthesis |
-
-The CI job (`.github/workflows/synth.yml`) runs this flow on a self-hosted
-Vivado runner for every PR that touches `rtl/stage5/` and fails if post-route
-WNS < −0.5 ns.
 
 ## ACT4 compliance
 


### PR DESCRIPTION
## Summary

Updates the KV260 FPGA Implementation section of the README to reflect the measured post-route timing on `main` (after the #38 timing-closure wave):

| Target | WNS | Status |
|--------|-----|--------|
| 200 MHz | **0.000 ns** (0 failing endpoints) | Closes |
| 220 MHz | ≈ −0.34 ns | Does not close — tracked in #37 |

The 220 MHz gap is bounded by DSP48 cascade intrinsic delay on the 53×53 FPU multiplies. Karatsuba-style decomposition is the next step, tracked separately in #37 with a full plan.

Also drops the reference to `.github/workflows/synth.yml` (not on `main`) and fixes the build-dir path to the frequency-suffixed form (`build/vivado_kv260_<freq>/`).

## Synthesis evidence (Vivado 2025.2, xck26-sfvc784-2LV)

200 MHz post-route (HEAD `437a008`):
- WNS = **0.000 ns** — "All user specified timing constraints are met."
- 0 failing endpoints (setup + hold + pulse-width)
- Worst path: `u_fmul/s1c_sigb_q[6] → s2_prod_q[105]`, 4.821 ns data delay
- Utilization: 17.54% CLB LUTs, 4.64% CLB Registers, 2.72% DSPs, 0% BRAM

## Test plan

- [x] README renders correctly on GitHub
- [x] Final 200 MHz post-route synth confirms WNS = 0.000 ns at HEAD