### PR TITLE
chore(core): default to stage6 and enumerate filesets explicitly

### DIFF
--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -38,13 +38,72 @@ filesets:
     depend:
       - pulp-platform.org::axi:0.39.9
     files:
-      - rtl/filelist_s5.f: {file_type: f}
+      - rtl/kronos_pkg.sv
+      - rtl/common/kronos_ram.sv
+      - rtl/stage0/kronos_regfile.sv
+      - rtl/stage1/kronos_forward.sv
+      - rtl/stage1/kronos_hazard.sv
+      - rtl/stage3/kronos_align.sv
+      - rtl/stage3/kronos_bpred.sv
+      - rtl/stage5/kronos_alu.sv
+      - rtl/stage5/kronos_decode.sv
+      - rtl/stage5/kronos_regfile_fp.sv
+      - rtl/stage5/kronos_icache.sv
+      - rtl/stage5/kronos_csr.sv
+      - rtl/stage5/kronos_trigger.sv
+      - rtl/stage5/kronos_lsu.sv
+      - rtl/stage5/kronos_dcache.sv
+      - rtl/stage5/kronos_muldiv.sv
+      - rtl/stage5/kronos_decompress.sv
+      - rtl/stage5/fpu/kronos_fpu_scoreboard.sv
+      - rtl/stage5/fpu/kronos_fpu_fmisc.sv
+      - rtl/stage5/fpu/kronos_fpu_fcvt.sv
+      - rtl/stage5/fpu/kronos_fpu_fadd.sv
+      - rtl/stage5/fpu/kronos_fpu_fmul.sv
+      - rtl/stage5/fpu/kronos_fpu_fma.sv
+      - rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
+      - rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
+      - rtl/stage5/fpu/kronos_fpu_iter.sv
+      - rtl/stage5/fpu/kronos_fpu_top.sv
+      - rtl/stage5/kronos_top.sv
+    file_type: systemVerilogSource
 
   files_rtl_s6:
     depend:
       - pulp-platform.org::axi:0.39.9
     files:
-      - rtl/filelist_s6.f: {file_type: f}
+      - rtl/kronos_pkg.sv
+      - rtl/common/kronos_ram.sv
+      - rtl/stage0/kronos_regfile.sv
+      - rtl/stage1/kronos_forward.sv
+      - rtl/stage1/kronos_hazard.sv
+      - rtl/stage6/kronos_align.sv
+      - rtl/stage3/kronos_bpred.sv
+      - rtl/stage6/kronos_alu.sv
+      - rtl/stage6/kronos_decode.sv
+      - rtl/stage6/kronos_regfile_fp.sv
+      - rtl/stage6/kronos_icache.sv
+      - rtl/stage6/kronos_csr.sv
+      - rtl/stage6/kronos_pmp.sv
+      - rtl/stage6/kronos_tlb.sv
+      - rtl/stage6/kronos_ptw.sv
+      - rtl/stage6/kronos_trigger.sv
+      - rtl/stage6/kronos_lsu.sv
+      - rtl/stage6/kronos_dcache.sv
+      - rtl/stage6/kronos_muldiv.sv
+      - rtl/stage6/kronos_decompress.sv
+      - rtl/stage6/fpu/kronos_fpu_scoreboard.sv
+      - rtl/stage6/fpu/kronos_fpu_fmisc.sv
+      - rtl/stage6/fpu/kronos_fpu_fcvt.sv
+      - rtl/stage6/fpu/kronos_fpu_fadd.sv
+      - rtl/stage6/fpu/kronos_fpu_fmul.sv
+      - rtl/stage6/fpu/kronos_fpu_fma.sv
+      - rtl/stage6/fpu/kronos_fpu_fdiv_core.sv
+      - rtl/stage6/fpu/kronos_fpu_fsqrt_core.sv
+      - rtl/stage6/fpu/kronos_fpu_iter.sv
+      - rtl/stage6/fpu/kronos_fpu_top.sv
+      - rtl/stage6/kronos_top.sv
+    file_type: systemVerilogSource
 
   files_fpga_kv260:
     depend:
@@ -70,11 +129,11 @@ filesets:
 
 targets:
   default:
-    filesets: [files_rtl_s5]
+    filesets: [files_rtl_s6]
     toplevel: kronos_top
 
   lint:
-    filesets: [files_lint_waivers, files_rtl_s5]
+    filesets: [files_lint_waivers, files_rtl_s6]
     tools:
       verilator:
         mode: lint-only


### PR DESCRIPTION
## Summary

Two related changes to `kronos_riscv.core`:

1. Make `files_rtl_s6` the **default** fileset (and the `lint` target). Stage 6 is the current production stage, so plain `fusesoc run --target=lint opensoc:ip:kronos_riscv` should build it.
2. Replace the `rtl/filelist_s<N>.f: {file_type: f}` references in `files_rtl_s5` and `files_rtl_s6` with explicit `systemVerilogSource` enumeration of the same files.

## Why the file_type:f change

`file_type: f` is treated by FuseSoC as a single Verilog command file: it copies the `.f` into the downstream build's src tree and passes it as `-f` to the EDA tool, but does **not** parse the file to copy the RTL it references.

- Standalone kronos builds work because Verilator can resolve the relative paths at runtime against the in-place rtl directory.
- Any downstream consumer that depends on `opensoc:ip:kronos_riscv` from another core ends up with only the `.f` file in their assembled src tree (no kronos RTL), and the integration build fails with `Import package not found: 'kronos_pkg'`.

Restoring explicit `systemVerilogSource` enumeration matches the pre-stage5b layout that other consumers expect, with no behavioural change for kronos's own build/lint.

## Test plan

- [x] `fusesoc run --target=lint opensoc:ip:kronos_riscv` — clean
- [x] OpenSoC integration build (`make lint` against this kronos pin) — clean
- [x] OpenSoC `make regression` — 15/15 PASS

## Notes

This is a packaging-only change; no RTL touched. Discovered while integrating v0.6.1 into OpenSoC.