### PR TITLE
feat(csr): performance counters (Zicntr + partial Zihpm)

### DIFF
--- a/.github/actions/setup-verilator/action.yml
+++ b/.github/actions/setup-verilator/action.yml
@@ -1,0 +1,46 @@
+name: Setup Verilator
+description: Build and install Verilator 5.046 from source, with caching across CI runs.
+
+inputs:
+  version:
+    description: Verilator git tag to build
+    default: v5.046
+  cache-version:
+    description: Bump to invalidate the cache
+    default: v1
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Verilator
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: /opt/verilator
+        key: verilator-${{ inputs.version }}-${{ runner.os }}-${{ inputs.cache-version }}
+
+    - name: Install build dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends \
+          autoconf flex bison g++ help2man libfl-dev libfl2 zlib1g-dev git ca-certificates make
+
+    - name: Build Verilator from source
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        sudo rm -rf /opt/verilator
+        sudo git clone --depth=1 --branch ${{ inputs.version }} https://github.com/verilator/verilator /opt/verilator
+        cd /opt/verilator
+        sudo autoconf
+        sudo ./configure
+        sudo make -j$(nproc)
+
+    - name: Expose Verilator on PATH
+      shell: bash
+      run: |
+        echo "/opt/verilator/bin" >> "$GITHUB_PATH"
+        echo "VERILATOR_ROOT=/opt/verilator" >> "$GITHUB_ENV"
+        /opt/verilator/bin/verilator --version

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -18,10 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Verilator
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y verilator
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
 
       - name: Install RISC-V toolchain
         run: |
@@ -61,10 +59,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Verilator
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y verilator
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
 
       - name: Install RISC-V GCC toolchain
         run: |
@@ -115,10 +111,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Verilator
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y verilator
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
 
       - name: Install RISC-V GCC toolchain
         run: |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 4     | RV64I + A extension                             | RV64IMAC         | AXI4    | Complete    |
 | 5a    | F/D extensions (pipelined, no FDIV/FSQRT)       | RV64IMAFD        | AXI4    | Complete    |
 | 5b    | FDIV/FSQRT (iterative SRT)                      | RV64IMAFDC       | AXI4    | Complete    |
+| 5c    | Performance counters (Zicntr + partial Zihpm)   | RV64IMAFDC       | AXI4    | Complete    |
 | 6     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -334,3 +334,59 @@ Cycles measured from the instruction entering EX to its result being available i
 | `0x0000000000000003` | EBREAK |
 | `0x000000000000000B` | ECALL from M-mode |
 | `0x8000000000000007` | Machine timer interrupt |
+
+---
+
+## 12. Performance counters (Zicntr + partial Zihpm)
+
+Stage 5c adds architectural performance counters so subsequent
+microarchitectural changes (caches, MMU, OOO) can be measured
+quantitatively.
+
+**CSR additions** (all 64-bit on RV64):
+
+| Address       | Name                | Access      | Notes                                                |
+|---------------|---------------------|-------------|------------------------------------------------------|
+| 0x320         | `mcountinhibit`     | M-mode RW   | Bit X gates increment of counter X (bit 0=mcycle, 2=minstret, 3..10=mhpmcounter3..10). |
+| 0xB00         | `mcycle`            | M-mode RW   | Was read-only; now spec-compliant.                   |
+| 0xB02         | `minstret`          | M-mode RW   | Was read-only; now spec-compliant.                   |
+| 0xB03–0xB0A   | `mhpmcounter3..10`  | M-mode RW   | 8 programmable 64-bit event counters.                |
+| 0xC03–0xC0A   | `hpmcounter3..10`   | U-mode RO   | Aliases of the M-mode counters.                      |
+| 0x323–0x32A   | `mhpmevent3..10`    | M-mode RW   | Event-select; only bits [7:0] are meaningful.        |
+
+**Event-ID table** (wired now; reserved IDs documented for later):
+
+| ID    | Event                                       |
+|-------|---------------------------------------------|
+| 0x00  | No event (counter held)                     |
+| 0x01  | Branch retired (conditional B-type)         |
+| 0x02  | Branch mispredicted                         |
+| 0x03  | Load retired                                |
+| 0x04  | Store retired                               |
+| 0x05  | AXI memory-stall cycle                      |
+| 0x06  | Muldiv busy cycle                           |
+| 0x07  | FPU busy cycle (any FPU unit busy)          |
+| 0x08  | Trap or interrupt taken                     |
+| 0x10–0x1F | reserved for future I$/D$/TLB miss, ROB full, IQ full, etc. |
+
+The event bus is assembled in `rtl/stage5/kronos_top.sv` from the
+existing pipeline signals (plus three small derivations:
+`bpred_mispredict_pulse`, `fpu_busy_any`, `trap_taken_pulse`) and fed
+into `kronos_csr` via the `event_bus_i [15:0]` input. Per-counter
+increment logic in `kronos_csr` selects the bus line indexed by the
+low 8 bits of `mhpmevent[i]` and is gated by `mcountinhibit[i]`. SW
+writes to a counter on the same cycle as a selected event leave the
+counter at the SW-written value (write wins).
+
+**Pipeline-visibility delay:** CSR reads execute in EX, while events
+fire in WB and the counter increment is registered. A `csrr` of a
+counter sees the value flopped at the *previous* posedge — events
+that retire in the same cycle as the read are not yet visible.
+Software that wants an exact post-event count should leave ~2
+instructions of slack between the event and the read (e.g. the asm
+test in `sw/stage5/test_perf_counters.S` inserts two `nop`s before
+its readback). This matches the standard RISC-V perf-counter
+semantic; no forwarding path is provided.
+
+See `docs/superpowers/specs/2026-04-26-perf-counters-design.md` for
+the full design spec.

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -142,6 +142,7 @@ per-stage section.
 | Softfloat smoke        | `tb/stage5/tb_softfloat_smoke.sv`    | Softfloat DPI smoke                    | `make sim-sf-smoke`          |
 | Core FP basic          | `tb/stage5/tb_core_fp_basic.sv`      | Top-level FP smoke                     | `make sim-core-fp-basic`     |
 | Core FP forwarding     | `tb/stage5/tb_core_fp_forwarding.sv` | FP writeback→consumer forwarding       | `make sim-core-fp-forwarding`|
