### PR TITLE
fix(sw,sim): fix blt64/blt_act4 tests + restructure sim-all into CI matrix

### DIFF
--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -7,8 +7,13 @@ on:
     branches: [main]
 
 jobs:
-  sim-all:
+  sim-units:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [s1s2, s3s4, fp-unit, fp-top]
+    name: sim-${{ matrix.group }}
 
     steps:
       - uses: actions/checkout@v4
@@ -25,8 +30,22 @@ jobs:
       - name: Clone PULP AXI
         run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
 
-      - name: Run sim-all
-        run: make -C sim sim-all PULP_AXI_ROOT=/tmp/pulp_axi
+      - name: Run sim-${{ matrix.group }}
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim -j$(nproc) sim-group-${{ matrix.group }} PULP_AXI_ROOT=/tmp/pulp_axi
+
+  sim-all:
+    runs-on: ubuntu-latest
+    needs: sim-units
+    if: always()
+    steps:
+      - run: |
+          result="${{ needs.sim-units.result }}"
+          if [ "$result" != "success" ]; then
+            echo "sim-units result: $result"
+            exit 1
+          fi
 
   compliance:
     runs-on: ubuntu-latest

--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -8,79 +8,27 @@ description: "kronos-riscv: BOOM-inspired RISC-V CPU core in SystemVerilog"
 filesets:
   files_rtl_s0:
     files:
-      - rtl/kronos_pkg.sv
-      - rtl/stage0/kronos_alu.sv
-      - rtl/stage0/kronos_decode.sv
-      - rtl/stage0/kronos_regfile.sv
-      - rtl/stage0/kronos_lsu.sv
-      - rtl/stage0/kronos_csr.sv
-      - rtl/stage0/kronos_top.sv
-    file_type: systemVerilogSource
+      - rtl/filelist_s0.f: {file_type: f}
 
   files_rtl_s1:
     files:
-      - rtl/kronos_pkg.sv
-      - rtl/stage0/kronos_alu.sv
-      - rtl/stage0/kronos_decode.sv
-      - rtl/stage0/kronos_regfile.sv
-      - rtl/stage0/kronos_csr.sv
-      - rtl/stage1/kronos_lsu.sv
-      - rtl/stage1/kronos_forward.sv
-      - rtl/stage1/kronos_hazard.sv
-      - rtl/stage1/kronos_top.sv
-    file_type: systemVerilogSource
+      - rtl/filelist_s1.f: {file_type: f}
 
   files_rtl_s2:
     files:
-      - rtl/kronos_pkg.sv
-      - rtl/stage0/kronos_alu.sv
-      - rtl/stage2/kronos_decode.sv
-      - rtl/stage0/kronos_regfile.sv
-      - rtl/stage0/kronos_csr.sv
-      - rtl/stage1/kronos_lsu.sv
-      - rtl/stage1/kronos_forward.sv
-      - rtl/stage1/kronos_hazard.sv
-      - rtl/stage2/kronos_muldiv.sv
-      - rtl/stage2/kronos_top.sv
-    file_type: systemVerilogSource
+      - rtl/filelist_s2.f: {file_type: f}
 
   files_rtl_s3:
     depend:
       - pulp-platform.org::axi:0.39.9
     files:
-      - rtl/kronos_pkg.sv
-      - rtl/stage0/kronos_alu.sv
-      - rtl/stage2/kronos_decode.sv
-      - rtl/stage0/kronos_regfile.sv
-      - rtl/stage0/kronos_csr.sv
-      - rtl/stage3/kronos_lsu.sv
-      - rtl/stage1/kronos_forward.sv
-      - rtl/stage1/kronos_hazard.sv
-      - rtl/stage2/kronos_muldiv.sv
-      - rtl/stage3/kronos_decompress.sv
-      - rtl/stage3/kronos_align.sv
-      - rtl/stage3/kronos_bpred.sv
-      - rtl/stage3/kronos_top.sv
-    file_type: systemVerilogSource
+      - rtl/filelist_s3.f: {file_type: f}
 
   files_rtl_s4:
     depend:
       - pulp-platform.org::axi:0.39.9
     files:
