### PR TITLE
feat(top): top-level Makefile + KV260 200 MHz timing closure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+STAGE ?= 5
+JOBS  ?= $(shell nproc)
+
+-include fpga/kv260/synth.cfg
+SYNTH_FREQ_MHZ ?= 200
+
+# Map STAGE to the right sim/Makefile build target:
+#   stage 0 → "build", stages 1-5 → "build-s<N>"
+_BUILD_TARGET  = $(if $(filter 0,$(STAGE)),build,build-s$(STAGE))
+
+# Map STAGE to the right FuseSoC lint target:
+#   stage 5 → "lint" (default), others → "lint-s<N>"
+_LINT_TARGET   = $(if $(filter 5,$(STAGE)),lint,lint-s$(STAGE))
+
+.PHONY: help lint build regression compliance coverage synth clean
+
+help:
+	@echo "Usage: make <target> [STAGE=<0-5>] [JOBS=<N>]"
+	@echo ""
+	@echo "Targets"
+	@echo "  lint        Verilator lint (uses STAGE)"
+	@echo "  build       Build Verilator simulator (uses STAGE)"
+	@echo "  regression  Unit testbench suite across all stages"
+	@echo "  compliance  ACT4 compliance suite (uses STAGE, stages 1-5 only)"
+	@echo "  coverage    Line coverage gate (stage 5 FPU + ALU/LSU/decode)"
+	@echo "  synth       Vivado synthesis + P&R on KV260"
+	@echo "  clean       Remove build artefacts"
+	@echo ""
+	@echo "Options"
+	@echo "  STAGE=5   Active stage (0-5, default 5)"
+	@echo "  JOBS=$(JOBS)    Parallel jobs (default: nproc)"
+
+# ── Lint ──────────────────────────────────────────────────────────────────────
+
+lint:
+	fusesoc --cores-root=. run --target=$(_LINT_TARGET) opensoc:ip:kronos_riscv
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+build:
+	$(MAKE) -C sim $(_BUILD_TARGET)
+
+# ── Regression ────────────────────────────────────────────────────────────────
+
+regression:
+	$(MAKE) -C sim -j$(JOBS) sim-all
+
+# ── Compliance ────────────────────────────────────────────────────────────────
+
+compliance:
+ifeq ($(STAGE),0)
+	$(error compliance suite is not available for stage 0)
+endif
+	$(MAKE) -C sim sim-arch-test-s$(STAGE)
+
+# ── Coverage ──────────────────────────────────────────────────────────────────
+
+coverage:
+	$(MAKE) -C sim coverage
+
+# ── Synthesis ─────────────────────────────────────────────────────────────────
+
+synth:
+	vivado -mode batch -source fpga/kv260/synth.tcl \
+	  -tclargs SYNTH_FREQ_MHZ=$(SYNTH_FREQ_MHZ)
+
+# ── Clean ─────────────────────────────────────────────────────────────────────
+
+clean:
+	$(MAKE) -C sim clean
+	$(MAKE) -C sim clean-vivado
+	rm -rf build/opensoc_ip_kronos_riscv_0

--- a/fpga/kv260/synth.cfg
+++ b/fpga/kv260/synth.cfg
@@ -1,0 +1,1 @@
+SYNTH_FREQ_MHZ = 200

