### PR TITLE
fix(sw): fix test_blt64 and test_blt_act4, add to stage5 TESTS list

### DIFF
--- a/sw/stage5/Makefile
+++ b/sw/stage5/Makefile
@@ -7,7 +7,7 @@ ARCH   := rv64imafdc_zicsr
 ABI    := lp64
 CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
 
-TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect
+TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect test_blt64 test_blt_act4
 
 BUILD_DIR := build
 

--- a/sw/stage5/test_blt64.S
+++ b/sw/stage5/test_blt64.S
@@ -1,5 +1,4 @@
-// test_blt64.S — diagnose BLT for 64-bit near-maxint operands.
-// Each test is standalone with explicit forwarding patterns.
+// test_blt64.S — BLT with 64-bit near-maxint operands.
 // a0 = 0 means all pass.
 
 .section .text
@@ -9,80 +8,51 @@ main:
     li      a0, 0               // fail counter
 
     // --- Test 1: BLT with immediate li (no forwarding hazard) ---
-    // ra = 0x7FFFFFFFFFFFFFFE, sp = 0x7FFFFFFFFFFFFFFF
-    // via: li t1, 1; slli t1, t1, 62; addi ra, t1, -2; addi sp, t1, -1
     li      t1, 1
     slli    t1, t1, 62          // t1 = 0x4000000000000000
     slli    t1, t1, 1           // t1 = 0x8000000000000000 (INT64_MIN)
     addi    t1, t1, -1          // t1 = 0x7FFFFFFFFFFFFFFF
-    addi    ra, t1, -1          // ra = 0x7FFFFFFFFFFFFFFE
-    mv      sp, t1              // sp = 0x7FFFFFFFFFFFFFFF
-    // Now BLT with 3 NOPs to drain forwarding hazards
+    addi    t2, t1, -1          // t2 = 0x7FFFFFFFFFFFFFFE  (rs1)
+    mv      t3, t1              // t3 = 0x7FFFFFFFFFFFFFFF  (rs2)
     nop
     nop
     nop
-    blt     ra, sp, 1f
-    addi    a0, a0, 1           // FAIL: ra < sp not taken
+    blt     t2, t3, 1f
+    addi    a0, a0, 1           // FAIL: t2 < t3 not taken
 1:
 
-    // --- Test 2: BLT via LD then addi (the actual ACT4 pattern) ---
+    // --- Test 2: BLT via LD then addi ---
     la      t0, val_a
-    ld      ra, 0(t0)           // ra = 0x7FFFFFFFFFFFFFFE
-    addi    sp, ra, 1           // sp = 0x7FFFFFFFFFFFFFFF (load-use: hazard then forward)
-    blt     ra, sp, 2f
-    addi    a0, a0, 1           // FAIL
+    ld      t2, 0(t0)           // t2 = 0x7FFFFFFFFFFFFFFE
+    addi    t3, t2, 1           // t3 = 0x7FFFFFFFFFFFFFFF
+    blt     t2, t3, 2f
+    addi    a0, a0, 2           // FAIL
 2:
 
     // --- Test 3: BLT via LD, LD (two separate loads) ---
     la      t0, val_a
-    ld      ra, 0(t0)           // ra = 0x7FFFFFFFFFFFFFFE
+    ld      t2, 0(t0)           // t2 = 0x7FFFFFFFFFFFFFFE
     la      t0, val_b
-    ld      sp, 0(t0)           // sp = 0x7FFFFFFFFFFFFFFF
-    blt     ra, sp, 3f
-    addi    a0, a0, 1           // FAIL
+    ld      t3, 0(t0)           // t3 = 0x7FFFFFFFFFFFFFFF
+    blt     t2, t3, 3f
+    addi    a0, a0, 4           // FAIL
 3:
 
     // --- Test 4: BLT with addi forwarding (EX→ID bypass) ---
     la      t0, val_a
-    ld      ra, 0(t0)           // ra = 0x7FFFFFFFFFFFFFFE
+    ld      t2, 0(t0)           // t2 = 0x7FFFFFFFFFFFFFFE
     nop
     nop
-    addi    sp, ra, 1           // sp = 0x7FFFFFFFFFFFFFFF (no hazard, ra in regfile)
-    blt     ra, sp, 4f
-    addi    a0, a0, 1           // FAIL
+    addi    t3, t2, 1           // t3 = 0x7FFFFFFFFFFFFFFF
+    blt     t2, t3, 4f
+    addi    a0, a0, 8           // FAIL
 4:
 