-      - rtl/kronos_pkg.sv
-      - rtl/stage4/kronos_alu.sv
-      - rtl/stage4/kronos_decode.sv
-      - rtl/stage0/kronos_regfile.sv
-      - rtl/stage4/kronos_csr.sv
-      - rtl/stage4/kronos_lsu.sv
-      - rtl/stage1/kronos_forward.sv
-      - rtl/stage1/kronos_hazard.sv
-      - rtl/stage4/kronos_muldiv.sv
-      - rtl/stage4/kronos_decompress.sv
-      - rtl/stage3/kronos_align.sv
-      - rtl/stage3/kronos_bpred.sv
-      - rtl/stage4/kronos_top.sv
-    file_type: systemVerilogSource
+      - rtl/filelist_s4.f: {file_type: f}
 
   files_lint_waivers:
     files:
@@ -90,31 +38,7 @@ filesets:
     depend:
       - pulp-platform.org::axi:0.39.9
     files:
-      - rtl/kronos_pkg.sv
-      - rtl/stage5/kronos_alu.sv
-      - rtl/stage5/kronos_decode.sv
-      - rtl/stage0/kronos_regfile.sv
-      - rtl/stage5/kronos_regfile_fp.sv
-      - rtl/stage5/kronos_csr.sv
-      - rtl/stage5/kronos_lsu.sv
-      - rtl/stage1/kronos_forward.sv
-      - rtl/stage1/kronos_hazard.sv
-      - rtl/stage5/kronos_muldiv.sv
-      - rtl/stage5/kronos_decompress.sv
-      - rtl/stage3/kronos_align.sv
-      - rtl/stage3/kronos_bpred.sv
-      - rtl/stage5/fpu/kronos_fpu_scoreboard.sv
-      - rtl/stage5/fpu/kronos_fpu_fmisc.sv
-      - rtl/stage5/fpu/kronos_fpu_fcvt.sv
-      - rtl/stage5/fpu/kronos_fpu_fadd.sv
-      - rtl/stage5/fpu/kronos_fpu_fmul.sv
-      - rtl/stage5/fpu/kronos_fpu_fma.sv
-      - rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
-      - rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
-      - rtl/stage5/fpu/kronos_fpu_iter.sv
-      - rtl/stage5/fpu/kronos_fpu_top.sv
-      - rtl/stage5/kronos_top.sv
-    file_type: systemVerilogSource
+      - rtl/filelist_s5.f: {file_type: f}
 
   files_fpga_kv260:
     depend:

--- a/rtl/filelist_s0.f
+++ b/rtl/filelist_s0.f
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stage 0: RV32I single-cycle golden model
-# Paths are relative to the kronos-riscv rtl/ directory.
+# Paths are relative to this file's directory (rtl/).
 
-[packages]
 kronos_pkg.sv
-
-[rtl]
 stage0/kronos_alu.sv
 stage0/kronos_decode.sv
 stage0/kronos_regfile.sv

--- a/rtl/filelist_s1.f
+++ b/rtl/filelist_s1.f
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stage 1: RV32I 5-stage in-order pipeline
-# Paths are relative to the kronos-riscv rtl/ directory.
+# Paths are relative to this file's directory (rtl/).
 
-[packages]
 kronos_pkg.sv
-
-[rtl]
 stage0/kronos_alu.sv
 stage0/kronos_decode.sv
 stage0/kronos_regfile.sv

--- a/rtl/filelist_s2.f
+++ b/rtl/filelist_s2.f
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stage 2: RV32IM (M extension + CSR hardening)
-# Paths are relative to the kronos-riscv rtl/ directory.
+# Paths are relative to this file's directory (rtl/).
 
-[packages]
 kronos_pkg.sv
-
-[rtl]
 stage0/kronos_alu.sv
 stage0/kronos_regfile.sv
 stage0/kronos_csr.sv

--- a/rtl/filelist_s3.f
+++ b/rtl/filelist_s3.f
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stage 3: RV32IMC (C extension + branch predictor)
-# Paths are relative to the kronos-riscv rtl/ directory.
+# Paths are relative to this file's directory (rtl/).
 
-[packages]
 kronos_pkg.sv
-
-[rtl]
 stage0/kronos_alu.sv
 stage0/kronos_regfile.sv
 stage0/kronos_csr.sv

--- a/rtl/filelist_s4.f
+++ b/rtl/filelist_s4.f
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stage 4: RV64IMAC (64-bit + A extension)
-# Paths are relative to the kronos-riscv rtl/ directory.
+# Paths are relative to this file's directory (rtl/).
 
-[packages]
 kronos_pkg.sv
-
-[rtl]
 stage0/kronos_regfile.sv
 stage1/kronos_forward.sv
 stage1/kronos_hazard.sv