--- a/fpga/kv260/synth.tcl
+++ b/fpga/kv260/synth.tcl
@@ -170,6 +170,15 @@ if {$TOP eq "kronos_kv260_top"} {
 set MCP_XDC [file join $REPO_ROOT rtl/stage5/kronos_kv260.xdc]
 add_files -fileset constrs_1 -norecurse $MCP_XDC
 
+# Synthesis-only directives (MAX_FANOUT on high-fan-out pipeline-control nets).
+# Must be processed EARLY — before synth_design flattens the combinational cone
+# — and only during synthesis, never during implementation.
+set SYNTH_XDC [file join $REPO_ROOT fpga/kv260/synth_directives.xdc]
+add_files -fileset constrs_1 -norecurse $SYNTH_XDC
+set_property USED_IN_SYNTHESIS      true  [get_files $SYNTH_XDC]
+set_property USED_IN_IMPLEMENTATION false [get_files $SYNTH_XDC]
+set_property PROCESSING_ORDER       EARLY [get_files $SYNTH_XDC]
+
 # Clock constraint — generated from SYNTH_FREQ_MHZ so no manual XDC edit needed
 file mkdir $PROJ_DIR
 set CLK_XDC [file join $PROJ_DIR clk.xdc]

--- a/fpga/kv260/synth_directives.xdc
+++ b/fpga/kv260/synth_directives.xdc
@@ -1,0 +1,18 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Synthesis-only directives for kronos_top on KV260.
+#
+# Loaded with USED_IN_SYNTHESIS=true / USED_IN_IMPLEMENTATION=false and
+# PROCESSING_ORDER=EARLY so these properties are applied on the elaborated
+# RTL netlist before synth_design flattens the combinational cone (which is
+# why the same constraint placed in a regular impl XDC fails to match).
+
+# High fan-out pipeline-control nets: force driver replication so no single
+# copy drives more than 32 loads.  ex_redirect/mem_redirect each reach the
+# hazard unit, muldiv gating, pc_next mux, align flush, fetch-stale tracker
+# and every id_ex/if_id flush bit (~110 sinks without replication).
+set_property MAX_FANOUT 32 [get_nets -hierarchical -filter {NAME =~ */ex_redirect}]
+set_property MAX_FANOUT 32 [get_nets -hierarchical -filter {NAME =~ */mem_redirect}]
+

--- a/rtl/stage1/kronos_hazard.sv
+++ b/rtl/stage1/kronos_hazard.sv
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // kronos_hazard.sv — pipeline stall and flush control unit
-// Priority (highest first): MEM stall > load-use / JALR-fwd / FRM-hazard > EX/MEM redirect > normal.
+// Priority (highest first): MEM/FPU/fetch stall > load-use / JALR-fwd / FRM-hazard
+//                           > EX/MEM redirect > muldiv stall > normal.
+// Redirect out-ranks muldiv_stall so a wrong-path MUL can't block a flush.
 // Flush overrides enable: when both asserted, the register is cleared.
 module kronos_hazard
   import kronos_pkg::*;
@@ -37,8 +39,13 @@ module kronos_hazard
   input  logic       ex_redirect_i,
   // MEM redirect (branch target mismatch detected one cycle later)
   input  logic       mem_redirect_i,
-  // MEM stall (LSU waiting for OBI rvalid)
+  // MEM/FPU/fetch stall bundle (LSU bus wait, FPU scoreboard, IF not valid).
+  // These freeze the pipeline with absolute priority — they cannot be dropped
+  // by a redirect (e.g. an in-flight AXI transaction must complete).
   input  logic       mem_stall_i,
+  // muldiv stall — separate from mem_stall_i so redirect can flush a
+  // wrong-path MUL instead of being held by priority-1 pipeline freeze.
+  input  logic       muldiv_stall_i,
   // Pipeline register enables
   output logic       pc_en_o,
   output logic       if_id_en_o,
@@ -91,7 +98,7 @@ module kronos_hazard
     id_ex_flush_o = 1'b0;
 
     if (mem_stall_i) begin
-      // Priority 1: OBI stall — hold all stages
+      // Priority 1: MEM/FPU/fetch stall — hold all stages
       pc_en_o     = 1'b0;
       if_id_en_o  = 1'b0;
       id_ex_en_o  = 1'b0;
@@ -104,9 +111,19 @@ module kronos_hazard
       id_ex_en_o    = 1'b0;
       id_ex_flush_o = 1'b1;   // flush overrides en → bubble in ID/EX
     end else if (ex_redirect_i | mem_redirect_i) begin
-      // Priority 3: EX/MEM redirect — squash IF and ID
+      // Priority 3: EX/MEM redirect — squash IF and ID.  Placed above
+      // muldiv_stall so a wrong-path MUL (id_ex_q.valid=1, muldiv_valid=0)
+      // is flushed immediately instead of deadlocking the pipeline while the
+      // muldiv FSM waits for a muldiv_req that was gated by the redirect.
       if_id_flush_o = 1'b1;
       id_ex_flush_o = 1'b1;
+    end else if (muldiv_stall_i) begin
+      // Priority 4: muldiv FSM busy — hold all stages while it completes.
+      pc_en_o     = 1'b0;
+      if_id_en_o  = 1'b0;
+      id_ex_en_o  = 1'b0;
+      ex_mem_en_o = 1'b0;
+      mem_wb_en_o = 1'b0;
     end
   end
 

--- a/rtl/stage1/kronos_top.sv
+++ b/rtl/stage1/kronos_top.sv
@@ -144,6 +144,7 @@ module kronos_top
     .ex_redirect_i        (ex_redirect),
     .mem_redirect_i       (1'b0),
     .mem_stall_i          (mem_stall),
+    .muldiv_stall_i       (1'b0),
     .pc_en_o              (pc_en),
     .if_id_en_o           (if_id_en),
     .id_ex_en_o           (id_ex_en),

--- a/rtl/stage2/kronos_top.sv
+++ b/rtl/stage2/kronos_top.sv
@@ -181,6 +181,7 @@ module kronos_top
     .ex_redirect_i        (ex_redirect),
     .mem_redirect_i       (1'b0),
     .mem_stall_i          (combined_stall),
+    .muldiv_stall_i       (1'b0),
     .pc_en_o              (pc_en),
     .if_id_en_o           (if_id_en),
     .id_ex_en_o           (id_ex_en),

--- a/rtl/stage3/kronos_top.sv
+++ b/rtl/stage3/kronos_top.sv
@@ -193,6 +193,7 @@ module kronos_top
     .ex_redirect_i        (ex_redirect),
     .mem_redirect_i       (1'b0),
     .mem_stall_i          (combined_stall),
+    .muldiv_stall_i       (1'b0),
     .pc_en_o              (pc_en),
     .if_id_en_o           (if_id_en),
     .id_ex_en_o           (id_ex_en),

--- a/rtl/stage4/kronos_top.sv
+++ b/rtl/stage4/kronos_top.sv
@@ -199,6 +199,7 @@ module kronos_top
     .ex_redirect_i        (ex_redirect),
     .mem_redirect_i       (1'b0),
     .mem_stall_i          (combined_stall),
+    .muldiv_stall_i       (1'b0),
     .pc_en_o              (pc_en),
     .if_id_en_o           (if_id_en),
     .id_ex_en_o           (id_ex_en),

--- a/rtl/stage5/fpu/kronos_fpu_fadd.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fadd.sv
@@ -123,6 +123,26 @@ module kronos_fpu_fadd
     logic                both_zero;
   } s2_t;
 
+  // S2b: after the 56-bit add/subtract, before LZC + normalize. Inserted to
+  // split the long add/sub -> LZC -> barrel-shift -> sticky cone that was
+  // the critical path at 200 MHz on KV260.
+  typedef struct packed {
+    logic                valid;
+    logic                fmt_d;
+    logic [2:0]          rm;
+    fpu_tag_t            tag;
+    logic                is_special;
+    logic [63:0]         special_res;
+    logic [4:0]          special_flg;
+    logic                res_sign;
+    logic                op_sub;
+    logic signed [EXP_W-1:0] res_exp;   // exponent possibly bumped by add carry
+    // Post-add/sub significand. For ADD: already shifted right by the
+    // carry-out if one occurred (exp bumped). For SUB: the full |big-small|.
+    logic [SIG_W-1:0]    sum_sig;
+    logic                small_sticky; // final sticky contribution forwarded to S3
+  } s2b_t;
+
   typedef struct packed {
     logic                valid;
     logic                fmt_d;
@@ -182,6 +202,7 @@ module kronos_fpu_fadd
   // ---------------------------------------------------------------------------
   s1_t  s1_q;
   s2_t  s2_q;
+  s2b_t s2b_q;
   s3_t  s3_q;
   s3b_t s3b_q;
   s4_t  s4_q;
@@ -468,98 +489,120 @@ module kronos_fpu_fadd
   end
 
   // ===========================================================================
-  // Stage 3: add / subtract, normalize
+  // Stage 2b: add / subtract only.  LZC and normalize moved to Stage 3 so the
+  // 56-bit carry chain no longer shares a clock period with the CLZ + barrel
+  // shift + sticky extraction.  Resolves the S2→S3 critical path.
+  // ===========================================================================
+  s2b_t s2b_d;
+
+  always_comb begin
+    s2b_d = '0;
+    s2b_d.valid       = s2_q.valid;
+    s2b_d.fmt_d       = s2_q.fmt_d;
+    s2b_d.rm          = s2_q.rm;
+    s2b_d.tag         = s2_q.tag;
+    s2b_d.is_special  = s2_q.is_special;
+    s2b_d.special_res = s2_q.special_res;
+    s2b_d.special_flg = s2_q.special_flg;
+    s2b_d.res_sign    = s2_q.res_sign;
+    s2b_d.op_sub      = s2_q.op_sub;
+    s2b_d.res_exp     = s2_q.res_exp;
+
+    begin : s2b_addsub_blk
+      logic [SIG_W:0] sum_ext;
+      logic           small_sticky;
+
+      small_sticky = s2_q.small_sticky_extra;
+
+      if (!s2_q.op_sub) begin
+        // Addition of magnitudes.
+        sum_ext = {1'b0, s2_q.big_sig} + {1'b0, s2_q.small_sig};
+        if (sum_ext[SIG_W]) begin
+          // Carry-out: shift right by 1, bump exponent, fold LSB into sticky.
+          s2b_d.sum_sig      = sum_ext[SIG_W:1];
+          s2b_d.res_exp      = s2_q.res_exp + 13'sd1;
+          s2b_d.small_sticky = small_sticky | sum_ext[0];
+        end else begin
+          s2b_d.sum_sig      = sum_ext[SIG_W-1:0];
+          s2b_d.small_sticky = small_sticky;
+        end
+      end else begin
+        // Subtraction: big - small - borrow-for-sticky.
+        sum_ext = {1'b0, s2_q.big_sig} - {1'b0, s2_q.small_sig}
+                  - {{(SIG_W){1'b0}}, small_sticky};
+        s2b_d.sum_sig      = sum_ext[SIG_W-1:0];
+        s2b_d.small_sticky = small_sticky;
+      end
+    end
+  end
+
+  // ===========================================================================
+  // Stage 3: LZC + normalize + G/R/S extraction (reads from s2b_q)
   // ===========================================================================
   s3_t s3_d;
 
   always_comb begin
     s3_d = '0;
-    s3_d.valid       = s2_q.valid;
-    s3_d.fmt_d       = s2_q.fmt_d;
-    s3_d.rm          = s2_q.rm;
-    s3_d.tag         = s2_q.tag;
-    s3_d.is_special  = s2_q.is_special;
-    s3_d.special_res = s2_q.special_res;
-    s3_d.special_flg = s2_q.special_flg;
-    s3_d.res_sign    = s2_q.res_sign;
-    s3_d.res_exp     = s2_q.res_exp;
+    s3_d.valid       = s2b_q.valid;
+    s3_d.fmt_d       = s2b_q.fmt_d;
+    s3_d.rm          = s2b_q.rm;
+    s3_d.tag         = s2b_q.tag;
+    s3_d.is_special  = s2b_q.is_special;
+    s3_d.special_res = s2b_q.special_res;
+    s3_d.special_flg = s2b_q.special_flg;
+    s3_d.res_sign    = s2b_q.res_sign;
+    s3_d.res_exp     = s2b_q.res_exp;
 
-    begin : addsub_blk
-      logic [SIG_W:0]          sum_ext;      // one extra bit for carry
-      logic [SIG_W-1:0]        sum_sig;
-      logic                    carry_out;
+    begin : s3_norm_blk
       int unsigned             lzc;
       logic [SIG_W-1:0]        norm_sig;
       logic signed [EXP_W-1:0] norm_exp;
       logic                    result_zero;
-      logic                    small_sticky;
 
-      sum_sig      = {SIG_W{1'b0}};
-      carry_out    = 1'b0;
-      lzc          = 0;
-      norm_sig     = {SIG_W{1'b0}};
-      norm_exp     = {EXP_W{1'b0}};
-      result_zero  = 1'b0;
-      small_sticky = s2_q.small_sticky_extra;
+      lzc         = 0;
+      norm_sig    = {SIG_W{1'b0}};
+      norm_exp    = {EXP_W{1'b0}};
+      result_zero = 1'b0;
 
-      if (!s2_q.op_sub) begin
-        // Addition of magnitudes.
-        sum_ext   = {1'b0, s2_q.big_sig} + {1'b0, s2_q.small_sig};
-        carry_out = sum_ext[SIG_W];
-        if (carry_out) begin
-          // Overflow: shift right by 1, increment exponent. LSB goes into
-          // sticky (since it was a post-alignment bit).
-          norm_sig = sum_ext[SIG_W:1];
-          norm_exp = s3_d.res_exp + 13'sd1;
-          small_sticky = small_sticky | sum_ext[0];
-        end else begin
-          norm_sig = sum_ext[SIG_W-1:0];
-          norm_exp = s3_d.res_exp;
-        end
+      if (!s2b_q.op_sub) begin
+        // Addition path: sum_sig already normalized in S2b.  Just extract
+        // G/R/S from the low 3 bits and merge with the carried sticky.
+        norm_sig     = s2b_q.sum_sig;
+        norm_exp     = s2b_q.res_exp;
         s3_d.res_sig = norm_sig;
-        s3_d.res_exp = norm_exp;
-        // Extract G/R/S from the low 3 bits of norm_sig (the reserved alignment
-        // bits) merged with incoming small_sticky.
         s3_d.guard   = norm_sig[2];
         s3_d.round_b = norm_sig[1];
-        s3_d.sticky  = norm_sig[0] | small_sticky;
-        // Clear the sub-ULP bits in the stored significand (they were G/R/S).
+        s3_d.sticky  = norm_sig[0] | s2b_q.small_sticky;
         s3_d.res_sig[2:0] = 3'd0;
-        result_zero = (norm_sig == {SIG_W{1'b0}});
+        result_zero  = (norm_sig == {SIG_W{1'b0}});
       end else begin
-        // Subtraction: big - small. Include the extra sticky in the subtract as
-        // a "borrow that would be used by sticky" — we handle it by subtracting
-        // at full precision and keeping the extra bit as the sticky.
-        sum_ext   = {1'b0, s2_q.big_sig} - {1'b0, s2_q.small_sig}
-                    - {{(SIG_W){1'b0}}, small_sticky};
-        sum_sig   = sum_ext[SIG_W-1:0];
-        // Leading-zero count for normalization.
-        lzc = clz_sig(sum_sig);
+        // Subtraction path: LZC on the raw |big-small|, then left-shift to
+        // normalize.
+        lzc = clz_sig(s2b_q.sum_sig);
         if (lzc == SIG_W) begin
           result_zero = 1'b1;
           norm_sig    = {SIG_W{1'b0}};
           norm_exp    = {EXP_W{1'b0}};
         end else begin
           result_zero = 1'b0;
-          norm_sig    = sum_sig << lzc;
-          norm_exp    = s3_d.res_exp - 13'($signed(lzc));
+          norm_sig    = s2b_q.sum_sig << lzc;
+          norm_exp    = s2b_q.res_exp - 13'($signed(lzc));
         end
         s3_d.res_sig = norm_sig;
         s3_d.res_exp = norm_exp;
         s3_d.guard   = norm_sig[2];
         s3_d.round_b = norm_sig[1];
-        // After a cancellation-shift the bits that fed sticky via small_sticky
-        // are no longer meaningful if lzc shifted them in — but for RNE-correct
-        // subtraction in the close-path, sticky=0 when lzc>0 because only one
-        // bit differs. Conservative: keep OR.
-        s3_d.sticky  = norm_sig[0] | (small_sticky & (lzc == 0));
+        // Close-path sticky: when lzc shifted out the alignment bits, sticky
+        // from the pre-subtract borrow is no longer meaningful.  Preserve the
+        // original conservative-OR semantics.
+        s3_d.sticky  = norm_sig[0] | (s2b_q.small_sticky & (lzc == 0));
         s3_d.res_sig[2:0] = 3'd0;
       end
 
       s3_d.result_zero = result_zero;
       if (result_zero) begin
         // Cancellation-to-zero sign rule (non-special path): RDN→-0 else +0.
-        s3_d.res_sign = (s2_q.rm == FP_RM_RDN);
+        s3_d.res_sign = (s2b_q.rm == FP_RM_RDN);
       end
     end
   end
@@ -815,18 +858,21 @@ module kronos_fpu_fadd
     if (!rst_ni) begin
       s1_q  <= '0;
       s2_q  <= '0;
+      s2b_q <= '0;
       s3_q  <= '0;
       s3b_q <= '0;
       s4_q  <= '0;
     end else begin
       s1_q  <= s1_d;
       s2_q  <= s2_d;
+      s2b_q <= s2b_d;
       s3_q  <= s3_d;
       s3b_q <= s3b_d;
       s4_q  <= s4_d;
       if (flush_i) begin
         s1_q.valid  <= 1'b0;
         s2_q.valid  <= 1'b0;
+        s2b_q.valid <= 1'b0;
         s3_q.valid  <= 1'b0;
         s3b_q.valid <= 1'b0;
         s4_q.valid  <= 1'b0;

--- a/rtl/stage5/fpu/kronos_fpu_fmul.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fmul.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// 8-stage pipelined IEEE 754 floating-point multiplier (single and double).
+// 9-stage pipelined IEEE 754 floating-point multiplier (single and double).
 //
 // Pipeline:
 //   S1:  NaN-unbox single, decompose operands, classify specials, precompute
@@ -11,11 +11,14 @@
 //        DSP48 cascade.
 //   S1c: Re-latch multiplicands into s1c_*_q. Pipeline register #2 into the
 //        DSP48 cascade. Together with S1b, gives Vivado three flops between
-//        the multiplicand source and the DSP cascade output, letting retiming
-//        (global_retiming on) place them in the DSP48 internal AREG/MREG/PREG
-//        pipeline. This closes the 53×53 DSP-chain critical path at 220 MHz.
-//   S2:  Multiply significands (wide multiply registered at stage boundary for
-//        DSP inference).
+//        the multiplicand source and the start of the partial-product DSP
+//        cascade, so retiming can place them in the DSP48 AREG/MREG pipeline.
+//   S2a: Two partial products — split sigb into a 27-bit low half and a 26-bit
+//        high half and compute 53×27 / 53×26 in parallel. Each partial fits in
+//        a short DSP48E2 cascade (≤ 2 tiles), breaking the 53×53 cascade that
+//        would otherwise span 3 cascaded DSP48E2 slices combinationally.
+//   S2:  Sum the two registered partial products (pp_hi << 27 + pp_lo) into
+//        the 106-bit product. Registered at stage boundary.
 //   S3:  LZC only — compute 7-bit leading-zero count and normalized exponent
 //        from the 106-bit product. Carry full product forward.
 //   S3b: Normalize barrel shift — use registered LZC to shift product and
@@ -56,6 +59,14 @@ module kronos_fpu_fmul
   localparam int unsigned SIG_W     = 53;             // mantissa incl. hidden bit
   localparam int unsigned PROD_W    = 2 * SIG_W;      // 106
   localparam int unsigned EXP_EXT_W = 13;             // signed, covers both fmts
+
+  // Partial-product split for the S2a stage. sigb is split into a 27-bit
+  // low half [26:0] and a 26-bit high half [52:27]; each partial product
+  // fits in a short DSP48E2 cascade.
+  localparam int unsigned HALF_LO_W = 27;
+  localparam int unsigned HALF_HI_W = SIG_W - HALF_LO_W;    // 26
+  localparam int unsigned PP_LO_W   = SIG_W + HALF_LO_W;    // 80
+  localparam int unsigned PP_HI_W   = SIG_W + HALF_HI_W;    // 79
 
   // -------------------------------------------------------------------------
   // Classification helpers
@@ -335,12 +346,75 @@ module kronos_fpu_fmul
   end
 
   // -------------------------------------------------------------------------
-  // S2 combinational: multiply
+  // S2a combinational: two partial products (53×27 and 53×26)
+  // -------------------------------------------------------------------------
+  logic [PP_LO_W-1:0] s2a_pp_lo_c;
+  logic [PP_HI_W-1:0] s2a_pp_hi_c;
+
+  always_comb begin
+    s2a_pp_lo_c = s1c_siga_q * s1c_sigb_q[HALF_LO_W-1:0];
+    s2a_pp_hi_c = s1c_siga_q * s1c_sigb_q[SIG_W-1:HALF_LO_W];
+  end
+
+  // -------------------------------------------------------------------------
+  // S2a registers: register the two partial products plus forwarded metadata.
+  // This breaks the 53×53 DSP cascade into two shorter cascades, each fed by
+  // the s1c re-latches and followed by an output register that retiming can
+  // place in the DSP48E2 PREG.
+  // -------------------------------------------------------------------------
+  logic        s2a_valid_q;
+  logic        s2a_fmt_d_q;
+  logic [2:0]  s2a_rm_q;
+  fpu_tag_t    s2a_tag_q;
+  logic        s2a_sign_q;
+  logic signed [EXP_EXT_W-1:0] s2a_exp_sum_q;
+  logic [PP_LO_W-1:0] s2a_pp_lo_q;
+  logic [PP_HI_W-1:0] s2a_pp_hi_q;
+  logic        s2a_any_snan_q, s2a_any_nan_q, s2a_inf_times_zero_q;
+  logic        s2a_res_is_inf_q, s2a_res_is_zero_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s2a_regs
+    if (!rst_ni) begin
+      s2a_valid_q          <= 1'b0;
+      s2a_fmt_d_q          <= 1'b0;
+      s2a_rm_q             <= 3'd0;
+      s2a_tag_q            <= '0;
+      s2a_sign_q           <= 1'b0;
+      s2a_exp_sum_q        <= 13'h0;
+      s2a_pp_lo_q          <= {PP_LO_W{1'b0}};
+      s2a_pp_hi_q          <= {PP_HI_W{1'b0}};
+      s2a_any_snan_q       <= 1'b0;
+      s2a_any_nan_q        <= 1'b0;
+      s2a_inf_times_zero_q <= 1'b0;
+      s2a_res_is_inf_q     <= 1'b0;
+      s2a_res_is_zero_q    <= 1'b0;
+    end else begin
+      s2a_valid_q          <= flush_i ? 1'b0 : s1c_valid_q;
+      s2a_fmt_d_q          <= s1c_fmt_d_q;
+      s2a_rm_q             <= s1c_rm_q;
+      s2a_tag_q            <= s1c_tag_q;
+      s2a_sign_q           <= s1c_sign_q;
+      s2a_exp_sum_q        <= s1c_exp_sum_q;
+      s2a_pp_lo_q          <= s2a_pp_lo_c;
+      s2a_pp_hi_q          <= s2a_pp_hi_c;
+      s2a_any_snan_q       <= s1c_any_snan_q;
+      s2a_any_nan_q        <= s1c_any_nan_q;
+      s2a_inf_times_zero_q <= s1c_inf_times_zero_q;
+      s2a_res_is_inf_q     <= s1c_res_is_inf_q;
+      s2a_res_is_zero_q    <= s1c_res_is_zero_q;
+    end
+  end
+
+  // -------------------------------------------------------------------------
+  // S2 combinational: sum the two partial products into the full 106-bit
+  // product. pp_hi << 27 + pp_lo. Result fits in PROD_W (106) bits since
+  // siga × sigb < 2^106 for any 53-bit operands.
   // -------------------------------------------------------------------------
   logic [PROD_W-1:0] s2_prod_c;
 
   always_comb begin
-    s2_prod_c = s1c_siga_q * s1c_sigb_q;
+    s2_prod_c = {s2a_pp_hi_q, {HALF_LO_W{1'b0}}}
+              + {{(PROD_W - PP_LO_W){1'b0}}, s2a_pp_lo_q};
   end
 
   // -------------------------------------------------------------------------
@@ -371,18 +445,18 @@ module kronos_fpu_fmul
       s2_res_is_inf_q     <= 1'b0;
       s2_res_is_zero_q    <= 1'b0;
     end else begin
-      s2_valid_q          <= flush_i ? 1'b0 : s1c_valid_q;
-      s2_fmt_d_q          <= s1c_fmt_d_q;
-      s2_rm_q             <= s1c_rm_q;
-      s2_tag_q            <= s1c_tag_q;
-      s2_sign_q           <= s1c_sign_q;
-      s2_exp_sum_q        <= s1c_exp_sum_q;
+      s2_valid_q          <= flush_i ? 1'b0 : s2a_valid_q;
+      s2_fmt_d_q          <= s2a_fmt_d_q;
+      s2_rm_q             <= s2a_rm_q;
+      s2_tag_q            <= s2a_tag_q;
+      s2_sign_q           <= s2a_sign_q;
+      s2_exp_sum_q        <= s2a_exp_sum_q;
       s2_prod_q           <= s2_prod_c;
-      s2_any_snan_q       <= s1c_any_snan_q;
-      s2_any_nan_q        <= s1c_any_nan_q;
-      s2_inf_times_zero_q <= s1c_inf_times_zero_q;
-      s2_res_is_inf_q     <= s1c_res_is_inf_q;
-      s2_res_is_zero_q    <= s1c_res_is_zero_q;
+      s2_any_snan_q       <= s2a_any_snan_q;
+      s2_any_nan_q        <= s2a_any_nan_q;
+      s2_inf_times_zero_q <= s2a_inf_times_zero_q;
+      s2_res_is_inf_q     <= s2a_res_is_inf_q;
+      s2_res_is_zero_q    <= s2a_res_is_zero_q;
     end
   end
 

--- a/rtl/stage5/fpu/kronos_fpu_top.sv
+++ b/rtl/stage5/fpu/kronos_fpu_top.sv
@@ -9,8 +9,9 @@
 // Latency table (clock cycles from dispatch to out_valid):
 //   FMISC  1  (FSGNJ*, FMIN, FMAX, FCLASS, FEQ, FLT, FLE, FMV.*)
 //   FCVT   3  (FCVT.*.* integer↔FP conversions)
-//   FADD   6  (FADD, FSUB — extra S3b stage for timing closure at 148 MHz)
-//   FMUL   8  (FMUL — s1b+s1c pipeline stages added for DSP timing closure)
+//   FADD   7  (FADD, FSUB — s2b add/sub stage separates the 56-bit adder
+//              from the S3 CLZ + normalize + sticky cone)
+//   FMUL   9  (FMUL — s1b+s1c re-latch + s2a partial-product pipelining stage)
 //   FMA    9  (FMADD, FMSUB, FNMADD, FNMSUB — s2b re-latch + s3b barrel-shift stage)
 //   ITER   variable (FDIV, FSQRT) — late-reservation via scoreboard
 //
@@ -72,11 +73,11 @@ module kronos_fpu_top
       end
       FP_FADD, FP_FSUB: begin
         sel_fadd         = 1'b1;
-        dispatch_latency = 4'd6;
+        dispatch_latency = 4'd7;
       end
       FP_FMUL: begin
         sel_fmul         = 1'b1;
-        dispatch_latency = 4'd8;
+        dispatch_latency = 4'd9;
       end
       FP_FMADD, FP_FMSUB, FP_FNMADD, FP_FNMSUB: begin
         sel_fma          = 1'b1;

--- a/rtl/stage5/kronos_muldiv.sv
+++ b/rtl/stage5/kronos_muldiv.sv
@@ -4,13 +4,15 @@
 
 // kronos_muldiv.sv — multi-cycle 64-bit multiply/divide unit (RV64M).
 //
-// MUL/MULH/MULHSU/MULHU: 4-cycle latency (MUL_IN, MUL_OUT, DONE).
+// MUL/MULH/MULHSU/MULHU: 5-cycle latency (MUL_IN, MUL_MID, MUL_OUT, DONE).
 //   IDLE: latch sign-extended 65-bit operands into mul_a65_q / mul_b65_q.
-//   MUL_IN: register the 65×65 product into mul_product_q.
+//   MUL_IN: split mul_b65_q into a 33-bit signed high half [64:32] and a
+//           32-bit unsigned low half [31:0], compute two 65×33 partial
+//           products pp_hi_q / pp_lo_q.  Each fits in a short DSP48E2
+//           cascade rather than the 3-DSP cascade a single 65×65 requires.
+//   MUL_MID: sum pp_hi_q << 32 + pp_lo_q into mul_product_q.
 //   MUL_OUT: select high/low half, apply word_op sign extension → result_q.
 //   DONE: expose result.
-//   Breaking the multiply into two registered stages keeps each half under
-//   budget at 148 MHz: operand-extend path ~2–3 ns, DSP-cascade path ~5.5 ns.
 //
 // DIV/DIVU/REM/REMU: IDLE -> COMPUTE x N -> DONE, where
 //   N = 64 for full 64-bit ops and N = 32 when word_op_i is asserted.
@@ -54,9 +56,10 @@ module kronos_muldiv
   typedef enum logic [2:0] {
     IDLE    = 3'd0,
     MUL_IN  = 3'd1,  // register sign-extended operands
-    MUL_OUT = 3'd2,  // register DSP product
-    COMPUTE = 3'd3,  // iterative division step
-    DONE    = 3'd4
+    MUL_MID = 3'd2,  // register 65x33 partial products
+    MUL_OUT = 3'd3,  // register 130-bit full product
+    COMPUTE = 3'd4,  // iterative division step
+    DONE    = 3'd5
   } muldiv_state_e;
 
   muldiv_state_e state_q;
@@ -80,9 +83,15 @@ module kronos_muldiv
   logic [64:0] mul_a65;
   logic [64:0] mul_b65;
 
-  // Registered pipeline stages
+  // Registered pipeline stages.
+  // Partial-product width: 65 (signed a) × 33 (signed b-half) = 98 bits signed.
+  // The 65×65 signed multiply is decomposed into pp_hi = a × b[64:32]_signed
+  // and pp_lo = a × {1'b0, b[31:0]} (the low half treated as positive), then
+  // summed as (pp_hi << 32) + pp_lo in MUL_MID.
   logic [64:0]          mul_a65_q;
   logic [64:0]          mul_b65_q;
+  logic signed [97:0]   pp_lo_q;
+  logic signed [97:0]   pp_hi_q;
   logic signed [129:0]  mul_product_q;
   muldiv_op_e           op_q;
 
@@ -129,7 +138,8 @@ module kronos_muldiv
   // -------------------------------------------------------------------------
   // Output wiring
   // -------------------------------------------------------------------------
-  assign busy_o   = (state_q == MUL_IN) | (state_q == MUL_OUT) | (state_q == COMPUTE);
+  assign busy_o   = (state_q == MUL_IN) | (state_q == MUL_MID) |
+                    (state_q == MUL_OUT) | (state_q == COMPUTE);
   assign valid_o  = (state_q == DONE);
   assign idle_o   = (state_q == IDLE);
   assign result_o = result_q;
@@ -143,6 +153,8 @@ module kronos_muldiv
       result_q      <= {64{1'b0}};
       mul_a65_q     <= {65{1'b0}};
       mul_b65_q     <= {65{1'b0}};
+      pp_lo_q       <= 98'sd0;
+      pp_hi_q       <= 98'sd0;
       mul_product_q <= {130{1'b0}};
       op_q          <= MULDIV_MUL;
       dividend_q    <= {64{1'b0}};
@@ -253,17 +265,30 @@ module kronos_muldiv
         end
 
         // ---------------------------------------------------------------
-        // Pipeline stage 2: register the 65×65 product.
-        // Path B: registered 65-bit operands → DSP48E2 cascade → product register.
-        // ~5.5–6.0 ns, within budget.
+        // Pipeline stage 2: compute two 65×33 partial products.
+        // Splitting the 65×65 multiply into (a × b[64:32]_signed) and
+        // (a × {1'b0, b[31:0]}) lets each partial fit in a short DSP48E2
+        // cascade, keeping the logic depth per cycle under budget.
         MUL_IN: begin
-          mul_product_q <= $signed(mul_a65_q) * $signed(mul_b65_q);
-          state_q       <= MUL_OUT;
+          pp_lo_q <= $signed(mul_a65_q) * $signed({1'b0, mul_b65_q[31:0]});
+          pp_hi_q <= $signed(mul_a65_q) * $signed(mul_b65_q[64:32]);
+          state_q <= MUL_MID;
         end
 
         // ---------------------------------------------------------------
-        // Pipeline stage 3: select result half and sign-extend to 64 bits.
-        // Path C: product register → mux → result_q. ~1.5 ns.
+        // Pipeline stage 3: sum the partials into the full 130-bit product.
+        // {pp_hi_q, 32'd0} is pp_hi_q << 32 with sign preserved because the
+        // MSB of pp_hi_q lands in bit 129 of mul_product_q, the sign bit of
+        // the 130-bit signed result.
+        MUL_MID: begin
+          mul_product_q <= 130'($signed({pp_hi_q, 32'd0})
+                                + $signed({{33{pp_lo_q[97]}}, pp_lo_q}));
+          state_q <= MUL_OUT;
+        end
+
+        // ---------------------------------------------------------------
+        // Pipeline stage 4: select result half and sign-extend to 64 bits.
+        // Path: product register → mux → result_q. ~1.5 ns.
         MUL_OUT: begin
           logic [63:0] sel;
           unique case (op_q)

--- a/rtl/stage5/kronos_top.sv
+++ b/rtl/stage5/kronos_top.sv
@@ -118,6 +118,7 @@ module kronos_top
   logic         fetch_flush;
   logic         instr_fetch_stall;
   logic         combined_stall;
+  logic         combined_stall_no_muldiv;
 
   // STAGE3: C extension — alignment unit signals
   logic [31:0] align_instr;
@@ -263,8 +264,10 @@ module kronos_top
   );
 
   // STAGE3: combined_stall — mem_stall | muldiv_stall | instr_fetch_stall | fpu_stall
-  assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid
-                             & ~ex_redirect & ~mem_redirect;
+  // muldiv_stall is exposed raw (no redirect gating) — kronos_hazard resolves
+  // the priority so a redirect flushes the wrong-path MUL without needing
+  // muldiv_stall to fan in from ex_redirect/mem_redirect.
+  assign muldiv_stall      = id_ex_q.valid & id_ex_q.dec.is_muldiv & ~muldiv_valid;
   assign instr_fetch_stall = ~align_instr_valid;
   // fpu_dispatching: the FPU dispatch will fire this cycle.  Stall immediately
   // so the following instruction stays in IF/ID and can receive the FP result
@@ -280,7 +283,11 @@ module kronos_top
   assign fp_tag_cur        = fpu_out_valid ? fpu_tag_out : fp_tag_q;
   // Release stall once the result is available; keep stalled until then.
   assign fpu_stall         = (fp_inflight_q | fpu_dispatching) & ~fp_result_avail;
-  assign combined_stall    = mem_stall | muldiv_stall | instr_fetch_stall | fpu_stall;
+  // Non-muldiv stall sources that hazard must observe with absolute priority
+  // (bus/FPU/fetch can't be abandoned mid-flight by a redirect).  muldiv_stall
+  // is fed to hazard separately so redirect flush can out-rank it.
+  assign combined_stall_no_muldiv = mem_stall | instr_fetch_stall | fpu_stall;
+  assign combined_stall    = combined_stall_no_muldiv | muldiv_stall;
 
   // FRM/FCSR RAW hazard: a CSR write to FRM/FCSR in EX will update fcsr_q at
   // the posedge, but decode reads frm combinatorially from fcsr_q. Stall 1
@@ -321,7 +328,8 @@ module kronos_top
     .if_id_fp_dyn_rm_i    (if_id_fp_dyn_rm),
     .ex_redirect_i        (ex_redirect),
     .mem_redirect_i       (mem_redirect),
-    .mem_stall_i          (combined_stall),
+    .mem_stall_i          (combined_stall_no_muldiv),
+    .muldiv_stall_i       (muldiv_stall),
     .pc_en_o          (pc_en),
     .if_id_en_o       (if_id_en),
     .id_ex_en_o       (id_ex_en),

--- a/tb/stage1/tb_hazard.sv
+++ b/tb/stage1/tb_hazard.sv
@@ -39,6 +39,7 @@ module tb_hazard;
     .ex_redirect_i        (ex_redirect_i),
     .mem_redirect_i       ('0),
     .mem_stall_i          (mem_stall_i),
+    .muldiv_stall_i       ('0),
     .pc_en_o              (pc_en_o),
     .if_id_en_o           (if_id_en_o),
     .id_ex_en_o           (id_ex_en_o),

--- a/tb/stage5/tb_fpu_fadd.sv
+++ b/tb/stage5/tb_fpu_fadd.sv
@@ -41,8 +41,8 @@ module tb_fpu_fadd;
     b        = bin;
     @(negedge clk);
     in_valid = 0;
-    // Six pipeline stages (S1..S3b..S4..S5) → sample after 6 posedges.
-    repeat (6) @(posedge clk);
+    // Seven pipeline stages (S1..S2b..S3b..S4..S5) → sample after 7 posedges.
+    repeat (7) @(posedge clk);
     #1;
   endtask
 

--- a/tb/stage5/tb_fpu_fmul.sv
+++ b/tb/stage5/tb_fpu_fmul.sv
@@ -34,7 +34,7 @@ module tb_fpu_fmul;
                         input logic [63:0] ain, bin);
     @(negedge clk); in_valid=1; op=o; fmt_d=fmtd; rm=r; a=ain; b=bin;
     @(negedge clk); in_valid=0;
-    repeat(7) @(posedge clk); #1;
+    repeat(8) @(posedge clk); #1;
   endtask
 
   int errors = 0, total = 0;


### PR DESCRIPTION
## Summary

- Top-level `Makefile` dispatching per-stage `lint` / `build` / `regression` / `compliance` / `coverage` / `synth` (driven by `STAGE=N`, default 5).
- Hazard-unit rework so redirect flushes out-rank `muldiv_stall` — removes `ex_redirect` from `combined_stall`'s fan-in without reintroducing the wrong-path-MUL deadlock the 406c546 fix was guarding against.
- New pipeline stages inside FPU FMUL, FPU FADD, and integer muldiv to split previously-combinational wide arithmetic + CLZ + barrel-shift cones that were missing the 200 MHz target.
- Synth-only XDC with `MAX_FANOUT 32` on the redirect nets, applied with `PROCESSING_ORDER=EARLY` so it lands before the combinational cone is flattened.

## Post-route timing on KV260 (`xck26-sfvc784-2LV-c`)

| Step | WNS (ns) | Fmax (MHz) |
|---|---|---|
| baseline (before this PR) | −0.422 | 184.4 |
| + redirect-fanout XDC + FMUL `S2a` partial-product split | −0.401 | 185.2 |
| + FADD `S2b` add/sub stage | −0.286 | 189.2 |
| + muldiv `MUL_MID` partial-product split | **0.000** | **≥ 200.0** |

## Latency / interface changes

| Unit | Old latency | New latency |
|---|---|---|
| `kronos_fpu_fmul` | 8 | 9 |
| `kronos_fpu_fadd` | 6 | 7 |
| `kronos_muldiv` MUL | 4 | 5 |

`kronos_fpu_scoreboard.DEPTH=9` still covers all latencies. `kronos_muldiv` exposes `valid_o`/`busy_o`/`idle_o` so the top-level integration absorbs the extra cycle without changes.

`kronos_hazard` gains a new `muldiv_stall_i` input. Stages 1–4 tie it to `1'b0`.

## Test plan

- [x] `make build` (stage 5)
- [x] `make regression` — 37 unit TBs + stage-4 compliance subset (10/10) + sim-s5 integration all PASS
- [x] `make coverage` — line coverage **3330/3330 = 100.0 %** (threshold 100 %)
- [x] `make synth` — timing met, WNS 0.000 ns, Fmax ≥ 200.0 MHz on KV260
- [x] `make compliance` — **NOT RUN.** Blocked by environment toolchain (`riscv64-unknown-elf-gcc 13.2.0` vs ACT4's GCC 15+ requirement). ACT4 suite against stage 5 (303 tests) remains a verification gap to close on a host with a newer toolchain.