+| CSR perf               | `tb/stage5/tb_csr_perf.sv`           | mcountinhibit / mhpmcounter / event-mux | `make sim-csr-perf-s5`      |
 
 ### Assembly programs (stage 5)
 | Test                      | File                                       | Exercises                              | Run                                  |
@@ -162,6 +163,7 @@ per-stage section.
 | `test_mret_rvc`           | `sw/stage5/test_mret_rvc.S`                | MRET into compressed instruction       | `make run-s5-test_mret_rvc`          |
 | `test_csr_warl`           | `sw/stage5/test_csr_warl.S`                | WARL/WLRL CSR field probing            | `make run-s5-test_csr_warl`          |
 | `test_illegal_insn`       | `sw/stage5/test_illegal_insn.S`            | Illegal instruction trap coverage      | `make run-s5-test_illegal_insn`      |
+| `test_perf_counters`      | `sw/stage5/test_perf_counters.S`           | Zicntr + Zihpm event counters          | `make run-s5-test_perf_counters`     |
 
 ### ACT4 compliance
 - 303 tests (rv64imafdc). Run: `make sim-arch-test-s5`.

--- a/rtl/stage5/kronos_csr.sv
+++ b/rtl/stage5/kronos_csr.sv
@@ -39,7 +39,10 @@ module kronos_csr #(
   output logic [2:0]  frm_o,
   // Zicntr: instruction retirement pulse (mem_wb_q.valid & pipeline advance).
   // Asserted once per retired instruction.  Tie to 0 for stages without Zicntr.
-  input  logic        instret_retire_i
+  input  logic        instret_retire_i,
+  // Zihpm event bus.  Bit i high if event ID i fires this cycle.
+  // Indexed by mhpmeventX[7:0] (event IDs >= 16 increment no counter).
+  input  logic [15:0] event_bus_i
 );
 
   // -------------------------------------------------------------------------
@@ -60,6 +63,22 @@ module kronos_csr #(
   // counters at 0xC00/0xC02 so ACT4 Zicntr tests pass).
   logic [63:0] mcycle;    // 0xB00 / 0xC00 (U-mode alias)
   logic [63:0] minstret;  // 0xB02 / 0xC02 (U-mode alias)
+
+  // -------------------------------------------------------------------------
+  // Zihpm counter-control + event counters (Stage 5c)
+  // -------------------------------------------------------------------------
+  // mcountinhibit (0x320) — bit X gates increment of counter X:
+  //   bit 0  = mcycle, bit 1 = reserved (RAZ/WI), bit 2 = minstret,
+  //   bits 3..10 = mhpmcounter3..10.
+  logic [10:0] mcountinhibit;
+
+  // mhpmcounter3..10 — 8 programmable 64-bit event counters.
+  // Indexed as mhpmcounter[3]..mhpmcounter[10]; entries [0..2] are unused
+  // (their CSR slots are mcycle/reserved/minstret which live above).
+  logic [63:0] mhpmcounter [3:10];
+
+  // mhpmevent3..10 — paired event-select registers (only bits [7:0] used).
+  logic [7:0]  mhpmevent   [3:10];
 
   // -------------------------------------------------------------------------
   // Read-only / combinational CSRs
@@ -101,6 +120,15 @@ module kronos_csr #(
       12'h301: rdata_o = misa;
       12'h304: rdata_o = mie;
       12'h305: rdata_o = mtvec;
+      12'h320: rdata_o = {53'b0, mcountinhibit};         // mcountinhibit
+      12'h323: rdata_o = {56'b0, mhpmevent[3]};
+      12'h324: rdata_o = {56'b0, mhpmevent[4]};
+      12'h325: rdata_o = {56'b0, mhpmevent[5]};
+      12'h326: rdata_o = {56'b0, mhpmevent[6]};
+      12'h327: rdata_o = {56'b0, mhpmevent[7]};
+      12'h328: rdata_o = {56'b0, mhpmevent[8]};
+      12'h329: rdata_o = {56'b0, mhpmevent[9]};
+      12'h32A: rdata_o = {56'b0, mhpmevent[10]};
       12'h340: rdata_o = mscratch;
       12'h341: rdata_o = mepc;
       12'h342: rdata_o = mcause;
@@ -109,6 +137,15 @@ module kronos_csr #(
       12'hC00, 12'hB00: rdata_o = mcycle;                     // cycle / mcycle
       12'hC01:          rdata_o = mcycle;                     // time (mirror cycle)
       12'hC02, 12'hB02: rdata_o = minstret;                   // instret / minstret
+      // Zihpm counters: M-mode RW (0xB03..0xB0A) and U-mode RO aliases (0xC03..0xC0A)
+      12'hB03, 12'hC03: rdata_o = mhpmcounter[3];
+      12'hB04, 12'hC04: rdata_o = mhpmcounter[4];
+      12'hB05, 12'hC05: rdata_o = mhpmcounter[5];
+      12'hB06, 12'hC06: rdata_o = mhpmcounter[6];
+      12'hB07, 12'hC07: rdata_o = mhpmcounter[7];
+      12'hB08, 12'hC08: rdata_o = mhpmcounter[8];
+      12'hB09, 12'hC09: rdata_o = mhpmcounter[9];
+      12'hB0A, 12'hC0A: rdata_o = mhpmcounter[10];
       default: rdata_o = 64'hDEAD_C5A0_DEAD_C5A0; // unimplemented CSR
     endcase
   end