--- a/rtl/filelist_s5.f
+++ b/rtl/filelist_s5.f
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stage 5: RV64IMAFD (F/D extensions + FPU)
-# Paths are relative to the kronos-riscv rtl/ directory.
+# Paths are relative to this file's directory (rtl/).
 
-[packages]
 kronos_pkg.sv
-
-[rtl]
 stage0/kronos_regfile.sv
 stage1/kronos_forward.sv
 stage1/kronos_hazard.sv

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -113,7 +113,8 @@ SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
         sim-fpu-top-iter \
         sim-fpu-fmisc-cov sim-fpu-fcvt-cov sim-fpu-fadd-cov sim-fpu-fmul-cov \
         sim-fpu-fma-cov coverage \
-        sim-s5b
+        sim-s5b \
+        sim-group-s1s2 sim-group-s3s4 sim-group-fp-unit sim-group-fp-top
 
 .DEFAULT_GOAL := help
 
@@ -501,6 +502,33 @@ SIM_UNITS := sim-alu sim-regfile sim-decode \
              sim-fpu-fdiv-core sim-fpu-fsqrt-core sim-fpu-fcvt \
              sim-fpu-fadd sim-fpu-fmul sim-fpu-fma sim-fpu-fmisc \
              sim-fpu-iter sim-fpu-top sim-fpu-top-iter
+
+# ── CI test groups ────────────────────────────────────────────────────────────
+# Run as: make -j$(nproc) sim-group-<name>
+# Make's job server serialises shared prerequisites (e.g. $(SF_LIB)), so there
+# is no race between concurrent targets that both depend on softfloat.a.
+
+SIM_GROUP_S1S2    := sim-alu sim-regfile sim-decode \
+                     sim-lsu-s1 sim-forward sim-hazard sim-muldiv
+
+SIM_GROUP_S3S4    := sim-decompress sim-align sim-lsu-s3 sim-bpred \
+                     sim-alu-s4 sim-decode-s4 sim-muldiv-s4 sim-lsu-s4 \
+                     sim-compliance-s4
+
+SIM_GROUP_FP_UNIT := sim-pkg-fp sim-hf-smoke sim-sf-smoke \
+                     sim-fpu-scoreboard sim-regfile-fp sim-csr-fp sim-decode-fp sim-lsu-fp \
+                     sim-fpu-fdiv-core sim-fpu-fsqrt-core sim-fpu-fcvt \
+                     sim-fpu-fadd sim-fpu-fmul sim-fpu-fma sim-fpu-fmisc
+
+SIM_GROUP_FP_TOP  := sim-fpu-iter sim-fpu-top sim-fpu-top-iter sim-s5
+
+$(OBJ_DIR):
+	mkdir -p $@
+
+sim-group-s1s2:    $(SIM_GROUP_S1S2)    | $(OBJ_DIR)
+sim-group-s3s4:    $(SIM_GROUP_S3S4)    | $(OBJ_DIR)
+sim-group-fp-unit: $(SIM_GROUP_FP_UNIT) | $(OBJ_DIR)
+sim-group-fp-top:  $(SIM_GROUP_FP_TOP)  | $(OBJ_DIR)
 
 SIM_REPORT_DIR := $(OBJ_DIR)/sim-results
 

--- a/sw/stage5/Makefile
+++ b/sw/stage5/Makefile
@@ -7,7 +7,7 @@ ARCH   := rv64imafdc_zicsr
 ABI    := lp64
 CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
 
-TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect
+TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect test_blt64 test_blt_act4
 
 BUILD_DIR := build
 

--- a/sw/stage5/test_blt64.S
+++ b/sw/stage5/test_blt64.S
@@ -1,5 +1,4 @@
-// test_blt64.S — diagnose BLT for 64-bit near-maxint operands.
-// Each test is standalone with explicit forwarding patterns.
+// test_blt64.S — BLT with 64-bit near-maxint operands.
 // a0 = 0 means all pass.
 
 .section .text
@@ -9,80 +8,51 @@ main:
     li      a0, 0               // fail counter
 
     // --- Test 1: BLT with immediate li (no forwarding hazard) ---
-    // ra = 0x7FFFFFFFFFFFFFFE, sp = 0x7FFFFFFFFFFFFFFF
-    // via: li t1, 1; slli t1, t1, 62; addi ra, t1, -2; addi sp, t1, -1
     li      t1, 1
     slli    t1, t1, 62          // t1 = 0x4000000000000000
     slli    t1, t1, 1           // t1 = 0x8000000000000000 (INT64_MIN)
     addi    t1, t1, -1          // t1 = 0x7FFFFFFFFFFFFFFF