-    // --- Test 5: Check values via store (debug what ra, sp actually are) ---
-    // Store ra to result_ra, sp to result_sp, then compare stored values
-    la      t0, val_a
-    ld      ra, 0(t0)
-    addi    sp, ra, 1
-    la      t0, result_ra
-    sd      ra, 0(t0)
-    la      t0, result_sp
-    sd      sp, 0(t0)
-    // Now reload and compare
-    la      t0, result_ra
-    ld      x3, 0(t0)
-    la      t0, result_sp
-    ld      x4, 0(t0)
-    la      t0, val_a
-    ld      x5, 0(t0)           // expected ra
-    la      t0, val_b
-    ld      x6, 0(t0)           // expected sp
-    bne     x3, x5, 51f         // ra mismatch
-    bne     x4, x6, 52f         // sp mismatch
-    j       53f
-51: addi    a0, a0, 2           // ra was wrong
-    j       53f
-52: addi    a0, a0, 4           // sp was wrong
-53:
-
-    ret
+    li      t0, 0x40000000
+    sw      a0, 0(t0)
+    1: j 1b
 
 .section .data
 .align 3
 val_a:      .dword 0x7FFFFFFFFFFFFFFE
 val_b:      .dword 0x7FFFFFFFFFFFFFFF
-result_ra:  .dword 0
-result_sp:  .dword 0

--- a/sw/stage5/test_blt_act4.S
+++ b/sw/stage5/test_blt_act4.S
@@ -1,39 +1,33 @@
-// test_blt_act4.S — reproduces the exact ACT4 I-blt-00 test case 198 pattern.
-// Two 64-bit loads then BLT without extra NOPs.
+// test_blt_act4.S — reproduces the ACT4 I-blt-00 test case 198 pattern:
+// two 64-bit loads then BLT with near-maxint operands.
 // a0 = 0 = pass.
 
 .section .text
 .globl main
 
 main:
-    li      a0, 0
+    li      t4, 0               // fail counter (x10 is used as rs2val)
 
-    // Exact pattern from ACT4 I-blt test case 198:
-    //   ld x17, 0(x11)    → rs1 = 0x7FFFFFFFFFFFFFFE
-    //   addi x11, x11, 8
-    //   ld x10, 0(x11)    → rs2 = 0x7FFFFFFFFFFFFFFF
-    //   addi x11, x11, 8
-    //   blt x17, x10, target   (forward BLT, should be taken)
-    //   blt x17, x10, back     (never-taken BLT, should NOT be taken)
+    // ACT4 I-blt test case 198 pattern:
+    //   ld x17, ...  → rs1 = 0x7FFFFFFFFFFFFFFE
+    //   ld x10, ...  → rs2 = 0x7FFFFFFFFFFFFFFF
+    //   blt x17, x10  (should be TAKEN: rs1 < rs2)
     la      x11, sigvals
-    ld      x17, 0(x11)         // x17 = 0x7FFFFFFFFFFFFFFE (rs1val)
+    ld      x17, 0(x11)         // x17 = 0x7FFFFFFFFFFFFFFE
     addi    x11, x11, 8
-    ld      x10, 0(x11)         // x10 = 0x7FFFFFFFFFFFFFFF (rs2val)
-    addi    x11, x11, 8
-    blt     x17, x10, 1f        // forward BLT: should be TAKEN
-    blt     x17, x10, back      // never-taken backward BLT
-    // Taken path:
-1:  blt     x17, x10, 2f        // backward BLT to 2f (below) - never taken
-    j       3f                  // correct path after forward BLT taken
-back:
-    // We only reach here if forward BLT not taken
-    addi    a0, a0, 1           // FAIL: forward BLT not taken
+    ld      x10, 0(x11)         // x10 = 0x7FFFFFFFFFFFFFFF
+
+    // Test 1: BLT taken (x17 < x10)
+    blt     x17, x10, 1f
+    addi    t4, t4, 1           // FAIL: branch not taken
+1:
+    // Test 2: BLT not taken (x10 > x17, so x10 < x17 is false)
+    blt     x10, x17, 2f        // x10 > x17 → NOT taken
     j       3f
 2:
-    addi    a0, a0, 2           // FAIL: should not be taken
+    addi    t4, t4, 2           // FAIL: branch should not have been taken
 3:
-    // Check that backward BLT (the first one) was NOT executed
-    // Done - halt
+    mv      a0, t4
     li      t0, 0x40000000
     sw      a0, 0(t0)
     1: j 1b
@@ -41,5 +35,5 @@ back:
 .section .data
 .align 3
 sigvals:
-    .dword 0x7FFFFFFFFFFFFFFE   // rs1val (0(x11))
-    .dword 0x7FFFFFFFFFFFFFFF   // rs2val (8(x11))
+    .dword 0x7FFFFFFFFFFFFFFE
+    .dword 0x7FFFFFFFFFFFFFFF


### PR DESCRIPTION
## Summary

- `test_blt64.S`: was using `ra`/`sp` as comparison registers and ended with `ret`, jumping to `0x7FFFFFFFFFFFFFFE` → simulation timeout. Rewrote to use `t2`/`t3` with a proper halt sequence.
- `test_blt_act4.S`: `a0`/`x10` was used as both the fail counter and the BLT rs2 operand (overwritten by `ld x10`), and a mid-test BLT had a condition that was always true, landing on the FAIL path. Rewrote with `t4` as fail counter and corrected branch logic.
- Both tests added to `sw/stage5/Makefile` TESTS list so they are built and run as part of the standard regression.

`sim-all` passes cleanly after this change.