### PR TITLE
fix(top): gate muldiv_req and muldiv_stall on redirect

### DIFF
--- a/rtl/stage5/kronos_top.sv
+++ b/rtl/stage5/kronos_top.sv
@@ -240,7 +240,8 @@ module kronos_top
   );
 
   // STAGE3: combined_stall — mem_stall | muldiv_stall | instr_fetch_stall | fpu_stall
-  assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid;
+  assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid
+                             & ~ex_redirect & ~mem_redirect;
   assign instr_fetch_stall = ~align_instr_valid;
   // fpu_dispatching: the FPU dispatch will fire this cycle.  Stall immediately
   // so the following instruction stays in IF/ID and can receive the FP result
@@ -318,7 +319,8 @@ module kronos_top
   kronos_muldiv u_muldiv (
     .clk_i     (clk_i),
     .rst_ni    (rst_ni),
-    .req_i     (id_ex_q.valid & id_ex_q.dec.is_muldiv & muldiv_idle & ~mem_stall),
+    .req_i     (id_ex_q.valid & id_ex_q.dec.is_muldiv & muldiv_idle & ~mem_stall
+               & ~ex_redirect & ~mem_redirect),
     .op_i      (id_ex_q.dec.muldiv_op),
     .a_i       (fwd_rs1_data),
     .b_i       (fwd_rs2_data),

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -521,6 +521,12 @@ sim-all: $(SF_LIB)
 	      echo "FAIL  compliance  ($$(grep 'Stage 4 regression:' $(SIM_REPORT_DIR)/compliance.log | tail -1))"; }; \
 	  fi; } > $(SIM_REPORT_DIR)/compliance.result & \
 	pids="$$pids $$!"; \
+	{ if $(MAKE) sim-s5 > $(SIM_REPORT_DIR)/sim-s5.log 2>&1; then \
+	    echo "PASS  sim-s5"; \
+	  else \
+	    echo "FAIL  sim-s5"; \
+	  fi; } > $(SIM_REPORT_DIR)/sim-s5.result & \
+	pids="$$pids $$!"; \
 	wait $$pids || true; \
 	printf "\n%-50s\n" "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
 	printf "  sim-all results\n"; \
@@ -528,6 +534,7 @@ sim-all: $(SF_LIB)
 	for t in $(SIM_UNITS); do printf "  %s\n" "$$(cat $(SIM_REPORT_DIR)/$$t.result)"; done; \
 	printf "  %-48s\n" "──────────────────────────────────────────────────"; \
 	printf "  %s\n" "$$(cat $(SIM_REPORT_DIR)/compliance.result)"; \