-    addi    ra, t1, -1          // ra = 0x7FFFFFFFFFFFFFFE
-    mv      sp, t1              // sp = 0x7FFFFFFFFFFFFFFF
-    // Now BLT with 3 NOPs to drain forwarding hazards
+    addi    t2, t1, -1          // t2 = 0x7FFFFFFFFFFFFFFE  (rs1)
+    mv      t3, t1              // t3 = 0x7FFFFFFFFFFFFFFF  (rs2)
     nop
     nop
     nop
-    blt     ra, sp, 1f
-    addi    a0, a0, 1           // FAIL: ra < sp not taken
+    blt     t2, t3, 1f
+    addi    a0, a0, 1           // FAIL: t2 < t3 not taken
 1:
 
-    // --- Test 2: BLT via LD then addi (the actual ACT4 pattern) ---
+    // --- Test 2: BLT via LD then addi ---
     la      t0, val_a
-    ld      ra, 0(t0)           // ra = 0x7FFFFFFFFFFFFFFE
-    addi    sp, ra, 1           // sp = 0x7FFFFFFFFFFFFFFF (load-use: hazard then forward)
-    blt     ra, sp, 2f
-    addi    a0, a0, 1           // FAIL
+    ld      t2, 0(t0)           // t2 = 0x7FFFFFFFFFFFFFFE
+    addi    t3, t2, 1           // t3 = 0x7FFFFFFFFFFFFFFF
+    blt     t2, t3, 2f
+    addi    a0, a0, 2           // FAIL
 2:
 
     // --- Test 3: BLT via LD, LD (two separate loads) ---
     la      t0, val_a
-    ld      ra, 0(t0)           // ra = 0x7FFFFFFFFFFFFFFE
+    ld      t2, 0(t0)           // t2 = 0x7FFFFFFFFFFFFFFE
     la      t0, val_b
-    ld      sp, 0(t0)           // sp = 0x7FFFFFFFFFFFFFFF
-    blt     ra, sp, 3f
-    addi    a0, a0, 1           // FAIL
+    ld      t3, 0(t0)           // t3 = 0x7FFFFFFFFFFFFFFF
+    blt     t2, t3, 3f
+    addi    a0, a0, 4           // FAIL
 3:
 
     // --- Test 4: BLT with addi forwarding (EX→ID bypass) ---
     la      t0, val_a
-    ld      ra, 0(t0)           // ra = 0x7FFFFFFFFFFFFFFE
+    ld      t2, 0(t0)           // t2 = 0x7FFFFFFFFFFFFFFE
     nop
     nop
-    addi    sp, ra, 1           // sp = 0x7FFFFFFFFFFFFFFF (no hazard, ra in regfile)
-    blt     ra, sp, 4f
-    addi    a0, a0, 1           // FAIL
+    addi    t3, t2, 1           // t3 = 0x7FFFFFFFFFFFFFFF
+    blt     t2, t3, 4f
+    addi    a0, a0, 8           // FAIL
 4:
 
-    // --- Test 5: Check values via store (debug what ra, sp actually are) ---
-    // Store ra to result_ra, sp to result_sp, then compare stored values
-    la      t0, val_a
-    ld      ra, 0(t0)
-    addi    sp, ra, 1
-    la      t0, result_ra
-    sd      ra, 0(t0)
-    la      t0, result_sp
-    sd      sp, 0(t0)
-    // Now reload and compare
-    la      t0, result_ra
-    ld      x3, 0(t0)
-    la      t0, result_sp
-    ld      x4, 0(t0)
-    la      t0, val_a
-    ld      x5, 0(t0)           // expected ra
-    la      t0, val_b
-    ld      x6, 0(t0)           // expected sp
-    bne     x3, x5, 51f         // ra mismatch
-    bne     x4, x6, 52f         // sp mismatch
-    j       53f
-51: addi    a0, a0, 2           // ra was wrong
-    j       53f
-52: addi    a0, a0, 4           // sp was wrong
-53:
-
-    ret
+    li      t0, 0x40000000
+    sw      a0, 0(t0)
+    1: j 1b
 
 .section .data
 .align 3
 val_a:      .dword 0x7FFFFFFFFFFFFFFE
 val_b:      .dword 0x7FFFFFFFFFFFFFFF
-result_ra:  .dword 0
-result_sp:  .dword 0

