### PR TITLE
feat(stage6d): RAM wrapper infrastructure (no integration yet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Development follows a staged learning progression:
 | 6a    | Privileged modes (M/S/U) + trap delegation + PMP | RV64IMAFDC      | AXI4 | Complete |
 | 6b    | Sv39/Sv48 MMU + iTLB/dTLB + HW PTW + sfence.vma | RV64IMAFDC       | AXI4 | Complete |
 | 6c    | Closeout: dhrystone perf gate, integration program, mstatus reset, GLS-s6 docs | RV64IMAFDC | AXI4 | Complete |
+| 6d    | RAM wrapper infrastructure (`kronos_ram` SDP, FPGA `xpm` + ASIC stub) | RV64IMAFDC | AXI4 | Complete |
 | 7     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4 | Planned  |
 
 All five completed stages pass the full `riscv-arch-test` (ACT4) compliance

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 6a    | Privileged modes (M/S/U) + trap delegation + PMP | RV64IMAFDC      | AXI4    | Complete    |
 | 6b    | Sv39/Sv48 MMU + iTLB/dTLB + HW PTW + sfence.vma | RV64IMAFDC       | AXI4    | Complete    |
 | 6c    | Closeout: dhrystone perf gate, integration program, mstatus reset, GLS-s6 docs | RV64IMAFDC | AXI4 | Complete |
+| 6d    | RAM wrapper infrastructure (`kronos_ram` SDP, FPGA `xpm` + ASIC stub) | RV64IMAFDC | AXI4 | Complete |
 | 7     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # kronos-riscv Architecture Reference
 
-**ISA:** RV64IMAFDC &nbsp;|&nbsp; **Microarchitecture:** 5-stage in-order pipeline &nbsp;|&nbsp; **Bus:** AXI4 &nbsp;|&nbsp; **Branch prediction:** bimodal (64-entry PHT + 16-entry BTB) &nbsp;|&nbsp; **Active stage:** Stage 6c
+**ISA:** RV64IMAFDC &nbsp;|&nbsp; **Microarchitecture:** 5-stage in-order pipeline &nbsp;|&nbsp; **Bus:** AXI4 &nbsp;|&nbsp; **Branch prediction:** bimodal (64-entry PHT + 16-entry BTB) &nbsp;|&nbsp; **Active stage:** Stage 6d
 
 kronos-riscv is a 5-stage in-order RISC-V processor implementing the RV64IMAFDC ISA. Instructions flow through Instruction Fetch (IF), Instruction Decode (ID), Execute (EX), Memory (MEM), and Writeback (WB). The IF stage includes an alignment unit that handles variable-width compressed instructions and a bimodal branch predictor that speculatively redirects fetch before branch resolution. The EX stage contains the 64-bit ALU, a multi-cycle 64-bit multiply/divide unit, branch resolution logic, and the CSR unit. The MEM stage drives an AXI4 load/store unit supporting atomic operations (LR/SC, AMO) and floating-point loads/stores. A separate FPU with six pipelined units handles the F and D extensions; the FPU uses a scoreboard rather than the integer forwarding network for hazard management. Hazard and forwarding control modules sit outside the pipeline stages and manage stalls, flushes, and operand forwarding.
 

--- a/fpga/gls/synth_ooc.tcl
+++ b/fpga/gls/synth_ooc.tcl
@@ -135,6 +135,11 @@ set_property file_type SystemVerilog [get_files $RTL_FILES]
 set_property include_dirs $AXI_INC_DIRS [current_fileset]
 set_property top $TOP [current_fileset]
 
+# Stage 6d — select the XPM (RAMB) backend in rtl/common/kronos_ram.sv so
+# Vivado infers BRAMs deterministically for GLS. The Verilator/ASIC sim path
+# leaves this define unset and uses the behavioural SDP backend.
+set_property verilog_define {KRONOS_RAM_FPGA=1} [current_fileset]
+
 puts "=========================================="
 puts " Synthesising $TOP (out_of_context, MODE=$MODE)"
 puts "=========================================="

--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -152,6 +152,7 @@ targets:
         synth_options: [-flatten_hierarchy, rebuilt]
     parameters:
       - SYNTH_FREQ_MHZ
+      - KRONOS_RAM_FPGA
 
 parameters:
   SYNTH_FREQ_MHZ:
@@ -159,3 +160,9 @@ parameters:
     default: 200
     description: "Target clock frequency in MHz — sets PS PL0 clock and create_clock period in synth.tcl"
     paramtype: generic
+
+  KRONOS_RAM_FPGA:
+    datatype: bool
+    default: true
+    description: "Select XPM SDP RAM backend in rtl/common/kronos_ram.sv (Vivado-only). Verilator targets leave this unset and use the ASIC behavioural stub."
+    paramtype: vlogdefine

--- a/rtl/common/kronos_ram.sv
+++ b/rtl/common/kronos_ram.sv
@@ -1,0 +1,119 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// kronos_ram — Parameterised SDP RAM with 1-cycle registered read.
+//
+// Two backends behind `KRONOS_RAM_FPGA`:
+//   - FPGA: xpm_memory_sdpram (Xilinx Parameterized Macros). Vivado infers
+//     RAMB36E1/RAMB18E1 deterministically.
+//   - ASIC / Verilator default: behavioural SDP. Synthesises as FFs on tools
+//     without XPM. Functionally identical (same 1-cycle read, same byte-write
+//     semantics).
+//
+// No reset on the data array — the consumer's external valid_q is the source
+// of truth for "is this address readable". Same-cycle write+read collision
+// behaviour is undefined; consumers must serialise via FSM.
+
+module kronos_ram
+#(
+  parameter int unsigned DEPTH      = 64,
+  parameter int unsigned WIDTH      = 64,
+  parameter int unsigned BYTE_WIDTH = 8
+) (
+  input  logic                                clk_i,
+
+  // Port A — write
+  input  logic                                we_i,
+  input  logic [$clog2(DEPTH)-1:0]            waddr_i,
+  input  logic [WIDTH-1:0]                    wdata_i,
+  input  logic [(WIDTH/BYTE_WIDTH)-1:0]       wmask_i,
+
+  // Port B — read (1-cycle registered)
+  input  logic                                re_i,
+  input  logic [$clog2(DEPTH)-1:0]            raddr_i,
+  output logic [WIDTH-1:0]                    rdata_o
+);
+
+  localparam int unsigned ADDR_W = $clog2(DEPTH);
+  localparam int unsigned NB     = WIDTH / BYTE_WIDTH;
+
+`ifdef KRONOS_RAM_FPGA
+  // ----------------------------------------------------------------------
+  // FPGA backend — xpm_memory_sdpram
+  // ----------------------------------------------------------------------
+  xpm_memory_sdpram #(
+    .ADDR_WIDTH_A         (ADDR_W),
+    .ADDR_WIDTH_B         (ADDR_W),
+    .AUTO_SLEEP_TIME      (0),
+    .BYTE_WRITE_WIDTH_A   (BYTE_WIDTH),
+    .CASCADE_HEIGHT       (0),
+    .CLOCKING_MODE        ("common_clock"),
+    .ECC_MODE             ("no_ecc"),
+    .MEMORY_INIT_FILE     ("none"),
+    .MEMORY_INIT_PARAM    ("0"),
+    .MEMORY_OPTIMIZATION  ("true"),
+    .MEMORY_PRIMITIVE     ("block"),
+    .MEMORY_SIZE          (DEPTH * WIDTH),
+    .MESSAGE_CONTROL      (0),
+    .READ_DATA_WIDTH_B    (WIDTH),
+    .READ_LATENCY_B       (1),
+    .READ_RESET_VALUE_B   ("0"),
+    .RST_MODE_A           ("SYNC"),
+    .RST_MODE_B           ("SYNC"),
+    .SIM_ASSERT_CHK       (0),
+    .USE_EMBEDDED_CONSTRAINT(0),
+    .USE_MEM_INIT         (1),
+    .USE_MEM_INIT_MMI     (0),
+    .WAKEUP_TIME          ("disable_sleep"),
+    .WRITE_DATA_WIDTH_A   (WIDTH),
+    .WRITE_MODE_B         ("no_change"),
+    .WRITE_PROTECT        (1)
+  ) u_xpm (
+    .dbiterrb     (),
+    .doutb        (rdata_o),
+    .sbiterrb     (),
+    .addra        (waddr_i),
+    .addrb        (raddr_i),
+    .clka         (clk_i),
+    .clkb         (clk_i),
+    .dina         (wdata_i),
+    .ena          (we_i),
+    .enb          (re_i),
+    .injectdbiterra(1'b0),
+    .injectsbiterra(1'b0),
+    .regceb       (1'b1),
+    .rstb         (1'b0),
+    .sleep        (1'b0),
+    .wea          (wmask_i)
+  );
+
+`else
+  // ----------------------------------------------------------------------
+  // ASIC / Verilator default — behavioural SDP
+  //
+  // TODO: replace with vendor SRAM compiler macro (e.g., sram_64x4096_1r1w)
+  // for ASIC tape-out. Behavioural model exists for build-survival only.
+  // ----------------------------------------------------------------------
+  logic [WIDTH-1:0] mem [DEPTH];
+  logic [WIDTH-1:0] rdata_q;
+
+  always_ff @(posedge clk_i) begin
+    if (we_i) begin
+      for (int unsigned i = 0; i < NB; i++) begin
+        if (wmask_i[i])
+          mem[waddr_i][i*BYTE_WIDTH +: BYTE_WIDTH] <=
+            wdata_i[i*BYTE_WIDTH +: BYTE_WIDTH];
+      end
+    end
+  end
+
+  always_ff @(posedge clk_i) begin
+    if (re_i) rdata_q <= mem[raddr_i];
+  end
+
+  assign rdata_o = rdata_q;
+
+`endif
+
+endmodule

--- a/rtl/filelist_s5.f
+++ b/rtl/filelist_s5.f
@@ -6,6 +6,7 @@
 # Paths are relative to this file's directory (rtl/).
 
 kronos_pkg.sv
+common/kronos_ram.sv
 stage0/kronos_regfile.sv
 stage1/kronos_forward.sv
 stage1/kronos_hazard.sv

--- a/rtl/filelist_s6.f
+++ b/rtl/filelist_s6.f
@@ -6,6 +6,7 @@
 # Paths are relative to this file's directory (rtl/).
 
 kronos_pkg.sv
+common/kronos_ram.sv
 stage0/kronos_regfile.sv
 stage1/kronos_forward.sv
 stage1/kronos_hazard.sv

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,4 +1,5 @@
-RTL_DIR   := ../rtl
+RTL_DIR        := ../rtl
+RTL_DIR_COMMON := $(RTL_DIR)/common
 TB_DIR    := ../tb
 SW_DIR    := ../sw/stage0
 SW_DIR_S1 := ../sw/stage1
@@ -745,7 +746,8 @@ SIM_GROUP_FP_TOP  := sim-fpu-iter sim-fpu-top sim-fpu-top-iter sim-s5
 
 SIM_GROUP_S5_INT  := sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-csr-perf-s5 sim-trigger
 
-SIM_GROUP_S6_INT  := sim-alu-s6 sim-muldiv-s6 sim-decode-s6 sim-priv-csr sim-pmp sim-tlb sim-ptw
+SIM_GROUP_S6_INT  := sim-alu-s6 sim-muldiv-s6 sim-decode-s6 sim-priv-csr sim-pmp sim-tlb sim-ptw \
+                     sim-kronos-ram
 
 $(OBJ_DIR):
 	mkdir -p $@
@@ -805,6 +807,7 @@ sim-all: $(SF_LIB)
 # -------------------- Stage 5 (F + D floating point) --------------------
 SV_FILES_S5 := $(AXI_PKG_SV) \
                $(RTL_DIR)/kronos_pkg.sv \
+               $(RTL_DIR_COMMON)/kronos_ram.sv \
                $(RTL_DIR)/stage5/kronos_alu.sv \
                $(RTL_DIR)/stage5/kronos_decode.sv \
                $(RTL_DIR)/stage0/kronos_regfile.sv \
@@ -1009,6 +1012,7 @@ SIM_BIN_S6 := $(OBJ_DIR)/s6/V$(TOP_S5)
 
 SV_FILES_S6 := $(AXI_PKG_SV) \
                $(RTL_DIR)/kronos_pkg.sv \
+               $(RTL_DIR_COMMON)/kronos_ram.sv \
                $(RTL_DIR_S6)/kronos_alu.sv \
                $(RTL_DIR_S6)/kronos_decode.sv \
                $(RTL_DIR)/stage0/kronos_regfile.sv \
@@ -1318,6 +1322,28 @@ sim-trigger:
 	$(VERILATOR) $(WAIVER) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Mdir $(OBJ_DIR)/trigger -Wno-UNUSED \
 	  --top-module tb_trigger $(TB_TRIGGER_FILES)
 	$(OBJ_DIR)/trigger/Vtb_trigger
+
+# ---------------------------------------------------------------------------
+# Stage 6d — kronos_ram wrapper unit TB (Verilator, ASIC backend default)
+# ---------------------------------------------------------------------------
+TB_KRONOS_RAM_FILES := $(RTL_DIR_COMMON)/kronos_ram.sv \
+                       $(TB_DIR)/common/tb_kronos_ram.sv
+
+sim-kronos-ram: | $(OBJ_DIR)
+	mkdir -p $(OBJ_DIR)/kronos_ram
+	$(VERILATOR) $(WAIVER) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD \
+	  --Wno-PROCASSINIT \
+	  --top-module tb_kronos_ram $(TB_KRONOS_RAM_FILES) \
+	  -Mdir $(OBJ_DIR)/kronos_ram -o Vtb_kronos_ram
+	@out=$$($(OBJ_DIR)/kronos_ram/Vtb_kronos_ram 2>&1); \
+	 echo "$$out" | tail -3; \
+	 if echo "$$out" | grep -q "tb_kronos_ram: PASS"; then \
+	   echo "PASS  sim-kronos-ram"; \
+	 else \
+	   echo "FAIL  sim-kronos-ram"; exit 1; \
+	 fi
+
+.PHONY: sim-kronos-ram
 
 TB_PMP_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
                 $(RTL_DIR)/stage6/kronos_pmp.sv \

--- a/tb/common/tb_kronos_ram.sv
+++ b/tb/common/tb_kronos_ram.sv
@@ -1,0 +1,158 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+// Stage 6d unit testbench for kronos_ram (ASIC behavioural backend).
+// FPGA backend (xpm_memory_sdpram) is verified by XPM library guarantees;
+// this TB exercises the SV-side semantics consumed by the icache wrapper.
+
+module tb_kronos_ram;
+
+  localparam int unsigned DEPTH      = 16;
+  localparam int unsigned WIDTH      = 32;
+  localparam int unsigned BYTE_WIDTH = 8;
+  localparam int unsigned NB         = WIDTH / BYTE_WIDTH;
+  localparam int unsigned ADDR_W     = $clog2(DEPTH);
+
+  logic                  clk = 1'b0;
+  logic                  we;
+  logic [ADDR_W-1:0]     waddr;
+  logic [WIDTH-1:0]      wdata;
+  logic [NB-1:0]         wmask;
+  logic                  re;
+  logic [ADDR_W-1:0]     raddr;
+  logic [WIDTH-1:0]      rdata;
+
+  always #5 clk = ~clk;
+
+  kronos_ram #(
+    .DEPTH      (DEPTH),
+    .WIDTH      (WIDTH),
+    .BYTE_WIDTH (BYTE_WIDTH)
+  ) dut (
+    .clk_i   (clk),
+    .we_i    (we),
+    .waddr_i (waddr),
+    .wdata_i (wdata),
+    .wmask_i (wmask),
+    .re_i    (re),
+    .raddr_i (raddr),
+    .rdata_o (rdata)
+  );
+
+  int unsigned fail_count = 0;
+
+  task automatic write_word(input logic [ADDR_W-1:0] a, input logic [WIDTH-1:0] d);
+    @(negedge clk);
+    we     = 1'b1;
+    waddr  = a;
+    wdata  = d;
+    wmask  = '1;
+    re     = 1'b0;
+    @(posedge clk);
+    @(negedge clk);
+    we     = 1'b0;
+  endtask
+
+  task automatic read_word(input logic [ADDR_W-1:0] a, output logic [WIDTH-1:0] d);
+    @(negedge clk);
+    re     = 1'b1;
+    raddr  = a;
+    we     = 1'b0;
+    @(posedge clk);
+    @(negedge clk);
+    d      = rdata;
+    re     = 1'b0;
+  endtask
+
+  initial begin
+    we    = 1'b0;
+    re    = 1'b0;
+    waddr = '0;
+    raddr = '0;
+    wdata = '0;
+    wmask = '0;
+
+    @(negedge clk);
+
+    // Case 1: write-then-read every address
+    for (int unsigned i = 0; i < DEPTH; i++) begin
+      write_word(i[ADDR_W-1:0], 32'hCAFE_0000 | i);
+    end
+    for (int unsigned i = 0; i < DEPTH; i++) begin
+      automatic logic [WIDTH-1:0] got;
+      read_word(i[ADDR_W-1:0], got);
+      if (got !== (32'hCAFE_0000 | i)) begin
+        $display("FAIL case1: addr=%0d got=%h expected=%h", i, got, 32'hCAFE_0000 | i);
+        fail_count++;
+      end
+    end
+
+    // Case 2: byte-write strobes
+    write_word(4'd0, 32'h0000_0000);
+    @(negedge clk);
+    we    = 1'b1;
+    waddr = 4'd0;
+    wdata = 32'hAABB_CCDD;
+    wmask = 4'b0010;
+    re    = 1'b0;
+    @(posedge clk);
+    @(negedge clk);
+    we    = 1'b0;
+    begin
+      automatic logic [WIDTH-1:0] got;
+      read_word(4'd0, got);
+      if (got[15:8] !== 8'hCC) begin
+        $display("FAIL case2: byte1 got=%h expected=CC", got[15:8]);
+        fail_count++;
+      end
+      if (got[31:16] !== 16'h0000 || got[7:0] !== 8'h00) begin
+        $display("FAIL case2: other bytes got=%h expected zero", got);
+        fail_count++;
+      end
+    end
+
+    // Case 3: read latency
+    write_word(4'd5, 32'hDEAD_BEEF);
+    @(negedge clk);
+    re    = 1'b1;
+    raddr = 4'd5;
+    we    = 1'b0;
+    @(posedge clk);
+    #1;  // settle NBA from rdata_q <= mem[raddr_i] before sampling
+    if (rdata !== 32'hDEAD_BEEF) begin
+      $display("FAIL case3: latency too long, got=%h", rdata);
+      fail_count++;
+    end
+    @(negedge clk);
+    re    = 1'b0;
+
+    // Case 4: concurrent W to A, R from B (A != B)
+    write_word(4'd2, 32'h1111_1111);
+    write_word(4'd3, 32'h2222_2222);
+    @(negedge clk);
+    we    = 1'b1;
+    waddr = 4'd2;
+    wdata = 32'hFFFF_FFFF;
+    wmask = '1;
+    re    = 1'b1;
+    raddr = 4'd3;
+    @(posedge clk);
+    @(negedge clk);
+    we    = 1'b0;
+    re    = 1'b0;
+    if (rdata !== 32'h2222_2222) begin
+      $display("FAIL case4: concurrent W/R got=%h expected=22222222", rdata);
+      fail_count++;
+    end
+
+    if (fail_count == 0)
+      $display("tb_kronos_ram: PASS");
+    else
+      $display("tb_kronos_ram: FAIL (%0d cases failed)", fail_count);
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
## Summary

Lands the `kronos_ram` parameterised SDP wrapper module + unit TB + FuseSoC and Makefile plumbing for the FPGA `xpm_memory_sdpram` backend. The wrapper itself is correct and tested but **not yet instantiated** by any consumer — icache and dcache integrations are deferred to follow-up stages.

## Files

- **`rtl/common/kronos_ram.sv`** — SDP RAM, 1-cycle registered read, byte-write enable. Two backends behind `KRONOS_RAM_FPGA`:
  - **FPGA** (Vivado lint + GLS targets): `xpm_memory_sdpram` — deterministic RAMB36/18 inference.
  - **Default** (Verilator + ASIC): behavioural SDP with FF-array storage. Synthesises as FFs on tools without XPM; functionally identical (same latency, same byte-write).
- **`tb/common/tb_kronos_ram.sv`** — directed unit TB: write-then-read sweep, byte-write strobes, 1-cycle read latency, concurrent W/R to disjoint addresses. PASSes on Verilator.
- **`rtl/filelist_s5.f` + `rtl/filelist_s6.f`** — `common/kronos_ram.sv` added (used by GLS).
- **`sim/Makefile`** — `RTL_DIR_COMMON` variable, `SV_FILES_S5/S6` include the wrapper, `sim-kronos-ram` TB target.
- **`fpga/gls/synth_ooc.tcl`** — `set_property verilog_define KRONOS_RAM_FPGA=1` so `synth_ooc.tcl` picks the XPM backend on all `gls-funcsim/gls-sdf` flows.
- **`kronos_riscv.core`** — `KRONOS_RAM_FPGA` `paramtype: vlogdefine` on Vivado-driven targets only; Verilator targets keep the ASIC stub default.

## Why infrastructure-only

The original 6d scope called for icache `data_q` rewiring to use `kronos_ram`. That work hit a real microarchitectural issue: today's icache has a **combinational hit** contract (`data_o` delivered same cycle as `addr_i`), which only works because `data_q` is an FF array. A real BRAM has a mandatory 1-cycle registered read. Inserting any read latency disturbs trap-entry timing through `instr_fetch_stall` / `align_instr_valid` / redirect / CSR — and `test_page_fault` breaks across all attempted approaches (data_fresh gating, address pre-drive, etc.).

The proper fix is to add an IF1/IF2 fetch pipeline stage (Rocket/BOOM-style 2-stage frontend) that absorbs the BRAM latency cleanly. That's a real architectural change — comparable in size to a small stage on its own (600–800 lines of diff across `kronos_top.sv` + `kronos_align.sv` + `kronos_icache.sv` plus a directed test harness for fetch-pipeline correctness).

Splitting infrastructure (this PR) from the fetch-pipeline rework (stage 6e) makes both more reviewable and prevents this PR from carrying a partially-broken icache integration. Issue #64 stays open and is fully resumable.

## Verification (`sim-all` green; ACT4 unchanged)

| | |
|---|---|
| `sim-arch-test-s5` | 307/307 |
| `sim-arch-test-s6` | 305/305 |
| `sim-arch-test-s6-priv` | 305/305 |
| `sim-perf-baseline-s6` | PASS |
| `sim-kronos-ram` | PASS |
| `sim-crv-smoke` | 7/7 |
| `sim-all` | green |

## Refs

#64