+	printf "  %s\n" "$$(cat $(SIM_REPORT_DIR)/sim-s5.result)"; \
 	printf "%-50s\n\n" "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
 	for f in $(SIM_REPORT_DIR)/*.result; do \
 	  if grep -q "^FAIL" $$f; then \

--- a/sw/stage5/Makefile
+++ b/sw/stage5/Makefile
@@ -7,7 +7,7 @@ ARCH   := rv64imafdc_zicsr
 ABI    := lp64
 CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
 
-TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty
+TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect
 
 BUILD_DIR := build
 

--- a/sw/stage5/test_muldiv_redirect.S
+++ b/sw/stage5/test_muldiv_redirect.S
@@ -1,0 +1,190 @@
+// test_muldiv_redirect.S — regression: both muldiv_req and muldiv_stall must
+// be gated by ~ex_redirect and ~mem_redirect.
+//
+// Issue: when a BTB target misprediction (mem_redirect) fires while the first
+// speculatively-fetched wrong-path instruction is a MUL in EX, two things
+// must hold:
+//
+//   1. muldiv_req must not fire (prevents spurious FSM start).
+//   2. muldiv_stall must not assert (prevents a deadlock where the pipeline
+//      is frozen by the stall so the redirect flush can never fire).
+//
+// Without (1), muldiv_req fires for the wrong-path MUL, muldiv_stall kicks in
+// immediately (MUL in EX, FSM not done), and the pipeline freezes for 3 cycles.
+// After the FSM completes the stale computation, muldiv_stall deasserts and
+// the redirect finally flushes the pipeline.  The stale result is discarded,
+// so the wrong-path MUL result doesn't corrupt register state — but the 3-cycle
+// ghost stall affects instruction timing, and in production code it interacts
+// with forwarding and CSR state in ways that produce MCAUSE=2 traps.
+//
+// Without (2) but with (1): muldiv_req=0 keeps the FSM in IDLE, so
+// muldiv_valid=0 forever → muldiv_stall=1 permanently → deadlock.  This test
+// detects that case as a timeout.
+//
+// With both fixes: when mem_redirect fires, neither muldiv_req nor
+// muldiv_stall asserts.  The redirect flush fires immediately (priority-3 path
+// in kronos_hazard), the wrong-path MUL is discarded cleanly, and execution
+// resumes at the correct target.
+//
+// How mem_redirect is triggered (Test 1):
+//   Bimodal counter index = pc[7:2].  Counters start at 2'b01 (weak NT);
+//   JAL/JALR never update them, so btb_hit alone is insufficient for
+//   pred_taken.  bpred_warmup executes a taken conditional branch that aliases
+//   the jalr_site bimodal entry, bumping counter[1] to 1.
+//
+//   Layout (precise PC control from main at 0x16):
+//     2 + 8 + 8 + 2 + 2 + 2 + 2 = 26 bytes of setup → lands at 0x30.
+//
+//     bpred_warmup (0x30): beqz a0, jalr_site   [C.BEQZ, 2 bytes]
+//       • a0=0 at this point → always taken → counter[12]: 2'b01 → 2'b10
+//       • pc[7:2] = 0x30[7:2] = 12  ← shares bimodal + BTB entry with
+//         jalr_site (0x32[7:2] = 12; both have pc[31:6] = 0 → same tag)
+//
+//     jalr_site (0x32): jr t1                   [4 bytes]
+//       Pass 1 — t1=target_A, BTB miss → ex_redirect, BTB learns target_A.
+//       Pass 2 — t1=target_B, BTB hit (target_A) + counter[12][1]=1 →
+//                pred_taken=1 → predicts target_A → mem_redirect fires.
+//                MUL at target_A is in EX when mem_redirect fires.
+//
+// Observable behaviour:
+//   Incomplete fix (only muldiv_req gated): test hangs (deadlock timeout).
+//   Full fix (both muldiv_req and muldiv_stall gated): x10=0 in ~240 cycles.
+//
+// a0 = 0 on success.
+
+.section .text
+.globl main
+
+main:
+    li      a0, 0               // failure counter; also used as 0 for warm-up branch
+
+    // Setup for Test 1.  Total = 2+8+8+2+2+2+2 = 26 bytes → next instr at 0x30.
+    la      t1, target_A        // t1 = target_A (pass 1 JALR target); 8 bytes
+    la      s2, target_B        // s2 = target_B (stored for pass 2 handoff); 8 bytes
+    li      t2, 7               // wrong-path MUL operands (target_A)
+    li      t3, 6
+    li      t5, 5               // correct-path MUL operands (target_B)
+    li      t6, 8
+
+    // -----------------------------------------------------------------------
+    // Bimodal warm-up: beqz a0, jalr_site is at 0x30 (pc[7:2]=12).
+    // a0=0 → always taken; updates counter[12]: 2'b01 → 2'b10.
+    // jalr_site is at 0x32 (pc[7:2]=12) — same bimodal and BTB entry.
+    // After pass 1, BTB[12]={tag:0, target:target_A}.  On pass 2:
+    //   btb_hit=1 && counter[12][1]=1 → pred_taken=1 → mem_redirect.
+    // -----------------------------------------------------------------------
+
+bpred_warmup:                   // must be at 0x30
+    beqz    a0, jalr_site       // C.BEQZ (2 bytes); a0=0 → taken; target=0x32
+
+    // -----------------------------------------------------------------------
+    // Test 1: MUL immediately at BTB target-misprediction redirect target.
+    //
+    // Wrong-path MUL  (target_A, pass 2): 7 * 6 (spurious if FSM fires)
+    // Correct-path MUL (target_B, first instruction): 5 * 8 = 40
+    // -----------------------------------------------------------------------
+
+jalr_site:                      // must be at 0x32 (pc[7:2]=12)
+    jalr    zero, t1, 0         // pass 1: t1=target_A; pass 2: t1=target_B
+
+target_A:
+    // Pass 2 wrong path: this MUL is in EX when mem_redirect fires.
+    // Without fix, muldiv_req starts spurious 7*6=42 computation.
+    mul     t4, t2, t3          // wrong-path MUL: 7 * 6 = 42
+    // Pass 1 continuation: load target_B into t1 and loop back.
+    mv      t1, s2              // t1 = target_B
+    j       jalr_site           // pass 2: JALR fires mem_redirect
+
+target_B:
+    // First instruction at the correct redirect target.
+    // Bug: captures stale DONE result (42) instead of computing 40.
+    mul     s0, t5, t6          // must be 5 * 8 = 40
+
+    li      t1, 40
+    bne     s0, t1, test1_fail
+    j       test1_pass
+test1_fail:
+    addi    a0, a0, 1
+test1_pass:
+
+    // -----------------------------------------------------------------------
+    // Test 2: MULHU at JALR redirect target (ex_redirect path).
+    //
+    // Note: without a bimodal warm-up for jalr_site2, pred_taken=0 for the
+    // JALR → only ex_redirect fires (direction misprediction on pass 1),
+    // not mem_redirect.  The wrong-path MULHU fires AFTER the redirect
+    // completes, so muldiv_req does not race with the flush.  This test
+    // exercises the basic "JALR + MUL at target" sequencing without
+    // specifically triggering the mem_redirect variant of the bug.
+    //
+    // Wrong-path MULHU: 0x100000000 * 0x100000000, high = 1
+    // Correct-path MULHU (target_D first instruction): 3 * 3, high = 0
+    // -----------------------------------------------------------------------
+
+    la      s3, target_C
+    la      s4, target_D
+
+    li      t2, 1
+    slli    t2, t2, 32          // t2 = 0x1_0000_0000
+    li      t3, 1
+    slli    t3, t3, 32          // t3 = 0x1_0000_0000
+
+    li      t5, 3
+    li      t6, 3
+
+    mv      t1, s3
+
+jalr_site2:
+    jalr    zero, t1, 0
+
+target_C:
+    mulhu   t4, t2, t3          // wrong-path computation (ex_redirect path)
+    mv      t1, s4
+    j       jalr_site2
+
+target_D:
+    mulhu   s0, t5, t6          // 3 * 3 = 9, high 64 bits = 0
+
+    bne     s0, zero, test2_fail
+    j       test2_pass
+test2_fail:
+    addi    a0, a0, 1
+test2_pass:
+
+    // -----------------------------------------------------------------------
+    // Test 3: MULW at JALR redirect target (ex_redirect path, same caveat).
+    //
+    // Wrong-path MULW:  (-3) * (-4) = 12 (sign-extended to 64)
+    // Correct-path MULW: 9 * 4 = 36 (sign-extended to 64)
+    // -----------------------------------------------------------------------
+
+    la      s5, target_E
+    la      s6, target_F
+
+    li      t2, -3
+    li      t3, -4
+
+    li      t5, 9
+    li      t6, 4
+
+    mv      t1, s5
+
+jalr_site3:
+    jalr    zero, t1, 0
+
+target_E:
+    mulw    t4, t2, t3          // wrong-path: (-3)*(-4) = 12
+    mv      t1, s6
+    j       jalr_site3
+
+target_F:
+    mulw    s0, t5, t6          // must be 9 * 4 = 36
+
+    li      t1, 36
+    bne     s0, t1, test3_fail
+    j       test3_pass
+test3_fail:
+    addi    a0, a0, 1
+test3_pass:
+
+    ret

--- a/tb/stage5/tb_core_fp_basic.sv
+++ b/tb/stage5/tb_core_fp_basic.sv
@@ -201,7 +201,7 @@ module tb_core_fp_basic;
         wait (halted > 0);
       end
       begin : timeout
-        repeat (500) @(posedge clk);
+        for (int i = 0; i < 500; i++) @(posedge clk);
         $display("FAIL tb_core_fp_basic: timeout (no halt within 500 cycles)");
         errors++;
         $finish(1);

--- a/tb/stage5/tb_core_fp_forwarding.sv
+++ b/tb/stage5/tb_core_fp_forwarding.sv
@@ -196,7 +196,7 @@ module tb_core_fp_forwarding;
         wait (halted > 0);
       end
       begin : timeout
-        repeat (700) @(posedge clk);
+        for (int i = 0; i < 700; i++) @(posedge clk);
         $display("FAIL tb_core_fp_forwarding: timeout (no halt within 700 cycles)");
         errors++;
         $finish(1);


### PR DESCRIPTION
## Summary

- **Bug**: When a BTB target misprediction (`mem_redirect`) fires while a wrong-path MUL is in EX, two things must be suppressed:
  1. `muldiv_req` must not fire — without this, the FSM starts a spurious 4-cycle computation that creates a ghost stall interacting with forwarding state, producing MCAUSE=2 traps in production tests.
  2. `muldiv_stall` must also not assert — without this, gating `muldiv_req` causes an immediate deadlock: FSM stays IDLE → `muldiv_valid=0` forever → `muldiv_stall=1` permanently blocks the redirect flush.

- **Fix**: Both signals are now gated by `~ex_redirect & ~mem_redirect`. When a redirect fires, `kronos_hazard` sees `combined_stall=0` and can immediately flush IF/ID (priority-3 path), discarding the wrong-path MUL in one cycle.

- **Regression test**: `sw/stage5/test_muldiv_redirect.S` engineers a BTB target misprediction with a bimodal warm-up branch at 0x30 that aliases `jalr_site` at 0x32 (same `pc[7:2]=12`), saturating the counter so `pred_taken=1` fires on the second JALR pass. With only `muldiv_req` gated the test deadlocks; with both signals gated it completes in ~240 cycles with x10=0.

## Test plan

- [x] `make run-s5-test_muldiv_redirect` → x10=0 (~234 cycles)
- [x] `make sim-all` → all unit tests pass; pre-existing `test_blt64` / `test_blt_act4` failures unchanged
- [x] `make sim-arch-test-s5` → all 303 ACT5 compliance tests pass

Closes #40