--- a/sw/stage5/test_blt_act4.S
+++ b/sw/stage5/test_blt_act4.S
@@ -1,39 +1,33 @@
-// test_blt_act4.S — reproduces the exact ACT4 I-blt-00 test case 198 pattern.
-// Two 64-bit loads then BLT without extra NOPs.
+// test_blt_act4.S — reproduces the ACT4 I-blt-00 test case 198 pattern:
+// two 64-bit loads then BLT with near-maxint operands.
 // a0 = 0 = pass.
 
 .section .text
 .globl main
 
 main:
-    li      a0, 0
+    li      t4, 0               // fail counter (x10 is used as rs2val)
 
-    // Exact pattern from ACT4 I-blt test case 198:
-    //   ld x17, 0(x11)    → rs1 = 0x7FFFFFFFFFFFFFFE
-    //   addi x11, x11, 8
-    //   ld x10, 0(x11)    → rs2 = 0x7FFFFFFFFFFFFFFF
-    //   addi x11, x11, 8
-    //   blt x17, x10, target   (forward BLT, should be taken)
-    //   blt x17, x10, back     (never-taken BLT, should NOT be taken)
+    // ACT4 I-blt test case 198 pattern:
+    //   ld x17, ...  → rs1 = 0x7FFFFFFFFFFFFFFE
+    //   ld x10, ...  → rs2 = 0x7FFFFFFFFFFFFFFF
+    //   blt x17, x10  (should be TAKEN: rs1 < rs2)
     la      x11, sigvals
-    ld      x17, 0(x11)         // x17 = 0x7FFFFFFFFFFFFFFE (rs1val)
+    ld      x17, 0(x11)         // x17 = 0x7FFFFFFFFFFFFFFE
     addi    x11, x11, 8
-    ld      x10, 0(x11)         // x10 = 0x7FFFFFFFFFFFFFFF (rs2val)
-    addi    x11, x11, 8
-    blt     x17, x10, 1f        // forward BLT: should be TAKEN
-    blt     x17, x10, back      // never-taken backward BLT
-    // Taken path:
-1:  blt     x17, x10, 2f        // backward BLT to 2f (below) - never taken
-    j       3f                  // correct path after forward BLT taken
-back:
-    // We only reach here if forward BLT not taken
-    addi    a0, a0, 1           // FAIL: forward BLT not taken
+    ld      x10, 0(x11)         // x10 = 0x7FFFFFFFFFFFFFFF
+
+    // Test 1: BLT taken (x17 < x10)
+    blt     x17, x10, 1f
+    addi    t4, t4, 1           // FAIL: branch not taken
+1:
+    // Test 2: BLT not taken (x10 > x17, so x10 < x17 is false)
+    blt     x10, x17, 2f        // x10 > x17 → NOT taken
     j       3f
 2:
-    addi    a0, a0, 2           // FAIL: should not be taken
+    addi    t4, t4, 2           // FAIL: branch should not have been taken
 3:
-    // Check that backward BLT (the first one) was NOT executed
-    // Done - halt
+    mv      a0, t4
     li      t0, 0x40000000
     sw      a0, 0(t0)
     1: j 1b
@@ -41,5 +35,5 @@ back:
 .section .data
 .align 3
 sigvals:
-    .dword 0x7FFFFFFFFFFFFFFE   // rs1val (0(x11))
-    .dword 0x7FFFFFFFFFFFFFFF   // rs2val (8(x11))
+    .dword 0x7FFFFFFFFFFFFFFE
+    .dword 0x7FFFFFFFFFFFFFFF


### PR DESCRIPTION
## Summary

- Fix `test_blt64` and `test_blt_act4`; add both to the stage5 `TESTS` list
- Replace the single `sim-all` CI job (shell-loop with softfloat race condition) with a 4-way matrix: `s1s2`, `s3s4`, `fp-unit`, `fp-top`; each group runs on its own 4-CPU runner with `make -j$(nproc)`, using make's job server to serialise the shared `softfloat.a` build and eliminate the race
- Pre-create `obj_dir/` in CI before running make so parallel Verilator instances can create their nested `-Mdir` subdirectories
- `sim-all` is kept unchanged for local use
- Refactor `kronos_riscv.core` filesets to reference `rtl/filelist_s{0..5}.f` files instead of inlining all source paths; the `.f` files are the single source of truth for each stage's RTL file list

## Test plan

- [x] All 4 `sim-*` matrix jobs pass
- [x] All 5 `compliance-*` matrix jobs pass