@@ -144,11 +181,30 @@ module kronos_csr #(
       fcsr_q   <= 8'h00;
       mcycle   <= {64{1'b0}};
       minstret <= {64{1'b0}};
+      mcountinhibit <= '0;
+      for (int i = 3; i <= 10; i++) begin
+        mhpmcounter[i] <= '0;
+        mhpmevent[i]   <= '0;
+      end
     end else begin
-      // Zicntr counters
-      mcycle   <= mcycle + 64'd1;
-      if (instret_retire_i) minstret <= minstret + 64'd1;
-      // Trap entry (highest priority)
+      // ---- Default: counters tick (gated by mcountinhibit) ----
+      // mcycle (gated by mcountinhibit[0]; SW write takes priority)
+      if (~mcountinhibit[0] & ~(req_i & (addr_i == 12'hB00))) mcycle <= mcycle + 64'd1;
+      // minstret (gated by mcountinhibit[2] and qualified by retire; SW write takes priority)
+      if (~mcountinhibit[2] & instret_retire_i & ~(req_i & (addr_i == 12'hB02)))
+        minstret <= minstret + 64'd1;
+      // mhpmcounterX: increment when event-mux selects the asserted bus line
+      // and counter is not inhibited.  Out-of-range event IDs (>= 16) result
+      // in no increment.  A same-cycle SW write to THIS counter takes priority;
+      // accesses to any other CSR address must not suppress the tick.
+      for (int i = 3; i <= 10; i++) begin
+        if (~mcountinhibit[i] & (mhpmevent[i] < 8'd16)
+                              & event_bus_i[mhpmevent[i][3:0]]
+                              & ~(req_i & (addr_i == 12'(12'hB00 + i))))
+          mhpmcounter[i] <= mhpmcounter[i] + 64'd1;
+      end
+
+      // Trap entry (highest priority for non-counter state)
       if (trap_i) begin
         mepc       <= {32'b0, trap_pc_i};
         mcause     <= {32'b0, trap_cause_i};
@@ -160,26 +216,44 @@ module kronos_csr #(
         mstatus[3] <= mstatus[7]; // MIE = MPIE
         mstatus[7] <= 1'b1;       // MPIE = 1
       end
-      // CSR write
+      // CSR write (overrides default counter tick on the same cycle)
       if (req_i) begin
         unique case (addr_i)
           12'h001: fcsr_q[4:0] <= csr_new_val[4:0];
           12'h002: fcsr_q[7:5] <= csr_new_val[2:0];
           12'h003: fcsr_q      <= csr_new_val[7:0];
-          12'h300: mstatus  <= csr_new_val & 64'h7FFF_FFFF_FFFF_FFFF; // bit63 SD is read-only
+          12'h300: mstatus  <= csr_new_val & 64'h7FFF_FFFF_FFFF_FFFF;
           12'h304: mie      <= csr_new_val;
           12'h305: mtvec    <= csr_new_val;
+          12'h320: mcountinhibit <= csr_new_val[10:0];
+          12'h323: mhpmevent[3]  <= csr_new_val[7:0];
+          12'h324: mhpmevent[4]  <= csr_new_val[7:0];
+          12'h325: mhpmevent[5]  <= csr_new_val[7:0];
+          12'h326: mhpmevent[6]  <= csr_new_val[7:0];
+          12'h327: mhpmevent[7]  <= csr_new_val[7:0];
+          12'h328: mhpmevent[8]  <= csr_new_val[7:0];
+          12'h329: mhpmevent[9]  <= csr_new_val[7:0];
+          12'h32A: mhpmevent[10] <= csr_new_val[7:0];
           12'h340: mscratch <= csr_new_val;
           12'h341: mepc     <= csr_new_val;
           12'h342: mcause   <= csr_new_val;
+          // Counter writes — SW-write-wins precedence over default increment
+          12'hB00: mcycle        <= csr_new_val;
+          12'hB02: minstret      <= csr_new_val;
+          12'hB03: mhpmcounter[3]  <= csr_new_val;
+          12'hB04: mhpmcounter[4]  <= csr_new_val;
+          12'hB05: mhpmcounter[5]  <= csr_new_val;
+          12'hB06: mhpmcounter[6]  <= csr_new_val;
+          12'hB07: mhpmcounter[7]  <= csr_new_val;
+          12'hB08: mhpmcounter[8]  <= csr_new_val;
+          12'hB09: mhpmcounter[9]  <= csr_new_val;
+          12'hB0A: mhpmcounter[10] <= csr_new_val;
           default: ; // read-only or unimplemented: ignore write
         endcase
       end
       // Sticky FFLAGS accumulation from FPU writeback (OR on top of CSR writes)
       if (fflags_we_i) fcsr_q[4:0] <= fcsr_q[4:0] | fflags_delta_i;
       // mstatus.FS becomes Dirty (11) on any FP register or fcsr write.
-      // Placed after the CSR-write case so HW-set wins over a same-cycle SW
-      // write that would otherwise leave FS at a non-Dirty value.
       if (fp_rd_we_i || fflags_we_i || fp_csr_sw_write) begin
         mstatus[14:13] <= 2'b11;
       end

--- a/rtl/stage5/kronos_top.sv
+++ b/rtl/stage5/kronos_top.sv
@@ -182,6 +182,12 @@ module kronos_top
   logic        fpu_stall;
   logic        fpu_dispatching;  // combinational: dispatch will fire this cycle
 
+  // ---- Stage 5c performance-counter event bus ----
+  logic        bpred_mispredict_pulse;
+  logic        fpu_busy_any;
+  logic        trap_taken_pulse;
+  logic [15:0] event_bus;
+
   // FPU result latch: captures fpu_result when fpu_out_valid fires so the
   // result survives instr_fetch_stall cycles that may hold combined_stall=1
   // even after fpu_stall drops to 0.
@@ -397,7 +403,8 @@ module kronos_top
     // Zicntr: pulse once per retired instruction.  Count at the EX→MEM
     // transition so the count is visible to a csrrc-instret two instructions
     // later (matches the SAIL reference-model semantics used by ACT4).
-    .instret_retire_i (ex_mem_en & id_ex_q.valid & ~combined_stall)
+    .instret_retire_i (ex_mem_en & id_ex_q.valid & ~combined_stall),
+    .event_bus_i      (event_bus)
   );
 
   // STAGE4: 64-bit LSU with AXI4 interface and A-extension stubs.
@@ -991,6 +998,40 @@ module kronos_top
   // =========================================================================
   logic retire_advance;
   assign retire_advance = mem_wb_q.valid & ~combined_stall;
+
+  // ---- Performance-counter event bus ----------------------------------------
+  // Single-cycle pulses for retire-tagged events; level signals for stall events.
+  // Bus indices match mhpmeventX[7:0] event IDs:
+  //   0x00 reserved-zero, 0x01 branch retired, 0x02 branch mispredict,
+  //   0x03 load retired,  0x04 store retired, 0x05 mem stall,
+  //   0x06 muldiv busy,    0x07 fpu busy,      0x08 trap taken.
+  // 0x09..0x0F currently tied to 0; 0x10..0x1F reserved for future caches/OOO.
+
+  // Mispredict pulse: combine the EX-stage branch mispredict and the MEM-stage
+  // JALR target-mispredict, gated by ~combined_stall so a stalled cycle is not
+  // counted twice.
+  assign bpred_mispredict_pulse =
+      (bpred_mispredict | bpred_mispredict_target) & ~combined_stall;
+
+  // FPU busy: the FPU top exposes its own OR-reduced busy line via fpu_busy.
+  assign fpu_busy_any = fpu_busy;
+
+  // Trap-taken pulse: re-derive the same expression we feed to u_csr.trap_i.
+  // (This is the canonical "trap entry will fire this cycle" condition.)
+  assign trap_taken_pulse = id_ex_q.valid & ~combined_stall &
+                            (id_ex_q.dec.illegal | id_ex_q.dec.is_ecall |
+                             id_ex_q.dec.is_ebreak | irq_pending);
+
+  assign event_bus[ 0]    = 1'b0;
+  assign event_bus[ 1]    = retire_advance & mem_wb_q.dec.is_branch;
+  assign event_bus[ 2]    = bpred_mispredict_pulse;
+  assign event_bus[ 3]    = retire_advance & mem_wb_q.dec.is_load;
+  assign event_bus[ 4]    = retire_advance & mem_wb_q.dec.is_store;
+  assign event_bus[ 5]    = mem_stall;
+  assign event_bus[ 6]    = muldiv_stall;
+  assign event_bus[ 7]    = fpu_busy_any;
+  assign event_bus[ 8]    = trap_taken_pulse;
+  assign event_bus[15:9]  = '0;
 
   assign retire_valid_o      = retire_advance;
   assign retire_pc_o         = {32'b0, mem_wb_q.pc};

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -107,13 +107,13 @@ SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
         build-s5 run-s5-% run-s5b-% sim-s5 sim-core-fp-basic sim-core-fp-forwarding \
         gen-arch-tests-s1 sim-arch-test-s1 gen-arch-tests-s2 sim-arch-test-s2 gen-arch-tests-s3 sim-arch-test-s3 gen-arch-tests-s4 sim-arch-test-s4 gen-arch-tests-s5 sim-arch-test-s5 \
         sim-pkg-fp sim-regfile-fp sim-hf-smoke sim-sf-smoke \
-        sim-csr-fp sim-fpu-scoreboard \
+        sim-csr-fp sim-csr-perf-s5 sim-fpu-scoreboard \
         sim-decode-fp sim-fpu-fmisc sim-fpu-fcvt sim-fpu-fadd sim-fpu-fmul \
         sim-fpu-fma sim-fpu-fdiv-core sim-fpu-fsqrt-core sim-fpu-iter-skeleton sim-fpu-top \
         sim-fpu-top-iter \
         sim-fpu-fmisc-cov sim-fpu-fcvt-cov sim-fpu-fadd-cov sim-fpu-fmul-cov \
         sim-fpu-fma-cov coverage \
-        sim-alu-s5-cov sim-muldiv-s5-cov sim-decode-s5-cov sim-lsu-s5-cov \
+        sim-alu-s5-cov sim-muldiv-s5-cov sim-decode-s5-cov sim-lsu-s5-cov sim-csr-perf-s5-cov \
         sim-decode-fp-cov sim-lsu-fp-cov \
         sim-s5b \
         sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-lsu-s5 sim-group-s5-int \
@@ -536,7 +536,7 @@ SIM_UNITS := sim-alu sim-regfile sim-decode \
              sim-fpu-fdiv-core sim-fpu-fsqrt-core sim-fpu-fcvt \
              sim-fpu-fadd sim-fpu-fmul sim-fpu-fma sim-fpu-fmisc \
              sim-fpu-iter sim-fpu-top sim-fpu-top-iter \
-             sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-lsu-s5
+             sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-lsu-s5 sim-csr-perf-s5
 
 # ── CI test groups ────────────────────────────────────────────────────────────
 # Run as: make -j$(nproc) sim-group-<name>
@@ -557,7 +557,7 @@ SIM_GROUP_FP_UNIT := sim-pkg-fp sim-hf-smoke sim-sf-smoke \
 
 SIM_GROUP_FP_TOP  := sim-fpu-iter sim-fpu-top sim-fpu-top-iter sim-s5
 
-SIM_GROUP_S5_INT  := sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-lsu-s5
+SIM_GROUP_S5_INT  := sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-lsu-s5 sim-csr-perf-s5
 
 $(OBJ_DIR):
 	mkdir -p $@
@@ -846,6 +846,14 @@ sim-csr-fp:
 	$(VERILATOR) $(WAIVER) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Mdir $(OBJ_DIR)/csr_fp \
 	  --top-module tb_csr_fp $(TB_CSR_FP_FILES)
 	$(OBJ_DIR)/csr_fp/Vtb_csr_fp
+
+TB_CSR_PERF_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
+                     $(RTL_DIR)/stage5/kronos_csr.sv \
+                     $(TB_DIR)/stage5/tb_csr_perf.sv
+sim-csr-perf-s5:
+	$(VERILATOR) $(WAIVER) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Mdir $(OBJ_DIR)/csr_perf -Wno-UNUSED \
+	  --top-module tb_csr_perf $(TB_CSR_PERF_FILES)
+	$(OBJ_DIR)/csr_perf/Vtb_csr_perf
 
 TB_FPU_SB_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
                    $(RTL_DIR)/stage5/fpu/kronos_fpu_scoreboard.sv \
@@ -1144,9 +1152,23 @@ sim-lsu-s5-cov:
 	$(OBJ_DIR)/lsu_s5_cov/Vtb_lsu_s5 \
 	  +verilator+coverage+file+$(OBJ_DIR)/lsu_s5_cov/coverage.dat
 
+sim-csr-perf-s5-cov:
+	$(VERILATOR) $(WAIVER) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-UNUSED \
+	  $(COV_FLAGS) -Mdir $(OBJ_DIR)/csr_perf_cov \
+	  --top-module tb_csr_perf $(TB_CSR_PERF_FILES)
+	$(OBJ_DIR)/csr_perf_cov/Vtb_csr_perf \
+	  +verilator+coverage+file+$(OBJ_DIR)/csr_perf_cov/coverage.dat
+
+sim-csr-fp-cov:
+	$(VERILATOR) $(WAIVER) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-UNUSED \
+	  $(COV_FLAGS) -Mdir $(OBJ_DIR)/csr_fp_cov \
+	  --top-module tb_csr_fp $(TB_CSR_FP_FILES)
+	$(OBJ_DIR)/csr_fp_cov/Vtb_csr_fp \
+	  +verilator+coverage+file+$(OBJ_DIR)/csr_fp_cov/coverage.dat
+
 coverage: sim-fpu-fmisc-cov sim-fpu-fcvt-cov sim-fpu-fadd-cov sim-fpu-fmul-cov sim-fpu-fma-cov \
-          sim-alu-s5-cov sim-muldiv-s5-cov sim-decode-s5-cov sim-lsu-s5-cov \
-          sim-decode-fp-cov sim-lsu-fp-cov
+          sim-alu-s5-cov sim-muldiv-s5-cov sim-decode-s5-cov sim-lsu-s5-cov sim-csr-perf-s5-cov \
+          sim-csr-fp-cov sim-decode-fp-cov sim-lsu-fp-cov
 	mkdir -p $(COV_DIR)
 	verilator_coverage --write-info $(COV_DIR)/merged.info \
 	  $(OBJ_DIR)/fpu_fmisc_cov/coverage.dat \
@@ -1158,6 +1180,8 @@ coverage: sim-fpu-fmisc-cov sim-fpu-fcvt-cov sim-fpu-fadd-cov sim-fpu-fmul-cov s
 	  $(OBJ_DIR)/muldiv_s5_cov/coverage.dat \
 	  $(OBJ_DIR)/decode_s5_cov/coverage.dat \
 	  $(OBJ_DIR)/lsu_s5_cov/coverage.dat \
+	  $(OBJ_DIR)/csr_perf_cov/coverage.dat \
+	  $(OBJ_DIR)/csr_fp_cov/coverage.dat \
 	  $(OBJ_DIR)/decode_fp_cov/coverage.dat \
 	  $(OBJ_DIR)/lsu_fp_cov/coverage.dat
 	python3 ../tools/coverage_gate.py $(COV_DIR)/merged.info 100

--- a/sw/stage5/Makefile
+++ b/sw/stage5/Makefile
@@ -7,7 +7,7 @@ ARCH   := rv64imafdc_zicsr
 ABI    := lp64
 CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
 
-TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect test_blt64 test_blt_act4 test_mret_rvc test_csr_warl test_illegal_insn
+TESTS  := test_fp_basic test_fp_loadstore test_fp_nan_box test_fp_rounding test_fp_csr test_fp_convert test_fp_compare test_rvc_fp_loadstore test_fcvt_sd_subnormal test_mstatus_fs_dirty test_muldiv_redirect test_blt64 test_blt_act4 test_mret_rvc test_csr_warl test_illegal_insn test_perf_counters
 
 BUILD_DIR := build
 

--- a/sw/stage5/test_perf_counters.S
+++ b/sw/stage5/test_perf_counters.S
@@ -1,0 +1,129 @@
+# test_perf_counters.S — Stage 5c performance counters end-to-end test
+#
+# Validates Zicntr (mcycle/minstret writability) and partial Zihpm
+# (mhpmcounter3..10 + mhpmevent3..10 + mcountinhibit).
+#
+# Layout:
+#   1. mcycle SW-write
+#   2. minstret SW-write
+#   3. mhpmcounter3 counts branches
+#   4. mhpmcounter4 counts loads
+#   5. mcountinhibit freezes everything
+#   6. Out-of-range event ID is inert
+#
+# x10 (a0) = failure count (0 = pass).
+
+.equ CSR_MCOUNTINHIBIT, 0x320
+.equ CSR_MHPMEVENT3,    0x323
+.equ CSR_MHPMEVENT4,    0x324
+.equ CSR_MHPMEVENT5,    0x325
+.equ CSR_MCYCLE,        0xB00
+.equ CSR_MINSTRET,      0xB02
+.equ CSR_MHPMCOUNTER3,  0xB03
+.equ CSR_MHPMCOUNTER4,  0xB04
+.equ CSR_MHPMCOUNTER5,  0xB05
+
+.equ EVT_BRANCH_RETIRE, 0x01
+.equ EVT_LOAD_RETIRE,   0x03
+.equ EVT_RESERVED_HI,   0x10        # out-of-range (>= 16)
+
+.section .text
+.global main
+main:
+    li      a0, 0                   # fail counter
+
+    # Make sure no counter is inhibited.
+    csrw    CSR_MCOUNTINHIBIT, zero
+
+    # ---- 1. mcycle SW-write takes effect ----
+    csrw    CSR_MCYCLE, zero
+    csrr    t0, CSR_MCYCLE
+    li      t1, 1000                # mcycle should be much smaller than 1000
+    bltu    t0, t1, 1f
+    addi    a0, a0, 1
+1:
+
+    # ---- 2. minstret SW-write takes effect ----
+    csrw    CSR_MINSTRET, zero
+    csrr    t0, CSR_MINSTRET
+    li      t1, 100
+    bltu    t0, t1, 2f
+    addi    a0, a0, 1
+2:
+
+    # ---- 3. mhpmcounter3 counts conditional branches ----
+    li      t0, EVT_BRANCH_RETIRE
+    csrw    CSR_MHPMEVENT3, t0
+    csrw    CSR_MHPMCOUNTER3, zero
+    li      t2, 8                   # loop iterations
+    li      t3, 0                   # i = 0
+.Lbloop:
+    addi    t3, t3, 1
+    blt     t3, t2, .Lbloop         # 1 conditional branch per iteration
+    nop                             # drain: let last branch retire before csrr
+    nop
+    csrr    t4, CSR_MHPMCOUNTER3
+    li      t5, 8
+    bgeu    t4, t5, 3f              # >= 8 branches
+    addi    a0, a0, 1
+3:
+
+    # ---- 4. mhpmcounter4 counts loads ----
+    li      t0, EVT_LOAD_RETIRE
+    csrw    CSR_MHPMEVENT4, t0
+    csrw    CSR_MHPMCOUNTER4, zero
+    la      t2, .Ldata
+    ld      t3, 0(t2)
+    ld      t3, 8(t2)
+    ld      t3, 16(t2)
+    ld      t3, 24(t2)
+    nop                             # drain: let last load retire before csrr
+    nop
+    csrr    t4, CSR_MHPMCOUNTER4
+    li      t5, 4
+    bgeu    t4, t5, 4f              # >= 4 loads
+    addi    a0, a0, 1
+4:
+
+    # ---- 5. mcountinhibit freezes counters ----
+    li      t0, 0x7FF               # inhibit ALL 11 counters
+    csrw    CSR_MCOUNTINHIBIT, t0
+    csrr    t1, CSR_MHPMCOUNTER3    # snapshot
+    csrr    t2, CSR_MCYCLE
+    nop
+    nop
+    nop
+    nop
+    csrr    t3, CSR_MHPMCOUNTER3
+    csrr    t4, CSR_MCYCLE
+    bne     t1, t3, .Linh_fail
+    bne     t2, t4, .Linh_fail
+    j       .Linh_ok
+.Linh_fail:
+    addi    a0, a0, 1
+.Linh_ok:
+    csrw    CSR_MCOUNTINHIBIT, zero # release
+
+    # ---- 6. Out-of-range event ID is inert ----
+    li      t0, EVT_RESERVED_HI
+    csrw    CSR_MHPMEVENT5, t0
+    csrw    CSR_MHPMCOUNTER5, zero
+    li      t6, 16
+    li      t5, 0
+.Lrloop:
+    addi    t5, t5, 1
+    blt     t5, t6, .Lrloop
+    csrr    t4, CSR_MHPMCOUNTER5
+    beqz    t4, 6f
+    addi    a0, a0, 1
+6:
+
+    ret
+
+.section .rodata
+.balign 8
+.Ldata:
+    .dword 0xAAAAAAAA00000001
+    .dword 0xAAAAAAAA00000002
+    .dword 0xAAAAAAAA00000003
+    .dword 0xAAAAAAAA00000004

--- a/tb/stage5/tb_csr_fp.sv
+++ b/tb/stage5/tb_csr_fp.sv
@@ -39,6 +39,7 @@ module tb_csr_fp;
     .fflags_delta_i(fflags_delta), .fflags_we_i(fflags_we),
     .fp_rd_we_i(1'b0),
     .instret_retire_i(1'b0),
+    .event_bus_i('0),
     .frm_o(frm)
   );
 

--- a/tb/stage5/tb_csr_perf.sv
+++ b/tb/stage5/tb_csr_perf.sv
@@ -1,0 +1,277 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+// Unit testbench for performance counters in kronos_csr (Stage 5c).
+// Drives the CSR module standalone and verifies Zicntr + partial Zihpm
+// behavior: register read/write, mcountinhibit gating, programmable
+// event-mux increment, and SW-write-vs-event precedence.
+module tb_csr_perf;
+  import kronos_pkg::*;
+
+  logic        clk = 0;
+  logic        rst_n = 0;
+  logic        req;
+  logic [11:0] addr;
+  logic [2:0]  funct3;
+  logic        use_imm;
+  logic [63:0] rs1_data;
+  logic [4:0]  rs1_addr;
+  logic [63:0] rdata;
+  logic        valid;
+  logic        trap = 0, mret = 0;
+  logic [31:0] trap_pc = 0, trap_cause = 0;
+  logic [63:0] trap_vector, mepc_out;
+  logic [4:0]  fflags_delta = '0;
+  logic        fflags_we = 0;
+  logic [2:0]  frm;
+  logic        irq_timer = 0;
+  logic [14:0] irq_fast = '0;
+  logic        irq_pending;
+  logic        instret_retire = 0;
+  logic [15:0] event_bus = '0;
+
+  kronos_csr u_dut (
+    .clk_i(clk), .rst_ni(rst_n),
+    .req_i(req), .addr_i(addr), .funct3_i(funct3), .use_imm_i(use_imm),
+    .rs1_data_i(rs1_data), .rs1_addr_i(rs1_addr),
+    .rdata_o(rdata), .valid_o(valid),
+    .trap_i(trap), .trap_pc_i(trap_pc), .trap_cause_i(trap_cause),
+    .mret_i(mret), .trap_vector_o(trap_vector), .mepc_o(mepc_out),
+    .irq_timer_i(irq_timer), .irq_fast_i(irq_fast), .irq_pending_o(irq_pending),
+    .fflags_delta_i(fflags_delta), .fflags_we_i(fflags_we),
+    .fp_rd_we_i(1'b0),
+    .instret_retire_i(instret_retire),
+    .event_bus_i(event_bus),
+    .frm_o(frm)
+  );
+
+  always #5 clk = ~clk;
+
+  // CSRRW (write rs1_data to addr)
+  task automatic csrrw(input logic [11:0] a, input logic [63:0] d);
+    @(negedge clk); req = 1; addr = a; funct3 = 3'b001; use_imm = 0; rs1_data = d;
+    @(negedge clk); req = 0;
+  endtask
+
+  // CSRRSI rs1=0 (pure read)
+  task automatic csrread(input logic [11:0] a, output logic [63:0] d);
+    @(negedge clk); req = 1; addr = a; funct3 = 3'b010; use_imm = 1; rs1_addr = 0;
+    @(posedge clk) #1; d = rdata;
+    @(negedge clk) req = 0;
+  endtask
+
+  logic [63:0] v;
+  initial begin
+    req = 0; addr = 0; funct3 = 0; use_imm = 0; rs1_data = 0; rs1_addr = 0;
+    #12 rst_n = 1;
+
+    // Smoke check: misa is readable.
+    csrread(12'h301, v);
+    if (v[63:62] !== 2'b10) $fatal(1, "tb_csr_perf: misa MXL: %h", v);
+
+    // ---- Test: SW writes to new CSRs are observable ----
+
+    // mcountinhibit (0x320): write 0x7FF, read back 0x7FF (only bits [10:0]).
+    csrrw(12'h320, 64'h0000_0000_0000_07FF);
+    csrread(12'h320, v);
+    if (v[10:0] !== 11'h7FF || v[63:11] !== 53'b0)
+      $fatal(1, "mcountinhibit: %h", v);
+
+    // mhpmevent3..10: write distinct event IDs, read back.
+    csrrw(12'h323, 64'd3);
+    csrrw(12'h324, 64'd4);
+    csrrw(12'h325, 64'd5);
+    csrrw(12'h326, 64'd6);
+    csrrw(12'h327, 64'd7);
+    csrrw(12'h328, 64'd8);
+    csrrw(12'h329, 64'd9);
+    csrrw(12'h32A, 64'd10);
+    csrread(12'h323, v); if (v[7:0] !== 8'd3)  $fatal(1, "mhpmevent3: %h", v);
+    csrread(12'h324, v); if (v[7:0] !== 8'd4)  $fatal(1, "mhpmevent4: %h", v);
+    csrread(12'h325, v); if (v[7:0] !== 8'd5)  $fatal(1, "mhpmevent5: %h", v);
+    csrread(12'h326, v); if (v[7:0] !== 8'd6)  $fatal(1, "mhpmevent6: %h", v);
+    csrread(12'h327, v); if (v[7:0] !== 8'd7)  $fatal(1, "mhpmevent7: %h", v);
+    csrread(12'h328, v); if (v[7:0] !== 8'd8)  $fatal(1, "mhpmevent8: %h", v);
+    csrread(12'h329, v); if (v[7:0] !== 8'd9)  $fatal(1, "mhpmevent9: %h", v);
+    csrread(12'h32A, v); if (v[7:0] !== 8'd10) $fatal(1, "mhpmevent10: %h", v);
+
+    // mhpmcounter3..10: write distinct values, read back.
+    csrrw(12'hB03, 64'hAAAA_AAAA_0000_0003);
+    csrrw(12'hB04, 64'hAAAA_AAAA_0000_0004);
+    csrrw(12'hB0A, 64'hAAAA_AAAA_0000_000A);
+    csrread(12'hB03, v); if (v !== 64'hAAAA_AAAA_0000_0003) $fatal(1, "mhpmcounter3 RW: %h", v);
+    csrread(12'hB04, v); if (v !== 64'hAAAA_AAAA_0000_0004) $fatal(1, "mhpmcounter4 RW: %h", v);
+    csrread(12'hB0A, v); if (v !== 64'hAAAA_AAAA_0000_000A) $fatal(1, "mhpmcounter10 RW: %h", v);
+    // U-mode alias mirrors the M-mode storage.
+    csrread(12'hC0A, v); if (v !== 64'hAAAA_AAAA_0000_000A) $fatal(1, "hpmcounter10 alias: %h", v);
+
+    // mcycle / minstret are M-mode writable (Zicntr).
+    csrrw(12'hB00, 64'h0);
+    csrread(12'hB00, v);
+    if (v >= 64'd100) $fatal(1, "mcycle SW-write didn't take effect: %h", v);
+
+    csrrw(12'hB02, 64'h0);
+    csrread(12'hB02, v);
+    if (v !== 64'h0) $fatal(1, "minstret SW-write didn't take effect: %h", v);
+
+    // ---- Test: event-mux + counter increment ----
+
+    // Configure: mhpmcounter3 counts event ID 0x05.
+    csrrw(12'h323, 64'h05);                       // mhpmevent3 = 5
+    csrrw(12'hB03, 64'h0);                        // mhpmcounter3 = 0
+    csrrw(12'h320, 64'h0);                        // mcountinhibit = 0 (all running)
+
+    // Pulse event_bus[5] high for 4 negedges; counter should increment 4 times.
+    for (int i = 0; i < 4; i++) begin
+      @(negedge clk); event_bus = 16'h0020;       // bit 5
+    end
+    @(negedge clk); event_bus = 16'h0;
+    csrread(12'hB03, v);
+    if (v !== 64'd4) $fatal(1, "mhpmcounter3 expected 4, got %h", v);
+
+    // ---- Test: mhpmcounterX does NOT increment when its event ID is unselected ----
+    csrrw(12'hB04, 64'h0);
+    csrrw(12'h324, 64'h08);                       // mhpmevent4 = 8 (unselected by bus)
+    @(negedge clk); event_bus = 16'h0020;
+    @(negedge clk); event_bus = 16'h0;
+    csrread(12'hB04, v);
+    if (v !== 64'd0) $fatal(1, "mhpmcounter4 should not have ticked: %h", v);
+
+    // ---- Test: mcountinhibit gates increment ----
+    csrrw(12'h320, 64'h7FF);                      // inhibit ALL counters
+    csrread(12'hB03, v);
+    begin
+      static logic [63:0] before_v = '0;
+      before_v = v;
+      for (int i = 0; i < 8; i++) begin
+        @(negedge clk); event_bus = 16'h0020;
+      end
+      @(negedge clk); event_bus = 16'h0;
+      csrread(12'hB03, v);
+      if (v !== before_v) $fatal(1, "mcountinhibit failed to freeze: %h vs %h", v, before_v);
+    end
+    csrrw(12'h320, 64'h0);
+
+    // ---- Test: SW-write-wins-on-same-cycle precedence ----
+    // Set event_bus and req=1 on the same negedge so they hit the same posedge.
+    csrrw(12'hB03, 64'h0);
+    @(negedge clk);
+    event_bus = 16'h0020;                         // bit 5 asserted
+    req = 1; addr = 12'hB03; funct3 = 3'b001; use_imm = 0;
+    rs1_data = 64'hDEAD_BEEF_DEAD_BEEF;           // CSRRW: write DEAD_BEEF...
+    @(negedge clk); req = 0; event_bus = 16'h0;
+    csrread(12'hB03, v);
+    if (v !== 64'hDEAD_BEEF_DEAD_BEEF)
+      $fatal(1, "SW write should win, got %h", v);
+
+    // ---- Test: out-of-range event ID does not increment ----
+    csrrw(12'h325, 64'h10);                       // mhpmevent5 = 0x10 (>= 16)
+    csrrw(12'hB05, 64'h0);
+    @(negedge clk); event_bus = 16'hFFFF;
+    @(negedge clk); event_bus = 16'h0;
+    csrread(12'hB05, v);
+    if (v !== 64'd0) $fatal(1, "out-of-range event ID should be inert: %h", v);
+
+    // ---- Test: mcycle stops when mcountinhibit[0] set ----
+    csrrw(12'h320, 64'h001);                      // inhibit only mcycle
+    csrread(12'hB00, v);
+    begin
+      static logic [63:0] before_v = '0;
+      before_v = v;
+      repeat (5) @(posedge clk);
+      csrread(12'hB00, v);
+      if (v !== before_v)
+        $fatal(1, "mcycle should be frozen by mcountinhibit[0]: %h vs %h", v, before_v);
+    end
+    csrrw(12'h320, 64'h0);
+
+    // ---- Test: minstret ticks only when instret_retire fires and bit 2 clear ----
+    csrrw(12'hB02, 64'h0);                        // minstret = 0
+    @(negedge clk); instret_retire = 1;
+    @(negedge clk); instret_retire = 0;
+    @(negedge clk); instret_retire = 1;
+    @(negedge clk); instret_retire = 0;
+    csrread(12'hB02, v);
+    if (v !== 64'd2) $fatal(1, "minstret expected 2, got %h", v);
+
+    // ---- Test: CSR access to an UNRELATED address must not suppress counter tick ----
+    csrrw(12'h323, 64'h05);                       // mhpmevent3 = 5
+    csrrw(12'hB03, 64'h0);                        // mhpmcounter3 = 0
+    csrrw(12'h320, 64'h0);                        // mcountinhibit = 0
+    // Drive event_bus[5] high while doing a CSR read of mstatus (unrelated addr).
+    @(negedge clk); event_bus = 16'h0020; req = 1; addr = 12'h300;
+                    funct3 = 3'b010; use_imm = 1; rs1_addr = 0;
+    @(negedge clk); event_bus = 16'h0; req = 0;
+    csrread(12'hB03, v);
+    if (v === 64'd0)
+      $fatal(1, "unrelated CSR access suppressed counter tick: %h", v);
+
+    // ---- Test: CSRRC clears bits ----
+    // Use mscratch (a plain RW CSR) to avoid side-effects.
+    csrrw(12'h340, 64'hFFFF_FFFF_FFFF_FFFF);      // mscratch = all ones
+    @(negedge clk); req = 1; addr = 12'h340; funct3 = 3'b011; use_imm = 0;
+                    rs1_data = 64'h0000_0000_FFFF_FFFF;
+    @(negedge clk); req = 0;
+    csrread(12'h340, v);
+    if (v !== 64'hFFFF_FFFF_0000_0000) $fatal(1, "CSRRC mscratch: %h", v);
+
+    // ---- Test: trap_i body executes ----
+    // Drive trap with a known PC and cause; verify mepc/mcause/mstatus updates.
+    csrrw(12'h300, 64'h0000_0000_0000_3888);      // mstatus: MIE=1, MPP=11, FS=01
+    @(negedge clk); trap = 1; trap_pc = 32'h0000_1000; trap_cause = 32'd2;
+    @(negedge clk); trap = 0;
+    csrread(12'h341, v);
+    if (v !== 64'h0000_0000_0000_1000) $fatal(1, "trap mepc: %h", v);
+    csrread(12'h342, v);
+    if (v[31:0] !== 32'd2) $fatal(1, "trap mcause: %h", v);
+    csrread(12'h300, v);
+    if (v[3] !== 1'b0) $fatal(1, "trap mstatus.MIE not cleared: %h", v);
+    if (v[7] !== 1'b1) $fatal(1, "trap mstatus.MPIE not set from MIE: %h", v);
+
+    // ---- Test: mret_i body restores interrupt state ----
+    @(negedge clk); mret = 1;
+    @(negedge clk); mret = 0;
+    csrread(12'h300, v);
+    if (v[3] !== 1'b1) $fatal(1, "mret mstatus.MIE not restored: %h", v);
+    if (v[7] !== 1'b1) $fatal(1, "mret mstatus.MPIE not set: %h", v);
+
+    // ---- Test: read all M-mode CSRs (covers read decoder branches) ----
+    csrread(12'h304, v);                          // mie
+    csrread(12'h305, v);                          // mtvec
+    csrread(12'h344, v);                          // mip
+    csrread(12'hC01, v);                          // time alias
+
+    // ---- Test: write all M-mode CSRs (covers write decoder branches) ----
+    csrrw(12'h001, 64'h0);                        // FFLAGS — also marks FS Dirty
+    csrrw(12'h002, 64'h0);                        // FRM — also marks FS Dirty
+    csrrw(12'h003, 64'h0);                        // FCSR — also marks FS Dirty
+    csrrw(12'h300, 64'h0000_0000_0000_3888);      // mstatus
+    csrrw(12'h304, 64'hDEAD_BEEF_DEAD_BEEF);      // mie
+    csrrw(12'h305, 64'hCAFE_BABE_CAFE_BABE);      // mtvec
+    csrrw(12'h340, 64'hAA);                       // mscratch
+    csrrw(12'h341, 64'hBB);                       // mepc
+    csrrw(12'h342, 64'hCC);                       // mcause
+
+    // ---- Test: read mhpmcounter6,7,8,9 (covers remaining counter slots) ----
+    csrread(12'hB06, v);
+    csrread(12'hB07, v);
+    csrread(12'hB08, v);
+    csrread(12'hB09, v);
+
+    // ---- Test: write mhpmcounter6,7,8,9 ----
+    csrrw(12'hB06, 64'h6);
+    csrrw(12'hB07, 64'h7);
+    csrrw(12'hB08, 64'h8);
+    csrrw(12'hB09, 64'h9);
+    csrread(12'hB06, v); if (v !== 64'h6) $fatal(1, "mhpmcounter6 RW: %h", v);
+    csrread(12'hB07, v); if (v !== 64'h7) $fatal(1, "mhpmcounter7 RW: %h", v);
+    csrread(12'hB08, v); if (v !== 64'h8) $fatal(1, "mhpmcounter8 RW: %h", v);
+    csrread(12'hB09, v); if (v !== 64'h9) $fatal(1, "mhpmcounter9 RW: %h", v);
+
+    $display("tb_csr_perf PASS");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

- Adds Zicntr-compliant `mcycle` / `minstret` (now M-mode writable) plus `mcountinhibit` (CSR 0x320).
- Adds 8 programmable event counters `mhpmcounter3..10` paired with `mhpmevent3..10`. Event IDs 0x01–0x08 wired now (branch retired, branch mispredict, load retired, store retired, mem stall, muldiv busy, FPU busy, trap taken); 0x10–0x1F reserved for cache/MMU/OOO events.
- Stage 5 only — older stages do not instantiate this CSR variant.
- Pipeline-visibility delay (CSR-read in EX vs. event-tick in WB) is documented in `docs/architecture.md`; the asm test inserts NOPs for slack, matching the standard RISC-V perf-counter semantic.

## Test plan

- [x] `make sim-all` — 38/38 unit TBs PASS
- [x] `make sim-arch-test-s5` — 303/303
- [x] `make coverage` — gate passes at **100%** (3436/3436); newly includes both `csr_perf_cov` and `csr_fp_cov`
- [x] `fusesoc --target=lint` — no warnings on `kronos_*` files
- [x] `make run-s5-test_perf_counters` — `a0 = 0`
- [x] `make sim-csr-perf-s5` — `tb_csr_perf PASS`