### PR TITLE
refactor(rtl): scope kronos_pkg constants with explicit `::` operator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,8 +523,30 @@ If the comment after the prefix is substantive (explains a non-obvious invariant
 ### Packages and Imports
 
 - Shared types live in `rtl/kronos_pkg.sv`. Do not duplicate type definitions across files.
-- Import packages at the module level with `import kronos_pkg::*;` — do not use the `::` scope operator inline in port lists or always blocks.
+- Import the package at module level with `import kronos_pkg::*;` — this brings types into scope for use in the port list, signal declarations, and bodies.
+- **Reference package `localparam` / `parameter` constants with the explicit `kronos_pkg::NAME` scope operator** at every use site (`kronos_pkg::XLEN`, `kronos_pkg::FLEN`, `kronos_pkg::MMIO_BASE`, `kronos_pkg::DECODED_INSTR_ZERO`, etc.). The scope prefix lets editor tooling (VSCode hover, LSP go-to-definition) resolve the constant's value without crawling every imported package. The wildcard `import` would otherwise hide the source file from the LSP.
+- **Types stay bare.** `decoded_instr_t`, `alu_op_e`, `id_ex_reg_t`, etc. are written without the package prefix in port lists, signal declarations, and `case` selectors. The wildcard import covers them and the type suffix (`_t`, `_e`) already signals package-origin.
+- **Enum members stay bare.** `ALU_ADD`, `FWD_NONE`, `PRIV_M`, `WB_ALU`, `FP_FADD`, etc. are written without the package prefix. The enclosing enum type already provides hover context, and scoping every case label would bloat decode tables and `case` statements.
 - Do not create per-stage packages; `kronos_pkg` is the single shared package across all stages.
+
+```systemverilog
+module kronos_alu
+  import kronos_pkg::*;
+(
+  input  alu_op_e                       op_i,        // type — bare
+  input  logic [kronos_pkg::XLEN-1:0]   a_i,         // constant — scoped
+  output logic [kronos_pkg::XLEN-1:0]   result_o
+);
+  always_comb begin
+    result_o = {kronos_pkg::XLEN{1'b0}};              // constant — scoped
+    unique case (op_i)
+      ALU_ADD: result_o = a_i + b_i;                  // enum member — bare
+      ALU_SUB: result_o = a_i - b_i;
+      default: ;
+    endcase
+  end
+endmodule
+```
 
 ### Hierarchy and Instantiation
 

--- a/rtl/stage0/kronos_decode.sv
+++ b/rtl/stage0/kronos_decode.sv
@@ -44,7 +44,7 @@ module kronos_decode
   assign funct7 = instr_i[31:25];
 
   always_comb begin
-    dec_o          = DECODED_INSTR_ZERO;
+    dec_o          = kronos_pkg::DECODED_INSTR_ZERO;
     dec_o.rs1      = rs1;
     dec_o.rs2      = rs2;
     dec_o.rd       = rd;

--- a/rtl/stage1/kronos_top.sv
+++ b/rtl/stage1/kronos_top.sv
@@ -261,9 +261,9 @@ module kronos_top
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_flush) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;

--- a/rtl/stage2/kronos_decode.sv
+++ b/rtl/stage2/kronos_decode.sv
@@ -44,7 +44,7 @@ module kronos_decode
   assign funct7 = instr_i[31:25];
 
   always_comb begin
-    dec_o          = DECODED_INSTR_ZERO;
+    dec_o          = kronos_pkg::DECODED_INSTR_ZERO;
     dec_o.rs1      = rs1;
     dec_o.rs2      = rs2;
     dec_o.rd       = rd;

--- a/rtl/stage2/kronos_top.sv
+++ b/rtl/stage2/kronos_top.sv
@@ -304,9 +304,9 @@ module kronos_top
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_flush) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;

--- a/rtl/stage3/kronos_top.sv
+++ b/rtl/stage3/kronos_top.sv
@@ -460,9 +460,9 @@ module kronos_top
   // =========================================================================
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_flush) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;

--- a/rtl/stage4/kronos_csr.sv
+++ b/rtl/stage4/kronos_csr.sv
@@ -5,7 +5,7 @@
 // kronos_csr.sv — machine-mode CSR file for Stage 4 (RV64)
 // Implements mstatus, misa, mie, mtvec, mscratch, mepc, mcause, mip.
 // Handles trap entry (ECALL/EBREAK/illegal), MRET, and CSR read/write.
-// All CSR data paths are 64 bits wide (MXL=10, XLEN=64).
+// All CSR data paths are 64 bits wide (MXL=10, kronos_pkg::XLEN=64).
 module kronos_csr #(
   // MISA extension bits [25:0]. Default = I-only (bit 8).
   // Stage 4 advertises I+M+A+C as appropriate via the top-level parameter.

--- a/rtl/stage4/kronos_decode.sv
+++ b/rtl/stage4/kronos_decode.sv
@@ -11,7 +11,7 @@
 //   - OP-32    (0111011): ADDW/SUBW/SLLW/SRLW/SRAW + MULW/DIVW/DIVUW/REMW/REMUW
 //   - AMO      (0101111): LR/SC/AMO*
 // Defaults for new fields (is_word_op, is_lr, is_sc, is_amo, amo_funct5) come
-// from the DECODED_INSTR_ZERO assignment at the top of always_comb, which
+// from the kronos_pkg::DECODED_INSTR_ZERO assignment at the top of always_comb, which
 // zero-initialises every field of the decoded_instr_t struct.
 module kronos_decode
   import kronos_pkg::*;
@@ -51,7 +51,7 @@ module kronos_decode
   assign funct7 = instr_i[31:25];
 
   always_comb begin
-    dec_o          = DECODED_INSTR_ZERO;
+    dec_o          = kronos_pkg::DECODED_INSTR_ZERO;
     dec_o.rs1      = rs1;
     dec_o.rs2      = rs2;
     dec_o.rd       = rd;

--- a/rtl/stage4/kronos_top.sv
+++ b/rtl/stage4/kronos_top.sv
@@ -458,9 +458,9 @@ module kronos_top
   // =========================================================================
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_flush) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;

--- a/rtl/stage5/fpu/kronos_fpu_fadd.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fadd.sv
@@ -261,8 +261,8 @@ module kronos_fpu_fadd
     b_d_nan  = b_d_snan || b_d_qnan;
 
     // --- Single decomposition (with NaN-unbox) ---
-    a_s_bits = (a_i[63:32] == FP_NANBOX_UPPER) ? a_i[31:0] : FP_CANON_QNAN_S;
-    b_s_bits = (b_i[63:32] == FP_NANBOX_UPPER) ? b_i[31:0] : FP_CANON_QNAN_S;
+    a_s_bits = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    b_s_bits = (b_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
     a_s_sign = a_s_bits[31];
     b_s_sign = b_s_bits[31];
     a_s_expf = a_s_bits[30:23];
@@ -368,26 +368,26 @@ module kronos_fpu_fadd
 
       if (a_nan_sel || b_nan_sel) begin
         s1_d.is_special  = 1'b1;
-        s1_d.special_res = fmt_d_i ? FP_CANON_QNAN_D
-                                   : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+        s1_d.special_res = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                   : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
         if (a_snan_sel || b_snan_sel) begin
-          s1_d.special_flg[FP_FFLAG_NV] = 1'b1;
+          s1_d.special_flg[kronos_pkg::FP_FFLAG_NV] = 1'b1;
         end
       end else if (both_inf_opposite) begin
         s1_d.is_special  = 1'b1;
-        s1_d.special_res = fmt_d_i ? FP_CANON_QNAN_D
-                                   : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-        s1_d.special_flg[FP_FFLAG_NV] = 1'b1;
+        s1_d.special_res = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                   : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+        s1_d.special_flg[kronos_pkg::FP_FFLAG_NV] = 1'b1;
       end else if (a_inf_sel || b_inf_sel) begin
         s1_d.is_special = 1'b1;
         // Propagate the infinity that's present; same sign as it (b sign already
         // flipped for FSUB).
         if (a_inf_sel) begin
           s1_d.special_res = fmt_d_i ? {a_sign_sel, 11'h7FF, 52'd0}
-                                     : {FP_NANBOX_UPPER, a_sign_sel, 8'hFF, 23'd0};
+                                     : {kronos_pkg::FP_NANBOX_UPPER, a_sign_sel, 8'hFF, 23'd0};
         end else begin
           s1_d.special_res = fmt_d_i ? {b_sign_pre, 11'h7FF, 52'd0}
-                                     : {FP_NANBOX_UPPER, b_sign_pre, 8'hFF, 23'd0};
+                                     : {kronos_pkg::FP_NANBOX_UPPER, b_sign_pre, 8'hFF, 23'd0};
         end
       end else if (both_zero_early) begin
         // 0 + 0: sign(result) = sign(a) & sign(b) for eff_sub=0; else for RDN,
@@ -402,7 +402,7 @@ module kronos_fpu_fadd
             zero_sign = (rm_i == FP_RM_RDN);
           end
           s1_d.special_res = fmt_d_i ? {zero_sign, 63'd0}
-                                     : {FP_NANBOX_UPPER, zero_sign, 31'd0};
+                                     : {kronos_pkg::FP_NANBOX_UPPER, zero_sign, 31'd0};
         end
       end
     end
@@ -801,7 +801,7 @@ module kronos_fpu_fadd
       s5_flags  = s4_q.special_flg;
     end else if (s4_q.result_zero) begin
       if (s4_q.fmt_d) s5_result = {s4_q.res_sign, 63'd0};
-      else            s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, 31'd0};
+      else            s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign, 31'd0};
     end else begin : pack_blk
       if (s4_q.fmt_d) begin
         mant_w = 52;
@@ -812,8 +812,8 @@ module kronos_fpu_fadd
       end
 
       if (s4_q.overflow) begin
-        s5_flags[FP_FFLAG_OF] = 1'b1;
-        s5_flags[FP_FFLAG_NX] = 1'b1;
+        s5_flags[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+        s5_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
         unique case (s4_q.rm)
           FP_RM_RNE: to_inf = 1'b1;
           FP_RM_RTZ: to_inf = 1'b0;
@@ -826,8 +826,8 @@ module kronos_fpu_fadd
           if (to_inf) s5_result = {s4_q.res_sign, 11'h7FF, 52'd0};
           else        s5_result = {s4_q.res_sign, 11'h7FE, {52{1'b1}}};
         end else begin
-          if (to_inf) s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, 8'hFF, 23'd0};
-          else        s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, 8'hFE, {23{1'b1}}};
+          if (to_inf) s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign, 8'hFF, 23'd0};
+          else        s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign, 8'hFE, {23{1'b1}}};
         end
       end else begin
         if (s4_q.fmt_d) begin
@@ -839,11 +839,11 @@ module kronos_fpu_fadd
           out_mant_s = s4_q.rounded_sig[SIG_W-2 -: 23];
           if (s4_q.is_subnormal_out) out_expf_s = 8'd0;
           else                       out_expf_s = 8'(s4_q.cur_exp + bias);
-          s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, out_expf_s, out_mant_s};
+          s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign, out_expf_s, out_mant_s};
         end
 
-        if (s4_q.inexact) s5_flags[FP_FFLAG_NX] = 1'b1;
-        if (s4_q.is_subnormal_out && s4_q.inexact) s5_flags[FP_FFLAG_UF] = 1'b1;
+        if (s4_q.inexact) s5_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
+        if (s4_q.is_subnormal_out && s4_q.inexact) s5_flags[kronos_pkg::FP_FFLAG_UF] = 1'b1;
       end
     end
   end

--- a/rtl/stage5/fpu/kronos_fpu_fcvt.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fcvt.sv
@@ -72,10 +72,10 @@ module kronos_fpu_fcvt
     endcase
 
     if (s1_src_is_single) begin
-      if (a_i[63:32] == FP_NANBOX_UPPER) begin
+      if (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) begin
         s1_a_d = {32'h0, a_i[31:0]};
       end else begin
-        s1_a_d = {32'h0, FP_CANON_QNAN_S};
+        s1_a_d = {32'h0, kronos_pkg::FP_CANON_QNAN_S};
       end
     end else begin
       s1_a_d = a_i;
@@ -431,8 +431,8 @@ module kronos_fpu_fcvt
       end else if ((sd_sexp == 8'hFF) && (sd_smant == 23'd0)) begin
         d_result = {sd_sign, 11'h7FF, 52'd0};
       end else if (sd_sexp == 8'hFF) begin
-        if (sd_smant[22] == 1'b0) fs_flags[FP_FFLAG_NV] = 1'b1;
-        d_result = FP_CANON_QNAN_D;
+        if (sd_smant[22] == 1'b0) fs_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+        d_result = kronos_pkg::FP_CANON_QNAN_D;
       end else if (sd_sexp == 8'd0) begin
         integer k;
         logic [22:0] m;
@@ -471,8 +471,8 @@ module kronos_fpu_fcvt
       end else if ((ds_dexp == 11'h7FF) && (ds_dmant == 52'd0)) begin
         s_result = {ds_sign, 8'hFF, 23'd0};
       end else if (ds_dexp == 11'h7FF) begin
-        if (ds_dmant[51] == 1'b0) fs_flags[FP_FFLAG_NV] = 1'b1;
-        s_result = FP_CANON_QNAN_S;
+        if (ds_dmant[51] == 1'b0) fs_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+        s_result = kronos_pkg::FP_CANON_QNAN_S;
       end else begin
         if (ds_dexp == 11'd0) begin
           logic nz_in;
@@ -485,12 +485,12 @@ module kronos_fpu_fcvt
             default: s_result = {ds_sign, 31'd0};
           endcase
           if (nz_in) begin
-            fs_flags[FP_FFLAG_UF] = 1'b1;
-            fs_flags[FP_FFLAG_NX] = 1'b1;
+            fs_flags[kronos_pkg::FP_FFLAG_UF] = 1'b1;
+            fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           end
         end else if (ds_unbiased > 13'sd127) begin
-          fs_flags[FP_FFLAG_OF] = 1'b1;
-          fs_flags[FP_FFLAG_NX] = 1'b1;
+          fs_flags[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+          fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           unique case (s1_rm_q)
             3'b001: s_result = {ds_sign, 8'hFE, 23'h7FFFFF};
             3'b010: s_result = ds_sign ? {1'b1, 8'hFF, 23'd0} : {1'b0, 8'hFE, 23'h7FFFFF};
@@ -528,7 +528,7 @@ module kronos_fpu_fcvt
           endcase
 
           subn_rounded = subn_sig + (subn_round_up ? 24'd1 : 24'd0);
-          if (subn_g | subn_sticky) fs_flags[FP_FFLAG_NX] = 1'b1;
+          if (subn_g | subn_sticky) fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
 
           if (subn_rounded[23]) begin
             subn_mant = {23{1'b0}};
@@ -540,7 +540,7 @@ module kronos_fpu_fcvt
           s_result = {ds_sign, subn_exp, subn_mant};
 
           if ((subn_g | subn_sticky) && (subn_exp == 8'd0))
-            fs_flags[FP_FFLAG_UF] = 1'b1;
+            fs_flags[kronos_pkg::FP_FFLAG_UF] = 1'b1;
         end else begin
           // Normal range: round 52-bit mantissa to 23 bits
           ds_sig    = {1'b1, ds_dmant[51:29]};
@@ -557,13 +557,13 @@ module kronos_fpu_fcvt
             default: ds_round_up = ds_g && (ds_sticky || ds_lsb);
           endcase
           ds_rounded = {1'b0, ds_sig} + (ds_round_up ? 25'd1 : 25'd0);
-          if (ds_g || ds_sticky) fs_flags[FP_FFLAG_NX] = 1'b1;
+          if (ds_g || ds_sticky) fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
 
           ds_sexp_out = ds_unbiased[7:0] + 8'd127;
           if (ds_rounded[24]) begin
             if ((ds_sexp_out + 8'd1) == 8'hFF) begin
               s_result = {ds_sign, 8'hFF, 23'd0};
-              fs_flags[FP_FFLAG_OF] = 1'b1;
+              fs_flags[kronos_pkg::FP_FFLAG_OF] = 1'b1;
             end else begin
               s_result = {ds_sign, ds_sexp_out + 8'd1, 23'd0};
             end
@@ -572,7 +572,7 @@ module kronos_fpu_fcvt
           end
         end
       end
-      s2c_ds_result = {FP_NANBOX_UPPER, s_result};
+      s2c_ds_result = {kronos_pkg::FP_NANBOX_UPPER, s_result};
       s2c_ds_fflags = fs_flags;
     end
   end
@@ -697,10 +697,10 @@ module kronos_fpu_fcvt
     ifp_fflags = {5{1'b0}};
     if (s2_fmt_d_q) begin
       ifp_result = d_bits;
-      if (!s2_ifp_imag_zero && s2_ifp_d_inexact) ifp_fflags[FP_FFLAG_NX] = 1'b1;
+      if (!s2_ifp_imag_zero && s2_ifp_d_inexact) ifp_fflags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
     end else begin
-      ifp_result = {FP_NANBOX_UPPER, s_bits};
-      if (!s2_ifp_imag_zero && s2_ifp_s_inexact) ifp_fflags[FP_FFLAG_NX] = 1'b1;
+      ifp_result = {kronos_pkg::FP_NANBOX_UPPER, s_bits};
+      if (!s2_ifp_imag_zero && s2_ifp_s_inexact) ifp_fflags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
     end
 
     // --- FP -> INT rounding (65-bit conditional increment + sign + range check) ---
@@ -713,11 +713,11 @@ module kronos_fpu_fcvt
 
     if (s2_fpi_src_is_nan) begin
       fpi_result               = s2_fpi_target_max;
-      fpi_fflags[FP_FFLAG_NV]  = 1'b1;
+      fpi_fflags[kronos_pkg::FP_FFLAG_NV]  = 1'b1;
     end else if (s2_fpi_overflow) begin
       if (s2_fpi_neg_of) fpi_result = s2_fpi_target_is_signed ? s2_fpi_target_min : 64'd0;
       else               fpi_result = s2_fpi_target_max;
-      fpi_fflags[FP_FFLAG_NV] = 1'b1;
+      fpi_fflags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else begin
       if (s2_fpi_target_is_32b && s2_fpi_target_is_signed) begin
         if (s2_fpi_src_sign) begin
@@ -750,7 +750,7 @@ module kronos_fpu_fcvt
       if (over_after_round) begin
         if (s2_fpi_src_sign) fpi_result = s2_fpi_target_is_signed ? s2_fpi_target_min : 64'd0;
         else                 fpi_result = s2_fpi_target_max;
-        fpi_fflags[FP_FFLAG_NV] = 1'b1;
+        fpi_fflags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
       end else begin
         signed_val = s2_fpi_src_sign ? (~mag + 64'd1) : mag;
         if (s2_fpi_target_is_32b) begin
@@ -758,7 +758,7 @@ module kronos_fpu_fcvt
         end else begin
           fpi_result = signed_val;
         end
-        if (s2_fpi_is_inexact) fpi_fflags[FP_FFLAG_NX] = 1'b1;
+        if (s2_fpi_is_inexact) fpi_fflags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
       end
     end
 

--- a/rtl/stage5/fpu/kronos_fpu_fma.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fma.sv
@@ -115,9 +115,9 @@ module kronos_fpu_fma
 
   always_comb begin
     // NaN-unbox single operands
-    a_s = (a_i[63:32] == FP_NANBOX_UPPER) ? a_i[31:0] : FP_CANON_QNAN_S;
-    b_s = (b_i[63:32] == FP_NANBOX_UPPER) ? b_i[31:0] : FP_CANON_QNAN_S;
-    c_s = (c_i[63:32] == FP_NANBOX_UPPER) ? c_i[31:0] : FP_CANON_QNAN_S;
+    a_s = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    b_s = (b_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    c_s = (c_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? c_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
     a_d = a_i;
     b_d = b_i;
     c_d = c_i;
@@ -198,34 +198,34 @@ module kronos_fpu_fma
 
     if (s1_a_snan || s1_b_snan || s1_c_snan) begin
       s1_special              = 1'b1;
-      s1_special_result       = fmt_d_i ? FP_CANON_QNAN_D
-                                        : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_special_flags[FP_FFLAG_NV] = 1'b1;
+      s1_special_result       = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                        : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_special_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if ((s1_a_inf && s1_b_zero) || (s1_a_zero && s1_b_inf)) begin
       // 0 * inf -> invalid
       s1_special              = 1'b1;
-      s1_special_result       = fmt_d_i ? FP_CANON_QNAN_D
-                                        : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_special_flags[FP_FFLAG_NV] = 1'b1;
+      s1_special_result       = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                        : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_special_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if ((s1_a_inf || s1_b_inf) && s1_c_inf &&
                  (s1_prod_sign != s1_addend_sign)) begin
       // Inf - Inf -> invalid
       s1_special              = 1'b1;
-      s1_special_result       = fmt_d_i ? FP_CANON_QNAN_D
-                                        : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_special_flags[FP_FFLAG_NV] = 1'b1;
+      s1_special_result       = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                        : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_special_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if (s1_a_nan || s1_b_nan || s1_c_nan) begin
       // Propagate as canonical qNaN
       s1_special        = 1'b1;
-      s1_special_result = fmt_d_i ? FP_CANON_QNAN_D
-                                  : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s1_special_result = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                  : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s1_a_inf || s1_b_inf) begin
       // Inf * finite (+/- finite addend, same sign or c finite)
       s1_special        = 1'b1;
       if (fmt_d_i) begin
         s1_special_result = {s1_prod_sign, 11'h7FF, 52'd0};
       end else begin
-        s1_special_result = {FP_NANBOX_UPPER, s1_prod_sign, 8'hFF, 23'd0};
+        s1_special_result = {kronos_pkg::FP_NANBOX_UPPER, s1_prod_sign, 8'hFF, 23'd0};
       end
     end else if (s1_c_inf) begin
       // finite * finite + inf -> +/- inf (sign = addend sign)
@@ -233,7 +233,7 @@ module kronos_fpu_fma
       if (fmt_d_i) begin
         s1_special_result = {s1_addend_sign, 11'h7FF, 52'd0};
       end else begin
-        s1_special_result = {FP_NANBOX_UPPER, s1_addend_sign, 8'hFF, 23'd0};
+        s1_special_result = {kronos_pkg::FP_NANBOX_UPPER, s1_addend_sign, 8'hFF, 23'd0};
       end
     end
   end
@@ -1091,18 +1091,18 @@ module kronos_fpu_fma
       if (s5b_eff_sub) begin
         if (s5b_rm == FP_RM_RDN) begin
           s5b_result_comb = s5b_fmt_d ? {1'b1, 63'd0}
-                                      : {FP_NANBOX_UPPER, 1'b1, 31'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 31'd0};
         end else begin
           s5b_result_comb = s5b_fmt_d ? 64'd0
-                                      : {FP_NANBOX_UPPER, 32'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 32'd0};
         end
       end else begin
         if (s5b_prod_sign) begin
           s5b_result_comb = s5b_fmt_d ? {1'b1, 63'd0}
-                                      : {FP_NANBOX_UPPER, 1'b1, 31'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 31'd0};
         end else begin
           s5b_result_comb = s5b_fmt_d ? 64'd0
-                                      : {FP_NANBOX_UPPER, 32'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 32'd0};
         end
       end
     end else begin
@@ -1203,44 +1203,44 @@ module kronos_fpu_fma
         end
 
         if (!(carry_n && (s5b_exp_pre_tiny + 13'sd1 == emin))) begin
-          s5b_flags_comb[FP_FFLAG_UF] = 1'b1;
+          s5b_flags_comb[kronos_pkg::FP_FFLAG_UF] = 1'b1;
         end
       end
 
-      if (inexact) s5b_flags_comb[FP_FFLAG_NX] = 1'b1;
+      if (inexact) s5b_flags_comb[kronos_pkg::FP_FFLAG_NX] = 1'b1;
 
       if (overflow_ovf) begin
-        s5b_flags_comb[FP_FFLAG_OF] = 1'b1;
-        s5b_flags_comb[FP_FFLAG_NX] = 1'b1;
+        s5b_flags_comb[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+        s5b_flags_comb[kronos_pkg::FP_FFLAG_NX] = 1'b1;
         unique case (s5b_rm)
           FP_RM_RTZ: begin
             if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, 11'd2046, {52{1'b1}}};
-            else           s5b_result_comb = {FP_NANBOX_UPPER,
+            else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                               s5b_res_sign, 8'd254, {23{1'b1}}};
           end
           FP_RM_RDN: begin
             if (s5b_res_sign) begin
               if (s5b_fmt_d) s5b_result_comb = {1'b1, 11'h7FF, 52'd0};
-              else           s5b_result_comb = {FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0};
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0};
             end else begin
               if (s5b_fmt_d) s5b_result_comb = {1'b0, 11'd2046, {52{1'b1}}};
-              else           s5b_result_comb = {FP_NANBOX_UPPER,
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                                1'b0, 8'd254, {23{1'b1}}};
             end
           end
           FP_RM_RUP: begin
             if (s5b_res_sign) begin
               if (s5b_fmt_d) s5b_result_comb = {1'b1, 11'd2046, {52{1'b1}}};
-              else           s5b_result_comb = {FP_NANBOX_UPPER,
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                                1'b1, 8'd254, {23{1'b1}}};
             end else begin
               if (s5b_fmt_d) s5b_result_comb = {1'b0, 11'h7FF, 52'd0};
-              else           s5b_result_comb = {FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
             end
           end
           default: begin
             if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, 11'h7FF, 52'd0};
-            else           s5b_result_comb = {FP_NANBOX_UPPER,
+            else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                              s5b_res_sign, 8'hFF, 23'd0};
           end
         endcase
@@ -1250,7 +1250,7 @@ module kronos_fpu_fma
           s5b_result_comb = {s5b_res_sign, exp_field_d, final_sig[51:0]};
         end else begin
           exp_field_s = final_exp[7:0];
-          s5b_result_comb = {FP_NANBOX_UPPER, s5b_res_sign, exp_field_s,
+          s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER, s5b_res_sign, exp_field_s,
                              final_sig[22:0]};
         end
       end

--- a/rtl/stage5/fpu/kronos_fpu_fmisc.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fmisc.sv
@@ -90,16 +90,16 @@ module kronos_fpu_fmisc
   // -------------------------------------------------------------------------
   always_comb begin
     // NaN-unbox single operands
-    a_s = (a_i[63:32] == FP_NANBOX_UPPER) ? a_i[31:0] : FP_CANON_QNAN_S;
-    b_s = (b_i[63:32] == FP_NANBOX_UPPER) ? b_i[31:0] : FP_CANON_QNAN_S;
+    a_s = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    b_s = (b_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
 
     // Effective operands for each format
     if (fmt_d_i) begin
       a_eff = a_i;
       b_eff = b_i;
     end else begin
-      a_eff = {FP_NANBOX_UPPER, a_s};
-      b_eff = {FP_NANBOX_UPPER, b_s};
+      a_eff = {kronos_pkg::FP_NANBOX_UPPER, a_s};
+      b_eff = {kronos_pkg::FP_NANBOX_UPPER, b_s};
     end
   end
 
@@ -231,7 +231,7 @@ module kronos_fpu_fmisc
         if (fmt_d_i) begin
           result_comb = {b_eff[63], a_eff[62:0]};
         end else begin
-          result_comb = {FP_NANBOX_UPPER, b_s[31], a_s[30:0]};
+          result_comb = {kronos_pkg::FP_NANBOX_UPPER, b_s[31], a_s[30:0]};
         end
       end
 
@@ -239,7 +239,7 @@ module kronos_fpu_fmisc
         if (fmt_d_i) begin
           result_comb = {~b_eff[63], a_eff[62:0]};
         end else begin
-          result_comb = {FP_NANBOX_UPPER, ~b_s[31], a_s[30:0]};
+          result_comb = {kronos_pkg::FP_NANBOX_UPPER, ~b_s[31], a_s[30:0]};
         end
       end
 
@@ -247,7 +247,7 @@ module kronos_fpu_fmisc
         if (fmt_d_i) begin
           result_comb = {a_eff[63] ^ b_eff[63], a_eff[62:0]};
         end else begin
-          result_comb = {FP_NANBOX_UPPER, a_s[31] ^ b_s[31], a_s[30:0]};
+          result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_s[31] ^ b_s[31], a_s[30:0]};
         end
       end
 
@@ -259,9 +259,9 @@ module kronos_fpu_fmisc
       //   - Quiet NaN on one operand silently returns the other.
       FP_FMIN: begin
         if (fmt_d_i) begin
-          if (a_snan_d || b_snan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_d || b_snan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_d && b_nan_d) begin
-            result_comb = FP_CANON_QNAN_D;
+            result_comb = kronos_pkg::FP_CANON_QNAN_D;
           end else if (a_nan_d) begin
             result_comb = b_i;
           end else if (b_nan_d) begin
@@ -275,20 +275,20 @@ module kronos_fpu_fmisc
             end
           end
         end else begin
-          if (a_snan_s || b_snan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_s || b_snan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_s && b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
           end else if (a_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, b_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, b_s};
           end else if (b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, a_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_s};
           end else begin
             // Both numeric: min(-0,+0) = -0
             if (a_zero_s && b_zero_s) begin
-              result_comb = (a_sign_s || b_sign_s) ? {FP_NANBOX_UPPER, 1'b1, 31'd0}
-                                                   : {FP_NANBOX_UPPER, a_s};
+              result_comb = (a_sign_s || b_sign_s) ? {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 31'd0}
+                                                   : {kronos_pkg::FP_NANBOX_UPPER, a_s};
             end else begin
-              result_comb = a_lt_b_s ? {FP_NANBOX_UPPER, a_s} : {FP_NANBOX_UPPER, b_s};
+              result_comb = a_lt_b_s ? {kronos_pkg::FP_NANBOX_UPPER, a_s} : {kronos_pkg::FP_NANBOX_UPPER, b_s};
             end
           end
         end
@@ -296,9 +296,9 @@ module kronos_fpu_fmisc
 
       FP_FMAX: begin
         if (fmt_d_i) begin
-          if (a_snan_d || b_snan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_d || b_snan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_d && b_nan_d) begin
-            result_comb = FP_CANON_QNAN_D;
+            result_comb = kronos_pkg::FP_CANON_QNAN_D;
           end else if (a_nan_d) begin
             result_comb = b_i;
           end else if (b_nan_d) begin
@@ -312,20 +312,20 @@ module kronos_fpu_fmisc
             end
           end
         end else begin
-          if (a_snan_s || b_snan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_s || b_snan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_s && b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
           end else if (a_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, b_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, b_s};
           end else if (b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, a_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_s};
           end else begin
             // Both numeric: max(-0,+0) = +0
             if (a_zero_s && b_zero_s) begin
-              result_comb = (!a_sign_s || !b_sign_s) ? {FP_NANBOX_UPPER, 1'b0, 31'd0}
-                                                     : {FP_NANBOX_UPPER, a_s};
+              result_comb = (!a_sign_s || !b_sign_s) ? {kronos_pkg::FP_NANBOX_UPPER, 1'b0, 31'd0}
+                                                     : {kronos_pkg::FP_NANBOX_UPPER, a_s};
             end else begin
-              result_comb = a_lt_b_s ? {FP_NANBOX_UPPER, b_s} : {FP_NANBOX_UPPER, a_s};
+              result_comb = a_lt_b_s ? {kronos_pkg::FP_NANBOX_UPPER, b_s} : {kronos_pkg::FP_NANBOX_UPPER, a_s};
             end
           end
         end
@@ -340,10 +340,10 @@ module kronos_fpu_fmisc
       FP_FEQ: begin
         if (fmt_d_i) begin
           // FEQ: only raises NV on sNaN
-          if (a_snan_d || b_snan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_d || b_snan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           result_comb = {63'd0, cmp_eq_d};
         end else begin
-          if (a_snan_s || b_snan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_s || b_snan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           result_comb = {63'd0, cmp_eq_s};
         end
       end
@@ -351,10 +351,10 @@ module kronos_fpu_fmisc
       FP_FLT: begin
         if (fmt_d_i) begin
           // FLT: raises NV on any NaN
-          if (a_nan_d || b_nan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_nan_d || b_nan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           result_comb = {63'd0, cmp_lt_d};
         end else begin
-          if (a_nan_s || b_nan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_nan_s || b_nan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           result_comb = {63'd0, cmp_lt_s};
         end
       end
@@ -362,10 +362,10 @@ module kronos_fpu_fmisc
       FP_FLE: begin
         if (fmt_d_i) begin
           // FLE: raises NV on any NaN
-          if (a_nan_d || b_nan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_nan_d || b_nan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           result_comb = {63'd0, cmp_le_d};
         end else begin
-          if (a_nan_s || b_nan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_nan_s || b_nan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           result_comb = {63'd0, cmp_le_s};
         end
       end
@@ -378,7 +378,7 @@ module kronos_fpu_fmisc
 
       FP_FMV_W_X: begin
         // NaN-box low 32 bits of integer source
-        result_comb = {FP_NANBOX_UPPER, a_i[31:0]};
+        result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_i[31:0]};
       end
 
       FP_FMV_X_D: begin

--- a/rtl/stage5/fpu/kronos_fpu_fmul.sv
+++ b/rtl/stage5/fpu/kronos_fpu_fmul.sv
@@ -132,8 +132,8 @@ module kronos_fpu_fmul
     logic signed [EXP_EXT_W-1:0] ea_ext, eb_ext;
 
     // NaN-unbox single operands (mirrors kronos_fpu_fmisc).
-    a_s_l = (a_i[63:32] == FP_NANBOX_UPPER) ? a_i[31:0] : FP_CANON_QNAN_S;
-    b_s_l = (b_i[63:32] == FP_NANBOX_UPPER) ? b_i[31:0] : FP_CANON_QNAN_S;
+    a_s_l = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    b_s_l = (b_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
     a_s_unb = a_s_l;
     b_s_unb = b_s_l;
 
@@ -854,39 +854,39 @@ module kronos_fpu_fmul
     // -------- Build result --------
     if (s4_any_snan_q) begin
       // sNaN operand → invalid, canonical qNaN
-      s5_fflags_c[FP_FFLAG_NV] = 1'b1;
-      s5_result_c = s4_fmt_d_q ? FP_CANON_QNAN_D
-                                : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s5_fflags_c[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+      s5_result_c = s4_fmt_d_q ? kronos_pkg::FP_CANON_QNAN_D
+                                : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s4_inf_times_zero_q) begin
       // inf * 0 → invalid, canonical qNaN
-      s5_fflags_c[FP_FFLAG_NV] = 1'b1;
-      s5_result_c = s4_fmt_d_q ? FP_CANON_QNAN_D
-                                : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s5_fflags_c[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+      s5_result_c = s4_fmt_d_q ? kronos_pkg::FP_CANON_QNAN_D
+                                : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s4_any_nan_q) begin
       // qNaN propagation → canonical qNaN, no flag
-      s5_result_c = s4_fmt_d_q ? FP_CANON_QNAN_D
-                                : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s5_result_c = s4_fmt_d_q ? kronos_pkg::FP_CANON_QNAN_D
+                                : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s4_res_is_inf_q) begin
       // inf * finite(non-zero) → signed infinity, no flag
       if (s4_fmt_d_q) begin
         s5_result_c = {s4_sign_q, 11'h7FF, 52'd0};
       end else begin
-        s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 8'hFF, 23'd0};
+        s5_result_c = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, 8'hFF, 23'd0};
       end
     end else if (s4_res_is_zero_q) begin
       // zero * finite → signed zero, no flag
       if (s4_fmt_d_q) begin
         s5_result_c = {s4_sign_q, 63'd0};
       end else begin
-        s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 31'd0};
+        s5_result_c = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, 31'd0};
       end
     end else begin
       // Normal numeric path — check overflow/underflow against format range.
       if (s4_fmt_d_q) begin
         overflow = (exp_rnd >= 13'sd2047);
         if (overflow) begin
-          s5_fflags_c[FP_FFLAG_OF] = 1'b1;
-          s5_fflags_c[FP_FFLAG_NX] = 1'b1;
+          s5_fflags_c[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+          s5_fflags_c[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           // Rounding mode controls whether we produce inf or max-finite.
           unique case (s4_rm_q)
             3'b001: // RTZ → max-finite
@@ -909,29 +909,29 @@ module kronos_fpu_fmul
           end
           pack_frac_d = mant_rnd[D_SIG_W-1:0];
           s5_result_c = {s4_sign_q, pack_exp_d, pack_frac_d};
-          s5_fflags_c[FP_FFLAG_NX] = inexact;
+          s5_fflags_c[kronos_pkg::FP_FFLAG_NX] = inexact;
           // Underflow: tiny before rounding AND inexact after rounding
           // (IEEE 754 "after rounding" underflow flag semantics).
-          s5_fflags_c[FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_d == 11'd0);
+          s5_fflags_c[kronos_pkg::FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_d == 11'd0);
         end
       end else begin
         overflow = (exp_rnd >= 13'sd255);
         if (overflow) begin
-          s5_fflags_c[FP_FFLAG_OF] = 1'b1;
-          s5_fflags_c[FP_FFLAG_NX] = 1'b1;
+          s5_fflags_c[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+          s5_fflags_c[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           unique case (s4_rm_q)
             3'b001:
-              s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 8'hFE, {S_SIG_W{1'b1}}};
+              s5_result_c = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, 8'hFE, {S_SIG_W{1'b1}}};
             3'b010:
               s5_result_c = s4_sign_q
-                ? {FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0}
-                : {FP_NANBOX_UPPER, 1'b0, 8'hFE, {S_SIG_W{1'b1}}};
+                ? {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 8'hFF, 23'd0}
+                : {kronos_pkg::FP_NANBOX_UPPER, 1'b0, 8'hFE, {S_SIG_W{1'b1}}};
             3'b011:
               s5_result_c = s4_sign_q
-                ? {FP_NANBOX_UPPER, 1'b1, 8'hFE, {S_SIG_W{1'b1}}}
-                : {FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
+                ? {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 8'hFE, {S_SIG_W{1'b1}}}
+                : {kronos_pkg::FP_NANBOX_UPPER, 1'b0, 8'hFF, 23'd0};
             default:
-              s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, 8'hFF, 23'd0};
+              s5_result_c = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, 8'hFF, 23'd0};
           endcase
         end else begin
           if (exp_rnd <= 13'sd0) begin
@@ -940,9 +940,9 @@ module kronos_fpu_fmul
             pack_exp_s = exp_rnd[S_EXP_W-1:0];
           end
           pack_frac_s = mant_rnd[S_SIG_W-1:0];
-          s5_result_c = {FP_NANBOX_UPPER, s4_sign_q, pack_exp_s, pack_frac_s};
-          s5_fflags_c[FP_FFLAG_NX] = inexact;
-          s5_fflags_c[FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_s == 8'd0);
+          s5_result_c = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, pack_exp_s, pack_frac_s};
+          s5_fflags_c[kronos_pkg::FP_FFLAG_NX] = inexact;
+          s5_fflags_c[kronos_pkg::FP_FFLAG_UF] = underflow_tiny & inexact & (pack_exp_s == 8'd0);
         end
       end
     end

--- a/rtl/stage5/fpu/kronos_fpu_iter.sv
+++ b/rtl/stage5/fpu/kronos_fpu_iter.sv
@@ -282,8 +282,8 @@ module kronos_fpu_iter
   localparam logic [63:0] S_NZERO = 64'hFFFF_FFFF_8000_0000;
 
   // Flag bits
-  localparam logic [4:0] FL_NV = 5'(1) << FP_FFLAG_NV;
-  localparam logic [4:0] FL_DZ = 5'(1) << FP_FFLAG_DZ;
+  localparam logic [4:0] FL_NV = 5'(1) << kronos_pkg::FP_FFLAG_NV;
+  localparam logic [4:0] FL_DZ = 5'(1) << kronos_pkg::FP_FFLAG_DZ;
 
   // Specials helper signals
   logic        sp_result_sign;

--- a/rtl/stage5/kronos_alu.sv
+++ b/rtl/stage5/kronos_alu.sv
@@ -8,73 +8,73 @@ module kronos_alu
   import kronos_pkg::*;
 (
   input  alu_op_e            op_i,
-  input  logic [XLEN-1:0]    a_i,
-  input  logic [XLEN-1:0]    b_i,
+  input  logic [kronos_pkg::XLEN-1:0]    a_i,
+  input  logic [kronos_pkg::XLEN-1:0]    b_i,
   input  logic               word_op_i,
-  output logic [XLEN-1:0]    result_o
+  output logic [kronos_pkg::XLEN-1:0]    result_o
 );
 
   // Combinational signals
-  logic [XLEN-1:0]      result_64;
-  logic [INST_W-1:0]    result_32;
+  logic [kronos_pkg::XLEN-1:0]      result_64;
+  logic [kronos_pkg::INST_W-1:0]    result_32;
 
   always_comb begin
-    result_64 = {XLEN{1'b0}};
-    result_32 = {INST_W{1'b0}};
-    result_o  = {XLEN{1'b0}};
+    result_64 = {kronos_pkg::XLEN{1'b0}};
+    result_32 = {kronos_pkg::INST_W{1'b0}};
+    result_o  = {kronos_pkg::XLEN{1'b0}};
 
     unique case (op_i)
       ALU_ADD: begin
         result_64 = a_i + b_i;
-        result_32 = a_i[INST_W-1:0] + b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] + b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_SUB: begin
         result_64 = a_i - b_i;
-        result_32 = a_i[INST_W-1:0] - b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] - b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_SLL: begin
-        result_64 = a_i << b_i[$clog2(XLEN)-1:0];
-        result_32 = a_i[INST_W-1:0] << b_i[$clog2(INST_W)-1:0];
+        result_64 = a_i << b_i[$clog2(kronos_pkg::XLEN)-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] << b_i[$clog2(kronos_pkg::INST_W)-1:0];
       end
       ALU_SLT: begin
-        result_64 = {{(XLEN-1){1'b0}}, $signed(a_i) < $signed(b_i)};
-        result_32 = result_64[INST_W-1:0];
+        result_64 = {{(kronos_pkg::XLEN-1){1'b0}}, $signed(a_i) < $signed(b_i)};
+        result_32 = result_64[kronos_pkg::INST_W-1:0];
       end
       ALU_SLTU: begin
-        result_64 = {{(XLEN-1){1'b0}}, a_i < b_i};
-        result_32 = result_64[INST_W-1:0];
+        result_64 = {{(kronos_pkg::XLEN-1){1'b0}}, a_i < b_i};
+        result_32 = result_64[kronos_pkg::INST_W-1:0];
       end
       ALU_XOR: begin
         result_64 = a_i ^ b_i;
-        result_32 = a_i[INST_W-1:0] ^ b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] ^ b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_SRL: begin
-        result_64 = a_i >> b_i[$clog2(XLEN)-1:0];
-        result_32 = a_i[INST_W-1:0] >> b_i[$clog2(INST_W)-1:0];
+        result_64 = a_i >> b_i[$clog2(kronos_pkg::XLEN)-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] >> b_i[$clog2(kronos_pkg::INST_W)-1:0];
       end
       ALU_SRA: begin
-        result_64 = XLEN'($signed(a_i) >>> b_i[$clog2(XLEN)-1:0]);
-        result_32 = INST_W'($signed(a_i[INST_W-1:0]) >>> b_i[$clog2(INST_W)-1:0]);
+        result_64 = kronos_pkg::XLEN'($signed(a_i) >>> b_i[$clog2(kronos_pkg::XLEN)-1:0]);
+        result_32 = kronos_pkg::INST_W'($signed(a_i[kronos_pkg::INST_W-1:0]) >>> b_i[$clog2(kronos_pkg::INST_W)-1:0]);
       end
       ALU_OR: begin
         result_64 = a_i | b_i;
-        result_32 = a_i[INST_W-1:0] | b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] | b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_AND: begin
         result_64 = a_i & b_i;
-        result_32 = a_i[INST_W-1:0] & b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] & b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_PASSB: begin
         result_64 = b_i;
-        result_32 = b_i[INST_W-1:0];
+        result_32 = b_i[kronos_pkg::INST_W-1:0];
       end
       default: begin
-        result_64 = {XLEN{1'b0}};
-        result_32 = {INST_W{1'b0}};
+        result_64 = {kronos_pkg::XLEN{1'b0}};
+        result_32 = {kronos_pkg::INST_W{1'b0}};
       end
     endcase
 
-    result_o = word_op_i ? {{(XLEN-INST_W){result_32[INST_W-1]}}, result_32} : result_64;
+    result_o = word_op_i ? {{(kronos_pkg::XLEN-kronos_pkg::INST_W){result_32[kronos_pkg::INST_W-1]}}, result_32} : result_64;
   end
 
 endmodule

--- a/rtl/stage5/kronos_csr.sv
+++ b/rtl/stage5/kronos_csr.sv
@@ -6,7 +6,7 @@
 // Implements mstatus, misa, mie, mtvec, mscratch, mepc, mcause, mip.
 // Handles trap entry (ECALL/EBREAK/illegal), MRET, and CSR read/write.
 // FFLAGS/FRM/FCSR floating-point CSRs and mstatus.FS storage are included.
-// All CSR data paths are 64 bits wide (MXL=10, XLEN=64).
+// All CSR data paths are 64 bits wide (MXL=10, kronos_pkg::XLEN=64).
 module kronos_csr #(
   // MISA extension bits [25:0]. Default = I+M+A+C+F+D (bits 8,12,0,2,5,3).
   parameter logic [25:0] MISA_EXT = 26'h0_112D

--- a/rtl/stage5/kronos_decode.sv
+++ b/rtl/stage5/kronos_decode.sv
@@ -15,7 +15,7 @@
 module kronos_decode
   import kronos_pkg::*;
 (
-  input  logic [INST_W-1:0] instr_i,
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
   input  logic [2:0]        frm_i,        // current FRM from FCSR (for dynamic rm)
   output decoded_instr_t    decoded_o,
   output logic              illegal_insn_o
@@ -68,7 +68,7 @@ module kronos_decode
   assign funct7 = instr_i[31:25];
 
   always_comb begin
-    decoded_o          = DECODED_INSTR_ZERO;
+    decoded_o          = kronos_pkg::DECODED_INSTR_ZERO;
     decoded_o.rs1      = rs1;
     decoded_o.rs2      = rs2;
     decoded_o.rd       = rd;

--- a/rtl/stage5/kronos_decompress.sv
+++ b/rtl/stage5/kronos_decompress.sv
@@ -9,7 +9,7 @@ module kronos_decompress
   import kronos_pkg::*;
 (
   input  logic [15:0]        instr16_i,
-  output logic [INST_W-1:0]  instr32_o,
+  output logic [kronos_pkg::INST_W-1:0]  instr32_o,
   output logic               illegal_o
 );
   // ---------------------------------------------------------------
@@ -42,9 +42,9 @@ module kronos_decompress
 
   // Temporary signals for immediate assembly (shared across case arms — only one active at a time)
   logic [11:0]        uimm;
-  logic [INST_W-1:0]  nzimm;
-  logic [INST_W-1:0]  imm;
-  logic [INST_W-1:0]  off;
+  logic [kronos_pkg::INST_W-1:0]  nzimm;
+  logic [kronos_pkg::INST_W-1:0]  imm;
+  logic [kronos_pkg::INST_W-1:0]  off;
   logic [5:0]         shamt;
 
   // ---------------------------------------------------------------
@@ -67,12 +67,12 @@ module kronos_decompress
   // ---------------------------------------------------------------
   always_comb begin
     // Defaults
-    instr32_o = {INST_W{1'b0}};
+    instr32_o = {kronos_pkg::INST_W{1'b0}};
     illegal_o = 1'b0;
     uimm      = 12'd0;
-    nzimm     = {INST_W{1'b0}};
-    imm       = {INST_W{1'b0}};
-    off       = {INST_W{1'b0}};
+    nzimm     = {kronos_pkg::INST_W{1'b0}};
+    imm       = {kronos_pkg::INST_W{1'b0}};
+    off       = {kronos_pkg::INST_W{1'b0}};
     shamt     = 6'd0;
 
     unique case (instr16_i[1:0])
@@ -153,11 +153,11 @@ module kronos_decompress
             if (rd == REG_X2) begin  // C.ADDI16SP → ADDI x2, x2, nzimm
               nzimm = {{23{instr16_i[12]}}, instr16_i[4:3], instr16_i[5],
                        instr16_i[2], instr16_i[6], 4'b0};
-              if (nzimm == {INST_W{1'b0}}) illegal_o = 1'b1;
+              if (nzimm == {kronos_pkg::INST_W{1'b0}}) illegal_o = 1'b1;
               else instr32_o = {nzimm[11:0], REG_X2, 3'b000, REG_X2, OP_IMM};
             end else begin  // C.LUI → LUI rd, nzimm
               nzimm = {{15{instr16_i[12]}}, instr16_i[6:2], 12'b0};
-              if (nzimm == {INST_W{1'b0}}) illegal_o = 1'b1;
+              if (nzimm == {kronos_pkg::INST_W{1'b0}}) illegal_o = 1'b1;
               else instr32_o = {nzimm[31:12], rd, OP_LUI};
             end
           end

--- a/rtl/stage5/kronos_lsu.sv
+++ b/rtl/stage5/kronos_lsu.sv
@@ -135,7 +135,7 @@ module kronos_lsu
   // -------------------------------------------------------------------------
   always_comb begin
     unique case (funct3_i)
-      3'b010: fp_rdata_o = {FP_NANBOX_UPPER, dcache_rdata_i[31:0]};  // FLW: NaN-box
+      3'b010: fp_rdata_o = {kronos_pkg::FP_NANBOX_UPPER, dcache_rdata_i[31:0]};  // FLW: NaN-box
       3'b011: fp_rdata_o = dcache_rdata_i;                           // FLD: full 64-bit
       default: fp_rdata_o = {64{1'b0}};
     endcase

--- a/rtl/stage5/kronos_muldiv.sv
+++ b/rtl/stage5/kronos_muldiv.sv
@@ -41,10 +41,10 @@ module kronos_muldiv
   input  logic            rst_ni,
   input  logic            req_i,
   input  muldiv_op_e      op_i,
-  input  logic [XLEN-1:0] a_i,
-  input  logic [XLEN-1:0] b_i,
+  input  logic [kronos_pkg::XLEN-1:0] a_i,
+  input  logic [kronos_pkg::XLEN-1:0] b_i,
   input  logic            word_op_i,
-  output logic [XLEN-1:0] result_o,
+  output logic [kronos_pkg::XLEN-1:0] result_o,
   output logic            busy_o,
   output logic            valid_o,
   output logic            idle_o
@@ -53,9 +53,9 @@ module kronos_muldiv
   // -------------------------------------------------------------------------
   // 1. Constants
   // -------------------------------------------------------------------------
-  localparam logic [XLEN-1:0] ALL_ONES_64 = 64'hFFFF_FFFF_FFFF_FFFF;
-  localparam logic [XLEN-1:0] INT_MIN_64  = 64'h8000_0000_0000_0000;
-  localparam logic [XLEN-1:0] INT_MIN_32  = 64'hFFFF_FFFF_8000_0000;
+  localparam logic [kronos_pkg::XLEN-1:0] ALL_ONES_64 = 64'hFFFF_FFFF_FFFF_FFFF;
+  localparam logic [kronos_pkg::XLEN-1:0] INT_MIN_64  = 64'h8000_0000_0000_0000;
+  localparam logic [kronos_pkg::XLEN-1:0] INT_MIN_32  = 64'hFFFF_FFFF_8000_0000;
 
   // -------------------------------------------------------------------------
   // 2. Types
@@ -73,23 +73,23 @@ module kronos_muldiv
   // 3. State registers
   // -------------------------------------------------------------------------
   muldiv_state_e         state_q;
-  logic [XLEN-1:0]       result_q;
+  logic [kronos_pkg::XLEN-1:0]       result_q;
   // Multiplier pipeline registers.
   // Partial-product width: 65 (signed a) × 33 (signed b-half) = 98 bits signed.
   // The 65×65 signed multiply is decomposed into pp_hi = a × b[64:32]_signed
   // and pp_lo = a × {1'b0, b[31:0]} (the low half treated as positive), then
   // summed as (pp_hi << 32) + pp_lo in MUL_MID.
-  logic [XLEN:0]         mul_a65_q;
-  logic [XLEN:0]         mul_b65_q;
+  logic [kronos_pkg::XLEN:0]         mul_a65_q;
+  logic [kronos_pkg::XLEN:0]         mul_b65_q;
   logic signed [97:0]    pp_lo_q;
   logic signed [97:0]    pp_hi_q;
   logic signed [129:0]   mul_product_q;
   muldiv_op_e            op_q;
   // Divider registers (restoring division)
-  logic [XLEN-1:0]       dividend_q;   // left-shifted each step; MSB feeds remainder
-  logic [XLEN:0]         remainder_q;  // 65-bit partial remainder (extra bit for borrow)
-  logic [XLEN-1:0]       quotient_q;
-  logic [XLEN-1:0]       abs_b_q;
+  logic [kronos_pkg::XLEN-1:0]       dividend_q;   // left-shifted each step; MSB feeds remainder
+  logic [kronos_pkg::XLEN:0]         remainder_q;  // 65-bit partial remainder (extra bit for borrow)
+  logic [kronos_pkg::XLEN-1:0]       quotient_q;
+  logic [kronos_pkg::XLEN-1:0]       abs_b_q;
   logic [6:0]            count_q;      // counts down from 64 (or 32 for word_op)
   logic                  div_neg_q;    // negate quotient at end (signed DIV)
   logic                  rem_neg_q;    // negate remainder at end (signed REM)
@@ -102,44 +102,44 @@ module kronos_muldiv
   // Multiplier sign-extend / word-op shaping
   logic              mul_signed_a;
   logic              mul_signed_b;
-  logic [INST_W-1:0] mul_a_low;
-  logic [INST_W-1:0] mul_b_low;
+  logic [kronos_pkg::INST_W-1:0] mul_a_low;
+  logic [kronos_pkg::INST_W-1:0] mul_b_low;
   logic              mul_a_sign_bit;
   logic              mul_b_sign_bit;
-  logic [XLEN-1:0]   mul_a_eff;
-  logic [XLEN-1:0]   mul_b_eff;
-  logic [XLEN:0]     mul_a65;
-  logic [XLEN:0]     mul_b65;
+  logic [kronos_pkg::XLEN-1:0]   mul_a_eff;
+  logic [kronos_pkg::XLEN-1:0]   mul_b_eff;
+  logic [kronos_pkg::XLEN:0]     mul_a65;
+  logic [kronos_pkg::XLEN:0]     mul_b65;
 
   // MUL_OUT half-select
-  logic [XLEN-1:0]   mul_sel;
+  logic [kronos_pkg::XLEN-1:0]   mul_sel;
 
   // IDLE → division setup combinational signals
   logic              is_signed_div;
   logic              a_sign_bit;
   logic              b_sign_bit;
-  logic [XLEN-1:0]   a_eff;
-  logic [XLEN-1:0]   b_eff;
+  logic [kronos_pkg::XLEN-1:0]   a_eff;
+  logic [kronos_pkg::XLEN-1:0]   b_eff;
   logic              neg_a;
   logic              neg_b;
-  logic [XLEN-1:0]   abs_a;
-  logic [XLEN-1:0]   abs_b;
+  logic [kronos_pkg::XLEN-1:0]   abs_a;
+  logic [kronos_pkg::XLEN-1:0]   abs_b;
   logic              b_is_zero;
   logic              ov_div;
   logic              ov_rem;
-  logic [XLEN-1:0]   int_min;
+  logic [kronos_pkg::XLEN-1:0]   int_min;
 
   // Restoring-division step
-  logic [XLEN:0]     rem_shifted;
-  logic [XLEN:0]     rem_sub;
-  logic [XLEN-1:0]   div_shifted;
+  logic [kronos_pkg::XLEN:0]     rem_shifted;
+  logic [kronos_pkg::XLEN:0]     rem_sub;
+  logic [kronos_pkg::XLEN-1:0]   div_shifted;
 
   // Final-step divider result composition
-  logic [XLEN-1:0]   final_quot;
-  logic [XLEN-1:0]   final_rem;
-  logic [XLEN-1:0]   signed_quot;
-  logic [XLEN-1:0]   signed_rem;
-  logic [XLEN-1:0]   pre_result;
+  logic [kronos_pkg::XLEN-1:0]   final_quot;
+  logic [kronos_pkg::XLEN-1:0]   final_rem;
+  logic [kronos_pkg::XLEN-1:0]   signed_quot;
+  logic [kronos_pkg::XLEN-1:0]   signed_rem;
+  logic [kronos_pkg::XLEN-1:0]   pre_result;
 
   // -------------------------------------------------------------------------
   // Multiplier operand shaping
@@ -150,30 +150,30 @@ module kronos_muldiv
   assign mul_signed_b = (op_i == MULDIV_MUL) | (op_i == MULDIV_MULH);
 
   // For word_op, the effective operands are the low 32 bits, extended to 64.
-  assign mul_a_low = a_i[INST_W-1:0];
-  assign mul_b_low = b_i[INST_W-1:0];
-  assign mul_a_sign_bit = mul_signed_a ? mul_a_low[INST_W-1] : 1'b0;
-  assign mul_b_sign_bit = mul_signed_b ? mul_b_low[INST_W-1] : 1'b0;
+  assign mul_a_low = a_i[kronos_pkg::INST_W-1:0];
+  assign mul_b_low = b_i[kronos_pkg::INST_W-1:0];
+  assign mul_a_sign_bit = mul_signed_a ? mul_a_low[kronos_pkg::INST_W-1] : 1'b0;
+  assign mul_b_sign_bit = mul_signed_b ? mul_b_low[kronos_pkg::INST_W-1] : 1'b0;
 
-  assign mul_a_eff = word_op_i ? {{INST_W{mul_a_sign_bit}}, mul_a_low} : a_i;
-  assign mul_b_eff = word_op_i ? {{INST_W{mul_b_sign_bit}}, mul_b_low} : b_i;
+  assign mul_a_eff = word_op_i ? {{kronos_pkg::INST_W{mul_a_sign_bit}}, mul_a_low} : a_i;
+  assign mul_b_eff = word_op_i ? {{kronos_pkg::INST_W{mul_b_sign_bit}}, mul_b_low} : b_i;
 
   // Extend to 65 bits for signed/unsigned product.
-  assign mul_a65 = mul_signed_a ? {mul_a_eff[XLEN-1], mul_a_eff} : {1'b0, mul_a_eff};
-  assign mul_b65 = mul_signed_b ? {mul_b_eff[XLEN-1], mul_b_eff} : {1'b0, mul_b_eff};
+  assign mul_a65 = mul_signed_a ? {mul_a_eff[kronos_pkg::XLEN-1], mul_a_eff} : {1'b0, mul_a_eff};
+  assign mul_b65 = mul_signed_b ? {mul_b_eff[kronos_pkg::XLEN-1], mul_b_eff} : {1'b0, mul_b_eff};
 
   // -------------------------------------------------------------------------
   // MUL_OUT half-select
   // -------------------------------------------------------------------------
   always_comb begin
-    mul_sel = mul_product_q[XLEN-1:0];
+    mul_sel = mul_product_q[kronos_pkg::XLEN-1:0];
     unique case (op_q)
-      MULDIV_MUL:    mul_sel = mul_product_q[XLEN-1:0];
-      MULDIV_MULH:   mul_sel = mul_product_q[2*XLEN-1:XLEN];
-      MULDIV_MULHSU: mul_sel = mul_product_q[2*XLEN-1:XLEN];
-      MULDIV_MULHU:  mul_sel = mul_product_q[2*XLEN-1:XLEN];
+      MULDIV_MUL:    mul_sel = mul_product_q[kronos_pkg::XLEN-1:0];
+      MULDIV_MULH:   mul_sel = mul_product_q[2*kronos_pkg::XLEN-1:XLEN];
+      MULDIV_MULHSU: mul_sel = mul_product_q[2*kronos_pkg::XLEN-1:XLEN];
+      MULDIV_MULHU:  mul_sel = mul_product_q[2*kronos_pkg::XLEN-1:XLEN];
       // verilator coverage_off
-      default:       mul_sel = mul_product_q[XLEN-1:0];
+      default:       mul_sel = mul_product_q[kronos_pkg::XLEN-1:0];
       // verilator coverage_on
     endcase
   end
@@ -184,17 +184,17 @@ module kronos_muldiv
   assign is_signed_div = (op_i == MULDIV_DIV) | (op_i == MULDIV_REM);
 
   // Effective operands: low 32 bits sign-extended when word_op.
-  assign a_sign_bit = is_signed_div ? a_i[INST_W-1] : 1'b0;
-  assign b_sign_bit = is_signed_div ? b_i[INST_W-1] : 1'b0;
-  assign a_eff      = word_op_i ? {{INST_W{a_sign_bit}}, a_i[INST_W-1:0]} : a_i;
-  assign b_eff      = word_op_i ? {{INST_W{b_sign_bit}}, b_i[INST_W-1:0]} : b_i;
+  assign a_sign_bit = is_signed_div ? a_i[kronos_pkg::INST_W-1] : 1'b0;
+  assign b_sign_bit = is_signed_div ? b_i[kronos_pkg::INST_W-1] : 1'b0;
+  assign a_eff      = word_op_i ? {{kronos_pkg::INST_W{a_sign_bit}}, a_i[kronos_pkg::INST_W-1:0]} : a_i;
+  assign b_eff      = word_op_i ? {{kronos_pkg::INST_W{b_sign_bit}}, b_i[kronos_pkg::INST_W-1:0]} : b_i;
 
-  assign neg_a = is_signed_div & a_eff[XLEN-1];
-  assign neg_b = is_signed_div & b_eff[XLEN-1];
-  assign abs_a = neg_a ? (~a_eff + XLEN'(1)) : a_eff;
-  assign abs_b = neg_b ? (~b_eff + XLEN'(1)) : b_eff;
+  assign neg_a = is_signed_div & a_eff[kronos_pkg::XLEN-1];
+  assign neg_b = is_signed_div & b_eff[kronos_pkg::XLEN-1];
+  assign abs_a = neg_a ? (~a_eff + kronos_pkg::XLEN'(1)) : a_eff;
+  assign abs_b = neg_b ? (~b_eff + kronos_pkg::XLEN'(1)) : b_eff;
 
-  assign b_is_zero = (b_eff == XLEN'(0));
+  assign b_is_zero = (b_eff == kronos_pkg::XLEN'(0));
 
   assign int_min = word_op_i ? INT_MIN_32 : INT_MIN_64;
   assign ov_div  = (op_i == MULDIV_DIV) & (a_eff == int_min) & (b_eff == ALL_ONES_64);
@@ -203,22 +203,22 @@ module kronos_muldiv
   // -------------------------------------------------------------------------
   // Restoring-division step
   // -------------------------------------------------------------------------
-  assign rem_shifted = {remainder_q[XLEN-1:0], dividend_q[XLEN-1]};
+  assign rem_shifted = {remainder_q[kronos_pkg::XLEN-1:0], dividend_q[kronos_pkg::XLEN-1]};
   assign rem_sub     = rem_shifted - {1'b0, abs_b_q};
-  assign div_shifted = {dividend_q[XLEN-2:0], 1'b0};
+  assign div_shifted = {dividend_q[kronos_pkg::XLEN-2:0], 1'b0};
 
   // -------------------------------------------------------------------------
   // Final-step divider result composition (used in COMPUTE last cycle)
   // -------------------------------------------------------------------------
   always_comb begin
-    final_quot  = {quotient_q[XLEN-2:0], 1'b0};
-    final_rem   = rem_shifted[XLEN-1:0];
-    if (!rem_sub[XLEN]) begin
-      final_quot = {quotient_q[XLEN-2:0], 1'b1};
-      final_rem  = rem_sub[XLEN-1:0];
+    final_quot  = {quotient_q[kronos_pkg::XLEN-2:0], 1'b0};
+    final_rem   = rem_shifted[kronos_pkg::XLEN-1:0];
+    if (!rem_sub[kronos_pkg::XLEN]) begin
+      final_quot = {quotient_q[kronos_pkg::XLEN-2:0], 1'b1};
+      final_rem  = rem_sub[kronos_pkg::XLEN-1:0];
     end
-    signed_quot = div_neg_q ? (~final_quot + XLEN'(1)) : final_quot;
-    signed_rem  = rem_neg_q ? (~final_rem  + XLEN'(1)) : final_rem;
+    signed_quot = div_neg_q ? (~final_quot + kronos_pkg::XLEN'(1)) : final_quot;
+    signed_rem  = rem_neg_q ? (~final_rem  + kronos_pkg::XLEN'(1)) : final_rem;
     pre_result  = is_rem_q  ? signed_rem : signed_quot;
   end
 
@@ -237,17 +237,17 @@ module kronos_muldiv
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       state_q       <= IDLE;
-      result_q      <= {XLEN{1'b0}};
-      mul_a65_q     <= {(XLEN+1){1'b0}};
-      mul_b65_q     <= {(XLEN+1){1'b0}};
+      result_q      <= {kronos_pkg::XLEN{1'b0}};
+      mul_a65_q     <= {(kronos_pkg::XLEN+1){1'b0}};
+      mul_b65_q     <= {(kronos_pkg::XLEN+1){1'b0}};
       pp_lo_q       <= 98'sd0;
       pp_hi_q       <= 98'sd0;
-      mul_product_q <= {(2*XLEN+2){1'b0}};
+      mul_product_q <= {(2*kronos_pkg::XLEN+2){1'b0}};
       op_q          <= MULDIV_MUL;
-      dividend_q    <= {XLEN{1'b0}};
-      remainder_q   <= {(XLEN+1){1'b0}};
-      quotient_q    <= {XLEN{1'b0}};
-      abs_b_q       <= {XLEN{1'b0}};
+      dividend_q    <= {kronos_pkg::XLEN{1'b0}};
+      remainder_q   <= {(kronos_pkg::XLEN+1){1'b0}};
+      quotient_q    <= {kronos_pkg::XLEN{1'b0}};
+      abs_b_q       <= {kronos_pkg::XLEN{1'b0}};
       count_q       <= 7'b0;
       div_neg_q     <= 1'b0;
       rem_neg_q     <= 1'b0;
@@ -279,7 +279,7 @@ module kronos_muldiv
                   // For word_op the all-ones is naturally sign-extended.
                   if ((op_i == MULDIV_REM) | (op_i == MULDIV_REMU)) begin
                     result_q <= word_op_i
-                                ? {{INST_W{a_i[INST_W-1]}}, a_i[INST_W-1:0]}
+                                ? {{kronos_pkg::INST_W{a_i[kronos_pkg::INST_W-1]}}, a_i[kronos_pkg::INST_W-1:0]}
                                 : a_i;
                   end else begin
                     result_q <= ALL_ONES_64;
@@ -291,20 +291,20 @@ module kronos_muldiv
                   state_q  <= DONE;
                 end else if (ov_rem) begin
                   // Signed overflow: INT_MIN % -1 = 0
-                  result_q <= XLEN'(0);
+                  result_q <= kronos_pkg::XLEN'(0);
                   state_q  <= DONE;
                 end else begin
                   // Normal case: iterative restoring division.
                   // For word_op, left-align the 32-bit dividend into the
                   // upper 32 bits so the MSB-first shift consumes real bits.
-                  dividend_q  <= word_op_i ? {abs_a[INST_W-1:0], {INST_W{1'b0}}} : abs_a;
-                  remainder_q <= {(XLEN+1){1'b0}};
-                  quotient_q  <= {XLEN{1'b0}};
+                  dividend_q  <= word_op_i ? {abs_a[kronos_pkg::INST_W-1:0], {kronos_pkg::INST_W{1'b0}}} : abs_a;
+                  remainder_q <= {(kronos_pkg::XLEN+1){1'b0}};
+                  quotient_q  <= {kronos_pkg::XLEN{1'b0}};
                   abs_b_q     <= abs_b;
-                  div_neg_q   <= (op_i == MULDIV_DIV) & (a_eff[XLEN-1] ^ b_eff[XLEN-1]);
-                  rem_neg_q   <= (op_i == MULDIV_REM) & a_eff[XLEN-1];
+                  div_neg_q   <= (op_i == MULDIV_DIV) & (a_eff[kronos_pkg::XLEN-1] ^ b_eff[kronos_pkg::XLEN-1]);
+                  rem_neg_q   <= (op_i == MULDIV_REM) & a_eff[kronos_pkg::XLEN-1];
                   is_rem_q    <= (op_i == MULDIV_REM) | (op_i == MULDIV_REMU);
-                  count_q     <= word_op_i ? 7'(INST_W) : 7'(XLEN);
+                  count_q     <= word_op_i ? 7'(kronos_pkg::INST_W) : 7'(kronos_pkg::XLEN);
                   state_q     <= COMPUTE;
                 end
               end
@@ -322,8 +322,8 @@ module kronos_muldiv
         // (a × {1'b0, b[31:0]}) lets each partial fit in a short DSP48E2
         // cascade, keeping the logic depth per cycle under budget.
         MUL_IN: begin
-          pp_lo_q <= $signed(mul_a65_q) * $signed({1'b0, mul_b65_q[INST_W-1:0]});
-          pp_hi_q <= $signed(mul_a65_q) * $signed(mul_b65_q[XLEN:INST_W]);
+          pp_lo_q <= $signed(mul_a65_q) * $signed({1'b0, mul_b65_q[kronos_pkg::INST_W-1:0]});
+          pp_hi_q <= $signed(mul_a65_q) * $signed(mul_b65_q[kronos_pkg::XLEN:INST_W]);
           state_q <= MUL_MID;
         end
 
@@ -333,7 +333,7 @@ module kronos_muldiv
         // MSB of pp_hi_q lands in bit 129 of mul_product_q, the sign bit of
         // the 130-bit signed result.
         MUL_MID: begin
-          mul_product_q <= 130'($signed({pp_hi_q, {INST_W{1'b0}}})
+          mul_product_q <= 130'($signed({pp_hi_q, {kronos_pkg::INST_W{1'b0}}})
                                 + $signed({{33{pp_lo_q[97]}}, pp_lo_q}));
           state_q <= MUL_OUT;
         end
@@ -342,19 +342,19 @@ module kronos_muldiv
         // Pipeline stage 4: select result half and sign-extend to 64 bits.
         // Path: product register → mux → result_q. ~1.5 ns.
         MUL_OUT: begin
-          result_q <= word_op_q ? {{INST_W{mul_sel[INST_W-1]}}, mul_sel[INST_W-1:0]} : mul_sel;
+          result_q <= word_op_q ? {{kronos_pkg::INST_W{mul_sel[kronos_pkg::INST_W-1]}}, mul_sel[kronos_pkg::INST_W-1:0]} : mul_sel;
           state_q  <= DONE;
         end
 
         // ---------------------------------------------------------------
         COMPUTE: begin
           // One restoring-division step per cycle.
-          if (!rem_sub[XLEN]) begin
-            remainder_q <= {1'b0, rem_sub[XLEN-1:0]};
-            quotient_q  <= {quotient_q[XLEN-2:0], 1'b1};
+          if (!rem_sub[kronos_pkg::XLEN]) begin
+            remainder_q <= {1'b0, rem_sub[kronos_pkg::XLEN-1:0]};
+            quotient_q  <= {quotient_q[kronos_pkg::XLEN-2:0], 1'b1};
           end else begin
-            remainder_q <= {1'b0, rem_shifted[XLEN-1:0]};
-            quotient_q  <= {quotient_q[XLEN-2:0], 1'b0};
+            remainder_q <= {1'b0, rem_shifted[kronos_pkg::XLEN-1:0]};
+            quotient_q  <= {quotient_q[kronos_pkg::XLEN-2:0], 1'b0};
           end
           dividend_q <= div_shifted;
           count_q    <= count_q - 7'd1;
@@ -362,7 +362,7 @@ module kronos_muldiv
           if (count_q == 7'd1) begin
             // For word_op, sign-extend the low 32 bits of the result.
             result_q <= word_op_q
-                        ? {{INST_W{pre_result[INST_W-1]}}, pre_result[INST_W-1:0]}
+                        ? {{kronos_pkg::INST_W{pre_result[kronos_pkg::INST_W-1]}}, pre_result[kronos_pkg::INST_W-1:0]}
                         : pre_result;
             state_q  <= DONE;
           end

--- a/rtl/stage5/kronos_top.sv
+++ b/rtl/stage5/kronos_top.sv
@@ -906,9 +906,9 @@ module kronos_top
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_flush) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;
@@ -1237,18 +1237,18 @@ module kronos_top
   // mispredict=0x1E↔0x02) so the consolidated taxonomy table is contiguous.
   assign event_bus[18]    = 1'b0;
   assign event_bus[19]    = 1'b0;
-  assign event_bus[EVT_LOAD_USE_STALL]      = load_use_event;
-  assign event_bus[EVT_JALR_FWD_STALL]      = jalr_fwd_event;
-  assign event_bus[EVT_FP_RAW_STALL]        = fp_load_use_event;
-  assign event_bus[EVT_FRM_HAZARD_STALL]    = id_ex_is_frm_write & if_id_fp_dyn_rm;
-  assign event_bus[EVT_FP_INFLIGHT_STALL]   = fpu_stall;
-  assign event_bus[EVT_FENCE_I_DRAIN_STALL] = fence_i_active_q;
-  assign event_bus[EVT_MEM_BUSY_STALL]      = lsu_mem_stall | dcache_stall;
-  assign event_bus[EVT_MULDIV_STALL]        = muldiv_stall;
-  assign event_bus[EVT_FPU_STALL]           = fpu_busy_any;
-  assign event_bus[EVT_INSTR_FETCH_STALL]   = instr_fetch_stall;
-  assign event_bus[EVT_BRANCH_MISPREDICT]   = bpred_mispredict_pulse;
-  assign event_bus[EVT_EX_REDIRECT]         = ex_redirect;
+  assign event_bus[kronos_pkg::EVT_LOAD_USE_STALL]      = load_use_event;
+  assign event_bus[kronos_pkg::EVT_JALR_FWD_STALL]      = jalr_fwd_event;
+  assign event_bus[kronos_pkg::EVT_FP_RAW_STALL]        = fp_load_use_event;
+  assign event_bus[kronos_pkg::EVT_FRM_HAZARD_STALL]    = id_ex_is_frm_write & if_id_fp_dyn_rm;
+  assign event_bus[kronos_pkg::EVT_FP_INFLIGHT_STALL]   = fpu_stall;
+  assign event_bus[kronos_pkg::EVT_FENCE_I_DRAIN_STALL] = fence_i_active_q;
+  assign event_bus[kronos_pkg::EVT_MEM_BUSY_STALL]      = lsu_mem_stall | dcache_stall;
+  assign event_bus[kronos_pkg::EVT_MULDIV_STALL]        = muldiv_stall;
+  assign event_bus[kronos_pkg::EVT_FPU_STALL]           = fpu_busy_any;
+  assign event_bus[kronos_pkg::EVT_INSTR_FETCH_STALL]   = instr_fetch_stall;
+  assign event_bus[kronos_pkg::EVT_BRANCH_MISPREDICT]   = bpred_mispredict_pulse;
+  assign event_bus[kronos_pkg::EVT_EX_REDIRECT]         = ex_redirect;
 
   assign retire_valid_o      = retire_advance;
   assign retire_pc_o         = {32'b0, mem_wb_q.pc};

--- a/rtl/stage6/fpu/kronos_fpu_fadd.sv
+++ b/rtl/stage6/fpu/kronos_fpu_fadd.sv
@@ -209,17 +209,17 @@ module kronos_fpu_fadd
 
   // Double operand fields
   logic        a_d_sign, b_d_sign;
-  logic [FP_D_EXP_W-1:0]  a_d_expf, b_d_expf;
-  logic [FP_D_MANT_W-1:0] a_d_mant, b_d_mant;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]  a_d_expf, b_d_expf;
+  logic [kronos_pkg::FP_D_MANT_W-1:0] a_d_mant, b_d_mant;
   logic        a_d_zero, b_d_zero, a_d_inf, b_d_inf;
   logic        a_d_subn, b_d_subn;
   logic        a_d_snan, b_d_snan, a_d_qnan, b_d_qnan, a_d_nan, b_d_nan;
 
   // Unboxed single operands
-  logic [FP_S_TOTAL_W-1:0] a_s_bits, b_s_bits;
+  logic [kronos_pkg::FP_S_TOTAL_W-1:0] a_s_bits, b_s_bits;
   logic        a_s_sign, b_s_sign;
-  logic [FP_S_EXP_W-1:0]  a_s_expf, b_s_expf;
-  logic [FP_S_MANT_W-1:0] a_s_mant, b_s_mant;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]  a_s_expf, b_s_expf;
+  logic [kronos_pkg::FP_S_MANT_W-1:0] a_s_mant, b_s_mant;
   logic        a_s_zero, b_s_zero, a_s_inf, b_s_inf;
   logic        a_s_subn, b_s_subn;
   logic        a_s_snan, b_s_snan, a_s_qnan, b_s_qnan, a_s_nan, b_s_nan;
@@ -299,14 +299,14 @@ module kronos_fpu_fadd
   // ---------------------------------------------------------------------------
   // Combinational signals (Stage 5: pack)
   // ---------------------------------------------------------------------------
-  logic [FP_D_TOTAL_W-1:0] s5_result;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] s5_result;
   logic [4:0]              s5_flags;
   int unsigned             s5_mant_w;
   logic signed [EXP_W-1:0] s5_bias;
-  logic [FP_D_MANT_W-1:0]  s5_out_mant_d;
-  logic [FP_S_MANT_W-1:0]  s5_out_mant_s;
-  logic [FP_D_EXP_W-1:0]   s5_out_expf_d;
-  logic [FP_S_EXP_W-1:0]   s5_out_expf_s;
+  logic [kronos_pkg::FP_D_MANT_W-1:0]  s5_out_mant_d;
+  logic [kronos_pkg::FP_S_MANT_W-1:0]  s5_out_mant_s;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]   s5_out_expf_d;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]   s5_out_expf_s;
   logic                    s5_to_inf;
 
   // ===========================================================================
@@ -320,18 +320,18 @@ module kronos_fpu_fadd
     s1_both_zero_early   = 1'b0;
 
     // --- Double decomposition ---
-    a_d_sign = a_i[FP_D_TOTAL_W-1];
-    b_d_sign = b_i[FP_D_TOTAL_W-1];
-    a_d_expf = a_i[FP_D_TOTAL_W-2 -: FP_D_EXP_W];
-    b_d_expf = b_i[FP_D_TOTAL_W-2 -: FP_D_EXP_W];
-    a_d_mant = a_i[FP_D_MANT_W-1:0];
-    b_d_mant = b_i[FP_D_MANT_W-1:0];
-    a_d_zero = (a_d_expf == {FP_D_EXP_W{1'b0}}) && (a_d_mant == {FP_D_MANT_W{1'b0}});
-    b_d_zero = (b_d_expf == {FP_D_EXP_W{1'b0}}) && (b_d_mant == {FP_D_MANT_W{1'b0}});
-    a_d_inf  = (a_d_expf == FP_D_EXP_MAX) && (a_d_mant == {FP_D_MANT_W{1'b0}});
-    b_d_inf  = (b_d_expf == FP_D_EXP_MAX) && (b_d_mant == {FP_D_MANT_W{1'b0}});
-    a_d_subn = (a_d_expf == {FP_D_EXP_W{1'b0}}) && (a_d_mant != {FP_D_MANT_W{1'b0}});
-    b_d_subn = (b_d_expf == {FP_D_EXP_W{1'b0}}) && (b_d_mant != {FP_D_MANT_W{1'b0}});
+    a_d_sign = a_i[kronos_pkg::FP_D_TOTAL_W-1];
+    b_d_sign = b_i[kronos_pkg::FP_D_TOTAL_W-1];
+    a_d_expf = a_i[kronos_pkg::FP_D_TOTAL_W-2 -: kronos_pkg::FP_D_EXP_W];
+    b_d_expf = b_i[kronos_pkg::FP_D_TOTAL_W-2 -: kronos_pkg::FP_D_EXP_W];
+    a_d_mant = a_i[kronos_pkg::FP_D_MANT_W-1:0];
+    b_d_mant = b_i[kronos_pkg::FP_D_MANT_W-1:0];
+    a_d_zero = (a_d_expf == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (a_d_mant == {kronos_pkg::FP_D_MANT_W{1'b0}});
+    b_d_zero = (b_d_expf == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (b_d_mant == {kronos_pkg::FP_D_MANT_W{1'b0}});
+    a_d_inf  = (a_d_expf == kronos_pkg::FP_D_EXP_MAX) && (a_d_mant == {kronos_pkg::FP_D_MANT_W{1'b0}});
+    b_d_inf  = (b_d_expf == kronos_pkg::FP_D_EXP_MAX) && (b_d_mant == {kronos_pkg::FP_D_MANT_W{1'b0}});
+    a_d_subn = (a_d_expf == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (a_d_mant != {kronos_pkg::FP_D_MANT_W{1'b0}});
+    b_d_subn = (b_d_expf == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (b_d_mant != {kronos_pkg::FP_D_MANT_W{1'b0}});
     a_d_snan = is_snan_d(a_i);
     b_d_snan = is_snan_d(b_i);
     a_d_qnan = is_qnan_d(a_i);
@@ -340,22 +340,22 @@ module kronos_fpu_fadd
     b_d_nan  = b_d_snan || b_d_qnan;
 
     // --- Single decomposition (with NaN-unbox) ---
-    a_s_bits = (a_i[FP_D_TOTAL_W-1:FP_S_TOTAL_W] == FP_NANBOX_UPPER)
-                 ? a_i[FP_S_TOTAL_W-1:0] : FP_CANON_QNAN_S;
-    b_s_bits = (b_i[FP_D_TOTAL_W-1:FP_S_TOTAL_W] == FP_NANBOX_UPPER)
-                 ? b_i[FP_S_TOTAL_W-1:0] : FP_CANON_QNAN_S;
-    a_s_sign = a_s_bits[FP_S_TOTAL_W-1];
-    b_s_sign = b_s_bits[FP_S_TOTAL_W-1];
-    a_s_expf = a_s_bits[FP_S_TOTAL_W-2 -: FP_S_EXP_W];
-    b_s_expf = b_s_bits[FP_S_TOTAL_W-2 -: FP_S_EXP_W];
-    a_s_mant = a_s_bits[FP_S_MANT_W-1:0];
-    b_s_mant = b_s_bits[FP_S_MANT_W-1:0];
-    a_s_zero = (a_s_expf == {FP_S_EXP_W{1'b0}}) && (a_s_mant == {FP_S_MANT_W{1'b0}});
-    b_s_zero = (b_s_expf == {FP_S_EXP_W{1'b0}}) && (b_s_mant == {FP_S_MANT_W{1'b0}});
-    a_s_inf  = (a_s_expf == FP_S_EXP_MAX) && (a_s_mant == {FP_S_MANT_W{1'b0}});
-    b_s_inf  = (b_s_expf == FP_S_EXP_MAX) && (b_s_mant == {FP_S_MANT_W{1'b0}});
-    a_s_subn = (a_s_expf == {FP_S_EXP_W{1'b0}}) && (a_s_mant != {FP_S_MANT_W{1'b0}});
-    b_s_subn = (b_s_expf == {FP_S_EXP_W{1'b0}}) && (b_s_mant != {FP_S_MANT_W{1'b0}});
+    a_s_bits = (a_i[kronos_pkg::FP_D_TOTAL_W-1:FP_S_TOTAL_W] == kronos_pkg::FP_NANBOX_UPPER)
+                 ? a_i[kronos_pkg::FP_S_TOTAL_W-1:0] : kronos_pkg::FP_CANON_QNAN_S;
+    b_s_bits = (b_i[kronos_pkg::FP_D_TOTAL_W-1:FP_S_TOTAL_W] == kronos_pkg::FP_NANBOX_UPPER)
+                 ? b_i[kronos_pkg::FP_S_TOTAL_W-1:0] : kronos_pkg::FP_CANON_QNAN_S;
+    a_s_sign = a_s_bits[kronos_pkg::FP_S_TOTAL_W-1];
+    b_s_sign = b_s_bits[kronos_pkg::FP_S_TOTAL_W-1];
+    a_s_expf = a_s_bits[kronos_pkg::FP_S_TOTAL_W-2 -: kronos_pkg::FP_S_EXP_W];
+    b_s_expf = b_s_bits[kronos_pkg::FP_S_TOTAL_W-2 -: kronos_pkg::FP_S_EXP_W];
+    a_s_mant = a_s_bits[kronos_pkg::FP_S_MANT_W-1:0];
+    b_s_mant = b_s_bits[kronos_pkg::FP_S_MANT_W-1:0];
+    a_s_zero = (a_s_expf == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (a_s_mant == {kronos_pkg::FP_S_MANT_W{1'b0}});
+    b_s_zero = (b_s_expf == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (b_s_mant == {kronos_pkg::FP_S_MANT_W{1'b0}});
+    a_s_inf  = (a_s_expf == kronos_pkg::FP_S_EXP_MAX) && (a_s_mant == {kronos_pkg::FP_S_MANT_W{1'b0}});
+    b_s_inf  = (b_s_expf == kronos_pkg::FP_S_EXP_MAX) && (b_s_mant == {kronos_pkg::FP_S_MANT_W{1'b0}});
+    a_s_subn = (a_s_expf == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (a_s_mant != {kronos_pkg::FP_S_MANT_W{1'b0}});
+    b_s_subn = (b_s_expf == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (b_s_mant != {kronos_pkg::FP_S_MANT_W{1'b0}});
     a_s_snan = is_snan_s(a_s_bits);
     b_s_snan = is_snan_s(b_s_bits);
     a_s_qnan = is_qnan_s(a_s_bits);
@@ -377,9 +377,9 @@ module kronos_fpu_fadd
       b_snan_sel  = b_d_snan;
       // Unbiased exponent: subnormal uses exp=1-bias, hidden bit = 0.
       a_exp_sel = a_d_subn ? -13'sd1022
-                           : (13'(a_d_expf) - 13'(FP_D_BIAS));
+                           : (13'(a_d_expf) - 13'(kronos_pkg::FP_D_BIAS));
       b_exp_sel = b_d_subn ? -13'sd1022
-                           : (13'(b_d_expf) - 13'(FP_D_BIAS));
+                           : (13'(b_d_expf) - 13'(kronos_pkg::FP_D_BIAS));
       // Hidden bit: 0 for subnormal/zero, 1 otherwise.
       a_sig_sel = {(a_d_subn || a_d_zero) ? 1'b0 : 1'b1, a_d_mant, 3'd0};
       b_sig_sel = {(b_d_subn || b_d_zero) ? 1'b0 : 1'b1, b_d_mant, 3'd0};
@@ -395,15 +395,15 @@ module kronos_fpu_fadd
       a_snan_sel  = a_s_snan;
       b_snan_sel  = b_s_snan;
       a_exp_sel = a_s_subn ? -13'sd126
-                           : (13'(a_s_expf) - 13'(FP_S_BIAS));
+                           : (13'(a_s_expf) - 13'(kronos_pkg::FP_S_BIAS));
       b_exp_sel = b_s_subn ? -13'sd126
-                           : (13'(b_s_expf) - 13'(FP_S_BIAS));
+                           : (13'(b_s_expf) - 13'(kronos_pkg::FP_S_BIAS));
       // Left-justify a 24-bit significand into SIG_W (56-bit) field.
       // For S, 53-bit equivalent: put the 24 bits at the top, zeros below.
       a_sig_sel = {(a_s_subn || a_s_zero) ? 1'b0 : 1'b1, a_s_mant,
-                   {(SIG_W-1-FP_S_MANT_W){1'b0}}};
+                   {(SIG_W-1-kronos_pkg::FP_S_MANT_W){1'b0}}};
       b_sig_sel = {(b_s_subn || b_s_zero) ? 1'b0 : 1'b1, b_s_mant,
-                   {(SIG_W-1-FP_S_MANT_W){1'b0}}};
+                   {(SIG_W-1-kronos_pkg::FP_S_MANT_W){1'b0}}};
     end
 
     // FSUB: logical sign flip on b at this stage.
@@ -440,33 +440,33 @@ module kronos_fpu_fadd
     s1_both_zero_early   = a_zero_sel && b_zero_sel;
 
     s1_d.is_special  = 1'b0;
-    s1_d.special_res = {FP_D_TOTAL_W{1'b0}};
+    s1_d.special_res = {kronos_pkg::FP_D_TOTAL_W{1'b0}};
     s1_d.special_flg = 5'd0;
 
     if (a_nan_sel || b_nan_sel) begin
       s1_d.is_special  = 1'b1;
-      s1_d.special_res = fmt_d_i ? FP_CANON_QNAN_D
-                                 : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s1_d.special_res = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                 : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
       if (a_snan_sel || b_snan_sel) begin
-        s1_d.special_flg[FP_FFLAG_NV] = 1'b1;
+        s1_d.special_flg[kronos_pkg::FP_FFLAG_NV] = 1'b1;
       end
     end else if (s1_both_inf_opposite) begin
       s1_d.is_special  = 1'b1;
-      s1_d.special_res = fmt_d_i ? FP_CANON_QNAN_D
-                                 : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_d.special_flg[FP_FFLAG_NV] = 1'b1;
+      s1_d.special_res = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                 : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_d.special_flg[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if (a_inf_sel || b_inf_sel) begin
       s1_d.is_special = 1'b1;
       // Propagate the infinity that's present; same sign as it (b sign already
       // flipped for FSUB).
       if (a_inf_sel) begin
         s1_d.special_res = fmt_d_i
-            ? {a_sign_sel, FP_D_EXP_MAX, {FP_D_MANT_W{1'b0}}}
-            : {FP_NANBOX_UPPER, a_sign_sel, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
+            ? {a_sign_sel, kronos_pkg::FP_D_EXP_MAX, {kronos_pkg::FP_D_MANT_W{1'b0}}}
+            : {kronos_pkg::FP_NANBOX_UPPER, a_sign_sel, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
       end else begin
         s1_d.special_res = fmt_d_i
-            ? {b_sign_pre, FP_D_EXP_MAX, {FP_D_MANT_W{1'b0}}}
-            : {FP_NANBOX_UPPER, b_sign_pre, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
+            ? {b_sign_pre, kronos_pkg::FP_D_EXP_MAX, {kronos_pkg::FP_D_MANT_W{1'b0}}}
+            : {kronos_pkg::FP_NANBOX_UPPER, b_sign_pre, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
       end
     end else if (s1_both_zero_early) begin
       // 0 + 0: sign(result) = sign(a) & sign(b) for eff_sub=0; else for RDN,
@@ -480,8 +480,8 @@ module kronos_fpu_fadd
         s1_zero_sign = (rm_i == FP_RM_RDN);
       end
       s1_d.special_res = fmt_d_i
-          ? {s1_zero_sign, {(FP_D_TOTAL_W-1){1'b0}}}
-          : {FP_NANBOX_UPPER, s1_zero_sign, {(FP_S_TOTAL_W-1){1'b0}}};
+          ? {s1_zero_sign, {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}}
+          : {kronos_pkg::FP_NANBOX_UPPER, s1_zero_sign, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
     end
   end
 
@@ -692,10 +692,10 @@ module kronos_fpu_fadd
 
     if (!s3_q.is_special && !s3_q.result_zero) begin
       if (s3_q.fmt_d) begin
-        s3b_mant_w = FP_D_MANT_W;
+        s3b_mant_w = kronos_pkg::FP_D_MANT_W;
         s3b_emin   = -13'sd1022;
       end else begin
-        s3b_mant_w = FP_S_MANT_W;
+        s3b_mant_w = kronos_pkg::FP_S_MANT_W;
         s3b_emin   = -13'sd126;
       end
 
@@ -725,7 +725,7 @@ module kronos_fpu_fadd
       if (!s3_q.fmt_d) begin
         s3b_g  = s3b_cur_sig[SIG_W - 1 - s3b_mant_w - 1];
         s3b_r  = s3b_cur_sig[SIG_W - 1 - s3b_mant_w - 2];
-        for (int i = 0; i < SIG_W - 1 - FP_S_MANT_W - 2; i++)
+        for (int i = 0; i < SIG_W - 1 - kronos_pkg::FP_S_MANT_W - 2; i++)
           if (i < SIG_W - 1 - s3b_mant_w - 2) begin
             if (s3b_cur_sig[i]) s3b_st = 1'b1;
           end
@@ -768,11 +768,11 @@ module kronos_fpu_fadd
 
     if (!s3b_q.is_special && !s3b_q.result_zero) begin
       if (s3b_q.fmt_d) begin
-        s4_mant_w = FP_D_MANT_W;
-        s4_emax   = 13'(FP_D_BIAS);
+        s4_mant_w = kronos_pkg::FP_D_MANT_W;
+        s4_emax   = 13'(kronos_pkg::FP_D_BIAS);
       end else begin
-        s4_mant_w = FP_S_MANT_W;
-        s4_emax   = 13'(FP_S_BIAS);
+        s4_mant_w = kronos_pkg::FP_S_MANT_W;
+        s4_emax   = 13'(kronos_pkg::FP_S_BIAS);
       end
 
       s4_cur_exp = s3b_q.cur_exp;
@@ -816,34 +816,34 @@ module kronos_fpu_fadd
   // ===========================================================================
   always_comb begin
     // Defaults
-    s5_result     = {FP_D_TOTAL_W{1'b0}};
+    s5_result     = {kronos_pkg::FP_D_TOTAL_W{1'b0}};
     s5_flags      = 5'd0;
     s5_mant_w     = 32'd0;
     s5_bias       = {EXP_W{1'b0}};
-    s5_out_mant_d = {FP_D_MANT_W{1'b0}};
-    s5_out_mant_s = {FP_S_MANT_W{1'b0}};
-    s5_out_expf_d = {FP_D_EXP_W{1'b0}};
-    s5_out_expf_s = {FP_S_EXP_W{1'b0}};
+    s5_out_mant_d = {kronos_pkg::FP_D_MANT_W{1'b0}};
+    s5_out_mant_s = {kronos_pkg::FP_S_MANT_W{1'b0}};
+    s5_out_expf_d = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    s5_out_expf_s = {kronos_pkg::FP_S_EXP_W{1'b0}};
     s5_to_inf     = 1'b0;
 
     if (s4_q.is_special) begin
       s5_result = s4_q.special_res;
       s5_flags  = s4_q.special_flg;
     end else if (s4_q.result_zero) begin
-      if (s4_q.fmt_d) s5_result = {s4_q.res_sign, {(FP_D_TOTAL_W-1){1'b0}}};
-      else            s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, {(FP_S_TOTAL_W-1){1'b0}}};
+      if (s4_q.fmt_d) s5_result = {s4_q.res_sign, {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}};
+      else            s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
     end else begin
       if (s4_q.fmt_d) begin
-        s5_mant_w = FP_D_MANT_W;
-        s5_bias   = 13'(FP_D_BIAS);
+        s5_mant_w = kronos_pkg::FP_D_MANT_W;
+        s5_bias   = 13'(kronos_pkg::FP_D_BIAS);
       end else begin
-        s5_mant_w = FP_S_MANT_W;
-        s5_bias   = 13'(FP_S_BIAS);
+        s5_mant_w = kronos_pkg::FP_S_MANT_W;
+        s5_bias   = 13'(kronos_pkg::FP_S_BIAS);
       end
 
       if (s4_q.overflow) begin
-        s5_flags[FP_FFLAG_OF] = 1'b1;
-        s5_flags[FP_FFLAG_NX] = 1'b1;
+        s5_flags[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+        s5_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
         unique case (s4_q.rm)
           FP_RM_RNE: s5_to_inf = 1'b1;
           FP_RM_RTZ: s5_to_inf = 1'b0;
@@ -853,29 +853,29 @@ module kronos_fpu_fadd
           default:   s5_to_inf = 1'b1;
         endcase
         if (s4_q.fmt_d) begin
-          if (s5_to_inf) s5_result = {s4_q.res_sign, FP_D_EXP_MAX, {FP_D_MANT_W{1'b0}}};
-          else           s5_result = {s4_q.res_sign, 11'h7FE, {FP_D_MANT_W{1'b1}}};
+          if (s5_to_inf) s5_result = {s4_q.res_sign, kronos_pkg::FP_D_EXP_MAX, {kronos_pkg::FP_D_MANT_W{1'b0}}};
+          else           s5_result = {s4_q.res_sign, 11'h7FE, {kronos_pkg::FP_D_MANT_W{1'b1}}};
         end else begin
-          if (s5_to_inf) s5_result = {FP_NANBOX_UPPER, s4_q.res_sign,
-                                      FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
-          else           s5_result = {FP_NANBOX_UPPER, s4_q.res_sign,
-                                      8'hFE, {FP_S_MANT_W{1'b1}}};
+          if (s5_to_inf) s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign,
+                                      kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
+          else           s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign,
+                                      8'hFE, {kronos_pkg::FP_S_MANT_W{1'b1}}};
         end
       end else begin
         if (s4_q.fmt_d) begin
-          s5_out_mant_d = s4_q.rounded_sig[SIG_W-2 -: FP_D_MANT_W];
-          if (s4_q.is_subnormal_out) s5_out_expf_d = {FP_D_EXP_W{1'b0}};
+          s5_out_mant_d = s4_q.rounded_sig[SIG_W-2 -: kronos_pkg::FP_D_MANT_W];
+          if (s4_q.is_subnormal_out) s5_out_expf_d = {kronos_pkg::FP_D_EXP_W{1'b0}};
           else                       s5_out_expf_d = 11'(s4_q.cur_exp + s5_bias);
           s5_result = {s4_q.res_sign, s5_out_expf_d, s5_out_mant_d};
         end else begin
-          s5_out_mant_s = s4_q.rounded_sig[SIG_W-2 -: FP_S_MANT_W];
-          if (s4_q.is_subnormal_out) s5_out_expf_s = {FP_S_EXP_W{1'b0}};
+          s5_out_mant_s = s4_q.rounded_sig[SIG_W-2 -: kronos_pkg::FP_S_MANT_W];
+          if (s4_q.is_subnormal_out) s5_out_expf_s = {kronos_pkg::FP_S_EXP_W{1'b0}};
           else                       s5_out_expf_s = 8'(s4_q.cur_exp + s5_bias);
-          s5_result = {FP_NANBOX_UPPER, s4_q.res_sign, s5_out_expf_s, s5_out_mant_s};
+          s5_result = {kronos_pkg::FP_NANBOX_UPPER, s4_q.res_sign, s5_out_expf_s, s5_out_mant_s};
         end
 
-        if (s4_q.inexact) s5_flags[FP_FFLAG_NX] = 1'b1;
-        if (s4_q.is_subnormal_out && s4_q.inexact) s5_flags[FP_FFLAG_UF] = 1'b1;
+        if (s4_q.inexact) s5_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
+        if (s4_q.is_subnormal_out && s4_q.inexact) s5_flags[kronos_pkg::FP_FFLAG_UF] = 1'b1;
       end
     end
   end
@@ -912,7 +912,7 @@ module kronos_fpu_fadd
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       out_valid_o <= 1'b0;
-      result_o    <= {FP_D_TOTAL_W{1'b0}};
+      result_o    <= {kronos_pkg::FP_D_TOTAL_W{1'b0}};
       fflags_o    <= 5'd0;
       tag_o       <= fpu_tag_t'({($bits(fpu_tag_t)){1'b0}});
     end else begin

--- a/rtl/stage6/fpu/kronos_fpu_fcvt.sv
+++ b/rtl/stage6/fpu/kronos_fpu_fcvt.sv
@@ -23,10 +23,10 @@ module kronos_fpu_fcvt
   input  fp_op_e          op_i,
   input  logic            fmt_d_i,
   input  logic [2:0]      rm_i,
-  input  logic [FLEN-1:0] a_i,
+  input  logic [kronos_pkg::FLEN-1:0] a_i,
   input  fpu_tag_t        tag_i,
   output logic            out_valid_o,
-  output logic [FLEN-1:0] result_o,
+  output logic [kronos_pkg::FLEN-1:0] result_o,
   output logic [4:0]      fflags_o,
   output fpu_tag_t        tag_o
 );
@@ -34,12 +34,12 @@ module kronos_fpu_fcvt
   // ---------------------------------------------------------------------------
   // Helper: count leading zeros (parameterised)
   // ---------------------------------------------------------------------------
-  function automatic integer clz64(input logic [XLEN-1:0] x);
+  function automatic integer clz64(input logic [kronos_pkg::XLEN-1:0] x);
     integer i;
-    clz64 = XLEN;
-    for (i = XLEN-1; i >= 0; i = i - 1) begin
-      if (x[i] && (clz64 == XLEN)) begin
-        clz64 = (XLEN-1) - i;
+    clz64 = kronos_pkg::XLEN;
+    for (i = kronos_pkg::XLEN-1; i >= 0; i = i - 1) begin
+      if (x[i] && (clz64 == kronos_pkg::XLEN)) begin
+        clz64 = (kronos_pkg::XLEN-1) - i;
       end
     end
   endfunction
@@ -52,7 +52,7 @@ module kronos_fpu_fcvt
   fp_op_e          s1_op_q;
   logic            s1_fmt_d_q;
   logic [2:0]      s1_rm_q;
-  logic [FLEN-1:0] s1_a_q;
+  logic [kronos_pkg::FLEN-1:0] s1_a_q;
   fpu_tag_t        s1_tag_q;
 
   // Stage-2 control
@@ -64,10 +64,10 @@ module kronos_fpu_fcvt
   // Stage-2 INT->FP intermediate (carry chain before the rounding adder)
   logic                  s2_ifp_isneg_q;
   logic                  s2_ifp_imag_zero_q;
-  logic [FP_S_EXP_W-1:0] s2_ifp_s_exp_q;
-  logic [FP_D_EXP_W-1:0] s2_ifp_d_exp_q;
-  logic [FP_S_MANT_W:0]  s2_ifp_s_mant_pre_q;  // 24 bits: implicit 1 + 23 fractional
-  logic [FP_D_MANT_W:0]  s2_ifp_d_mant_pre_q;  // 53 bits: implicit 1 + 52 fractional
+  logic [kronos_pkg::FP_S_EXP_W-1:0] s2_ifp_s_exp_q;
+  logic [kronos_pkg::FP_D_EXP_W-1:0] s2_ifp_d_exp_q;
+  logic [kronos_pkg::FP_S_MANT_W:0]  s2_ifp_s_mant_pre_q;  // 24 bits: implicit 1 + 23 fractional
+  logic [kronos_pkg::FP_D_MANT_W:0]  s2_ifp_d_mant_pre_q;  // 53 bits: implicit 1 + 52 fractional
   logic                  s2_ifp_s_round_up_q;
   logic                  s2_ifp_d_round_up_q;
   logic                  s2_ifp_s_inexact_q;
@@ -80,20 +80,20 @@ module kronos_fpu_fcvt
   logic            s2_fpi_src_sign_q;
   logic            s2_fpi_target_is_32b_q;
   logic            s2_fpi_target_is_signed_q;
-  logic [XLEN-1:0] s2_fpi_target_max_q;
-  logic [XLEN-1:0] s2_fpi_target_min_q;
-  logic [XLEN-1:0] s2_fpi_int_part_q;
+  logic [kronos_pkg::XLEN-1:0] s2_fpi_target_max_q;
+  logic [kronos_pkg::XLEN-1:0] s2_fpi_target_min_q;
+  logic [kronos_pkg::XLEN-1:0] s2_fpi_int_part_q;
   logic            s2_fpi_round_up_q;
   logic            s2_fpi_is_inexact_q;
 
   // Stage-2 S<->D full result (no long carry chains; computed in stage 2)
-  logic [FP_D_TOTAL_W-1:0] s2_ds_result_q;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] s2_ds_result_q;
   logic [4:0]              s2_ds_fflags_q;
 
   // ---------------------------------------------------------------------------
   // Stage-1 combinational (NaN-unbox single-precision inputs)
   // ---------------------------------------------------------------------------
-  logic [FLEN-1:0] s1_a_d;
+  logic [kronos_pkg::FLEN-1:0] s1_a_d;
   logic            s1_src_is_single;
 
   // ---------------------------------------------------------------------------
@@ -101,12 +101,12 @@ module kronos_fpu_fcvt
   // ---------------------------------------------------------------------------
   logic                    src_sign;
   logic                    src_is_s;
-  logic [FP_S_TOTAL_W-1:0] src_s;
-  logic [FP_D_TOTAL_W-1:0] src_d;
-  logic [FP_D_EXP_W-1:0]   src_exp_d;
-  logic [FP_D_MANT_W-1:0]  src_mant_d;
-  logic [FP_S_EXP_W-1:0]   src_exp_s;
-  logic [FP_S_MANT_W-1:0]  src_mant_s;
+  logic [kronos_pkg::FP_S_TOTAL_W-1:0] src_s;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] src_d;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]   src_exp_d;
+  logic [kronos_pkg::FP_D_MANT_W-1:0]  src_mant_d;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]   src_exp_s;
+  logic [kronos_pkg::FP_S_MANT_W-1:0]  src_mant_s;
   logic                    src_is_nan;
   logic                    src_is_inf;
   logic                    src_is_zero;
@@ -115,41 +115,41 @@ module kronos_fpu_fcvt
   // Stage-2 combinational: FP -> INT (compute int_part and round_up;
   //                                    int_rounded adder deferred to stage 3)
   // ---------------------------------------------------------------------------
-  logic signed [FP_EXP_EXT_W-1:0] unbiased_exp;
-  logic [XLEN-1:0]                int_part;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] unbiased_exp;
+  logic [kronos_pkg::XLEN-1:0]                int_part;
   logic                           rnd_g;
   logic                           rnd_s;
   logic                           rnd_lsb;
   logic                           fpi_round_up;
   logic                           is_inexact_fpi;
-  logic [XLEN-1:0]                target_max;
-  logic [XLEN-1:0]                target_min;
+  logic [kronos_pkg::XLEN-1:0]                target_max;
+  logic [kronos_pkg::XLEN-1:0]                target_min;
   logic                           target_is_signed;
   logic                           target_is_32b;
   logic                           fpi_overflow;
   logic                           fpi_neg_of;
-  logic [XLEN-1:0]                sig64;
-  logic [XLEN-1:0]                frac_mask;
+  logic [kronos_pkg::XLEN-1:0]                sig64;
+  logic [kronos_pkg::XLEN-1:0]                frac_mask;
   logic [6:0]                     shift_r;
-  logic [FP_S_EXP_W-1:0]          frac_bits;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]          frac_bits;
 
   // ---------------------------------------------------------------------------
   // Stage-2 combinational: INT -> FP
   // ---------------------------------------------------------------------------
   logic                  ifp_isneg;
   logic                  ifp_imag_zero;
-  logic [FP_S_EXP_W-1:0] ifp_s_exp;
-  logic [FP_D_EXP_W-1:0] ifp_d_exp;
-  logic [FP_S_MANT_W:0]  ifp_s_mant_pre;
-  logic [FP_D_MANT_W:0]  ifp_d_mant_pre;
+  logic [kronos_pkg::FP_S_EXP_W-1:0] ifp_s_exp;
+  logic [kronos_pkg::FP_D_EXP_W-1:0] ifp_d_exp;
+  logic [kronos_pkg::FP_S_MANT_W:0]  ifp_s_mant_pre;
+  logic [kronos_pkg::FP_D_MANT_W:0]  ifp_d_mant_pre;
   logic                  ifp_s_round_up;
   logic                  ifp_d_round_up;
   logic                  ifp_s_inexact;
   logic                  ifp_d_inexact;
-  logic [XLEN-1:0]       ifp_imag;
+  logic [kronos_pkg::XLEN-1:0]       ifp_imag;
   logic                  ifp_isigned;
   logic                  ifp_is32;
-  logic [XLEN-1:0]       ifp_norm;
+  logic [kronos_pkg::XLEN-1:0]       ifp_norm;
   integer                ifp_lz;
   logic                  s_guard;
   logic                  s_round_sticky;
@@ -161,61 +161,61 @@ module kronos_fpu_fcvt
   // ---------------------------------------------------------------------------
   // Stage-2 combinational: S <-> D format conversion
   // ---------------------------------------------------------------------------
-  logic [FP_D_TOTAL_W-1:0] s2c_ds_d;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] s2c_ds_d;
   logic [4:0]              s2c_ds_fflags_d;
-  logic [FP_D_TOTAL_W-1:0] d_result;
-  logic [FP_S_TOTAL_W-1:0] s_result;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] d_result;
+  logic [kronos_pkg::FP_S_TOTAL_W-1:0] s_result;
   logic [4:0]              fs_flags;
   logic                    sd_sign;
-  logic [FP_S_EXP_W-1:0]   sd_sexp;
-  logic [FP_S_MANT_W-1:0]  sd_smant;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]   sd_sexp;
+  logic [kronos_pkg::FP_S_MANT_W-1:0]  sd_smant;
   // D->S
   logic                           ds_sign;
-  logic [FP_D_EXP_W-1:0]          ds_dexp;
-  logic [FP_D_MANT_W-1:0]         ds_dmant;
-  logic signed [FP_EXP_EXT_W-1:0] ds_unbiased;
-  logic [FP_S_EXP_W-1:0]          ds_sexp_out;
-  logic [FP_S_MANT_W:0]           ds_sig;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]          ds_dexp;
+  logic [kronos_pkg::FP_D_MANT_W-1:0]         ds_dmant;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] ds_unbiased;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]          ds_sexp_out;
+  logic [kronos_pkg::FP_S_MANT_W:0]           ds_sig;
   logic                           ds_g;
   logic                           ds_sticky;
   logic                           ds_lsb;
   logic                           ds_round_up;
-  logic [FP_S_MANT_W+1:0]         ds_rounded;
+  logic [kronos_pkg::FP_S_MANT_W+1:0]         ds_rounded;
   logic [9:0]                     subn_shift_amt;
-  logic [FP_S_MANT_W:0]           subn_sig24;
-  logic [FP_S_MANT_W:0]           subn_sig;
+  logic [kronos_pkg::FP_S_MANT_W:0]           subn_sig24;
+  logic [kronos_pkg::FP_S_MANT_W:0]           subn_sig;
   logic                           subn_g;
   logic                           subn_sticky;
   logic                           subn_round_up;
-  logic [FP_S_MANT_W:0]           subn_rounded;
-  logic [FP_S_MANT_W-1:0]         subn_mant;
-  logic [FP_S_EXP_W-1:0]          subn_exp;
+  logic [kronos_pkg::FP_S_MANT_W:0]           subn_rounded;
+  logic [kronos_pkg::FP_S_MANT_W-1:0]         subn_mant;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]          subn_exp;
   // Subnormal S->D normalisation (used in FP_FCVT_D_S)
   integer                         sd_k;
-  logic [FP_S_MANT_W-1:0]         sd_m;
+  logic [kronos_pkg::FP_S_MANT_W-1:0]         sd_m;
   integer                         sd_shift_amt;
   logic                           sd_found_k;
-  logic [FP_D_MANT_W:0]           sd_new_mant;
-  logic [FP_D_EXP_W-1:0]          sd_new_exp;
+  logic [kronos_pkg::FP_D_MANT_W:0]           sd_new_mant;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]          sd_new_exp;
   // Underflow flag intermediate (FP_FCVT_S_D normal-zero path)
   logic                           ds_nz_in;
 
   // ---------------------------------------------------------------------------
   // Stage-3 combinational: rounding adders + final assembly
   // ---------------------------------------------------------------------------
-  logic [FLEN-1:0]         s3_final_result;
+  logic [kronos_pkg::FLEN-1:0]         s3_final_result;
   logic [4:0]              s3_final_fflags;
-  logic [FP_S_MANT_W+1:0]  s_rounded;
-  logic [FP_D_MANT_W+1:0]  d_rounded;
-  logic [FP_S_TOTAL_W-1:0] s_bits;
-  logic [FP_D_TOTAL_W-1:0] d_bits;
-  logic [FLEN-1:0]         ifp_result;
+  logic [kronos_pkg::FP_S_MANT_W+1:0]  s_rounded;
+  logic [kronos_pkg::FP_D_MANT_W+1:0]  d_rounded;
+  logic [kronos_pkg::FP_S_TOTAL_W-1:0] s_bits;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] d_bits;
+  logic [kronos_pkg::FLEN-1:0]         ifp_result;
   logic [4:0]              ifp_fflags;
-  logic [XLEN:0]           int_rounded;
-  logic [XLEN-1:0]         mag;
+  logic [kronos_pkg::XLEN:0]           int_rounded;
+  logic [kronos_pkg::XLEN-1:0]         mag;
   logic                    over_after_round;
-  logic [XLEN-1:0]         signed_val;
-  logic [XLEN-1:0]         fpi_result;
+  logic [kronos_pkg::XLEN-1:0]         signed_val;
+  logic [kronos_pkg::XLEN-1:0]         fpi_result;
   logic [4:0]              fpi_fflags;
 
   // ---------------------------------------------------------------------------
@@ -235,10 +235,10 @@ module kronos_fpu_fcvt
     endcase
 
     if (s1_src_is_single) begin
-      if (a_i[FLEN-1 -: FP_S_TOTAL_W] == FP_NANBOX_UPPER) begin
-        s1_a_d = {{(FLEN-FP_S_TOTAL_W){1'b0}}, a_i[FP_S_TOTAL_W-1:0]};
+      if (a_i[kronos_pkg::FLEN-1 -: kronos_pkg::FP_S_TOTAL_W] == kronos_pkg::FP_NANBOX_UPPER) begin
+        s1_a_d = {{(kronos_pkg::FLEN-kronos_pkg::FP_S_TOTAL_W){1'b0}}, a_i[kronos_pkg::FP_S_TOTAL_W-1:0]};
       end else begin
-        s1_a_d = {{(FLEN-FP_S_TOTAL_W){1'b0}}, FP_CANON_QNAN_S};
+        s1_a_d = {{(kronos_pkg::FLEN-kronos_pkg::FP_S_TOTAL_W){1'b0}}, kronos_pkg::FP_CANON_QNAN_S};
       end
     end else begin
       s1_a_d = a_i;
@@ -251,7 +251,7 @@ module kronos_fpu_fcvt
       s1_op_q    <= FP_FCVT_W_F;
       s1_fmt_d_q <= 1'b0;
       s1_rm_q    <= 3'd0;
-      s1_a_q     <= {FLEN{1'b0}};
+      s1_a_q     <= {kronos_pkg::FLEN{1'b0}};
       s1_tag_q   <= '{default: '0};
     end else begin
       s1_valid_q <= flush_i ? 1'b0 : in_valid_i;
@@ -269,12 +269,12 @@ module kronos_fpu_fcvt
   // Stage-2 combinational: source decomposition (FP->INT and S<->D)
   // ---------------------------------------------------------------------------
   always_comb begin
-    src_s       = s1_a_q[FP_S_TOTAL_W-1:0];
+    src_s       = s1_a_q[kronos_pkg::FP_S_TOTAL_W-1:0];
     src_d       = s1_a_q;
-    src_exp_s   = src_s[FP_S_TOTAL_W-2 -: FP_S_EXP_W];
-    src_mant_s  = src_s[FP_S_MANT_W-1:0];
-    src_exp_d   = src_d[FP_D_TOTAL_W-2 -: FP_D_EXP_W];
-    src_mant_d  = src_d[FP_D_MANT_W-1:0];
+    src_exp_s   = src_s[kronos_pkg::FP_S_TOTAL_W-2 -: kronos_pkg::FP_S_EXP_W];
+    src_mant_s  = src_s[kronos_pkg::FP_S_MANT_W-1:0];
+    src_exp_d   = src_d[kronos_pkg::FP_D_TOTAL_W-2 -: kronos_pkg::FP_D_EXP_W];
+    src_mant_d  = src_d[kronos_pkg::FP_D_MANT_W-1:0];
     src_sign    = 1'b0;
     src_is_nan  = 1'b0;
     src_is_inf  = 1'b0;
@@ -292,15 +292,15 @@ module kronos_fpu_fcvt
     endcase
 
     if (src_is_s) begin
-      src_sign    = src_s[FP_S_TOTAL_W-1];
-      src_is_nan  = (src_exp_s == FP_S_EXP_MAX) && (src_mant_s != {FP_S_MANT_W{1'b0}});
-      src_is_inf  = (src_exp_s == FP_S_EXP_MAX) && (src_mant_s == {FP_S_MANT_W{1'b0}});
-      src_is_zero = (src_exp_s == {FP_S_EXP_W{1'b0}}) && (src_mant_s == {FP_S_MANT_W{1'b0}});
+      src_sign    = src_s[kronos_pkg::FP_S_TOTAL_W-1];
+      src_is_nan  = (src_exp_s == kronos_pkg::FP_S_EXP_MAX) && (src_mant_s != {kronos_pkg::FP_S_MANT_W{1'b0}});
+      src_is_inf  = (src_exp_s == kronos_pkg::FP_S_EXP_MAX) && (src_mant_s == {kronos_pkg::FP_S_MANT_W{1'b0}});
+      src_is_zero = (src_exp_s == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (src_mant_s == {kronos_pkg::FP_S_MANT_W{1'b0}});
     end else begin
-      src_sign    = src_d[FP_D_TOTAL_W-1];
-      src_is_nan  = (src_exp_d == FP_D_EXP_MAX) && (src_mant_d != {FP_D_MANT_W{1'b0}});
-      src_is_inf  = (src_exp_d == FP_D_EXP_MAX) && (src_mant_d == {FP_D_MANT_W{1'b0}});
-      src_is_zero = (src_exp_d == {FP_D_EXP_W{1'b0}}) && (src_mant_d == {FP_D_MANT_W{1'b0}});
+      src_sign    = src_d[kronos_pkg::FP_D_TOTAL_W-1];
+      src_is_nan  = (src_exp_d == kronos_pkg::FP_D_EXP_MAX) && (src_mant_d != {kronos_pkg::FP_D_MANT_W{1'b0}});
+      src_is_inf  = (src_exp_d == kronos_pkg::FP_D_EXP_MAX) && (src_mant_d == {kronos_pkg::FP_D_MANT_W{1'b0}});
+      src_is_zero = (src_exp_d == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (src_mant_d == {kronos_pkg::FP_D_MANT_W{1'b0}});
     end
   end
 
@@ -309,16 +309,16 @@ module kronos_fpu_fcvt
   //                                    int_rounded adder deferred to stage 3)
   // ---------------------------------------------------------------------------
   always_comb begin
-    sig64            = {XLEN{1'b0}};
-    frac_mask        = {XLEN{1'b0}};
+    sig64            = {kronos_pkg::XLEN{1'b0}};
+    frac_mask        = {kronos_pkg::XLEN{1'b0}};
     shift_r          = {7{1'b0}};
-    frac_bits        = {FP_S_EXP_W{1'b0}};
-    unbiased_exp     = {FP_EXP_EXT_W{1'b0}};
-    target_max       = {XLEN{1'b0}};
-    target_min       = {XLEN{1'b0}};
+    frac_bits        = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    unbiased_exp     = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
+    target_max       = {kronos_pkg::XLEN{1'b0}};
+    target_min       = {kronos_pkg::XLEN{1'b0}};
     target_is_signed = 1'b0;
     target_is_32b    = 1'b0;
-    int_part         = {XLEN{1'b0}};
+    int_part         = {kronos_pkg::XLEN{1'b0}};
     rnd_g            = 1'b0;
     rnd_s            = 1'b0;
     rnd_lsb          = 1'b0;
@@ -328,28 +328,28 @@ module kronos_fpu_fcvt
     is_inexact_fpi   = 1'b0;
 
     if (src_is_s) begin
-      unbiased_exp = $signed({5'd0, src_exp_s}) - $signed(FP_EXP_EXT_W'(FP_S_BIAS));
-      sig64 = {1'b1, src_mant_s, {(XLEN-1-FP_S_MANT_W){1'b0}}};
+      unbiased_exp = $signed({5'd0, src_exp_s}) - $signed(kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_BIAS));
+      sig64 = {1'b1, src_mant_s, {(kronos_pkg::XLEN-1-kronos_pkg::FP_S_MANT_W){1'b0}}};
     end else begin
-      unbiased_exp = $signed({2'd0, src_exp_d}) - $signed(FP_EXP_EXT_W'(FP_D_BIAS));
-      sig64 = {1'b1, src_mant_d, {(XLEN-1-FP_D_MANT_W){1'b0}}};
+      unbiased_exp = $signed({2'd0, src_exp_d}) - $signed(kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_D_BIAS));
+      sig64 = {1'b1, src_mant_d, {(kronos_pkg::XLEN-1-kronos_pkg::FP_D_MANT_W){1'b0}}};
     end
 
     target_is_signed = (s1_op_q == FP_FCVT_W_F) || (s1_op_q == FP_FCVT_L_F);
     target_is_32b    = (s1_op_q == FP_FCVT_W_F) || (s1_op_q == FP_FCVT_WU_F);
 
     if (target_is_32b && target_is_signed) begin
-      target_max = {{(XLEN-INST_W){1'b0}}, 32'h7FFF_FFFF};
-      target_min = {{(XLEN-INST_W){1'b1}}, 32'h8000_0000};
+      target_max = {{(kronos_pkg::XLEN-kronos_pkg::INST_W){1'b0}}, 32'h7FFF_FFFF};
+      target_min = {{(kronos_pkg::XLEN-kronos_pkg::INST_W){1'b1}}, 32'h8000_0000};
     end else if (target_is_32b && !target_is_signed) begin
       target_max = {32'hFFFF_FFFF, 32'hFFFF_FFFF};
-      target_min = {XLEN{1'b0}};
+      target_min = {kronos_pkg::XLEN{1'b0}};
     end else if (!target_is_32b && target_is_signed) begin
       target_max = 64'h7FFF_FFFF_FFFF_FFFF;
       target_min = 64'h8000_0000_0000_0000;
     end else begin
       target_max = 64'hFFFF_FFFF_FFFF_FFFF;
-      target_min = {XLEN{1'b0}};
+      target_min = {kronos_pkg::XLEN{1'b0}};
     end
 
     if (src_is_nan) begin
@@ -360,10 +360,10 @@ module kronos_fpu_fcvt
       fpi_neg_of   = src_sign;
     end else if (!src_is_zero) begin
       if (unbiased_exp < 0) begin
-        int_part = {XLEN{1'b0}};
+        int_part = {kronos_pkg::XLEN{1'b0}};
         if (unbiased_exp == -13'sd1) begin
           rnd_g = 1'b1;
-          rnd_s = |sig64[XLEN-2:0];
+          rnd_s = |sig64[kronos_pkg::XLEN-2:0];
         end else begin
           rnd_g = 1'b0;
           rnd_s = 1'b1;
@@ -413,21 +413,21 @@ module kronos_fpu_fcvt
   // ---------------------------------------------------------------------------
   always_comb begin
     ifp_isneg      = 1'b0;
-    ifp_imag       = {XLEN{1'b0}};
+    ifp_imag       = {kronos_pkg::XLEN{1'b0}};
     ifp_isigned    = 1'b0;
     ifp_is32       = 1'b0;
     ifp_imag_zero  = 1'b0;
     ifp_lz         = 0;
-    ifp_norm       = {XLEN{1'b0}};
-    ifp_s_exp      = {FP_S_EXP_W{1'b0}};
-    ifp_s_mant_pre = {(FP_S_MANT_W+1){1'b0}};
+    ifp_norm       = {kronos_pkg::XLEN{1'b0}};
+    ifp_s_exp      = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    ifp_s_mant_pre = {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
     s_guard        = 1'b0;
     s_round_sticky = 1'b0;
     s_lsb          = 1'b0;
     ifp_s_round_up = 1'b0;
     ifp_s_inexact  = 1'b0;
-    ifp_d_exp      = {FP_D_EXP_W{1'b0}};
-    ifp_d_mant_pre = {(FP_D_MANT_W+1){1'b0}};
+    ifp_d_exp      = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    ifp_d_mant_pre = {(kronos_pkg::FP_D_MANT_W+1){1'b0}};
     d_guard        = 1'b0;
     d_round_sticky = 1'b0;
     d_lsb          = 1'b0;
@@ -439,33 +439,33 @@ module kronos_fpu_fcvt
 
     if (ifp_is32) begin
       if (ifp_isigned) begin
-        ifp_isneg = s1_a_q[INST_W-1];
-        ifp_imag = ifp_isneg ? {{(XLEN-INST_W){1'b0}}, (~s1_a_q[INST_W-1:0] + INST_W'(1))}
-                              : {{(XLEN-INST_W){1'b0}}, s1_a_q[INST_W-1:0]};
+        ifp_isneg = s1_a_q[kronos_pkg::INST_W-1];
+        ifp_imag = ifp_isneg ? {{(kronos_pkg::XLEN-kronos_pkg::INST_W){1'b0}}, (~s1_a_q[kronos_pkg::INST_W-1:0] + kronos_pkg::INST_W'(1))}
+                              : {{(kronos_pkg::XLEN-kronos_pkg::INST_W){1'b0}}, s1_a_q[kronos_pkg::INST_W-1:0]};
       end else begin
         ifp_isneg = 1'b0;
-        ifp_imag = {{(XLEN-INST_W){1'b0}}, s1_a_q[INST_W-1:0]};
+        ifp_imag = {{(kronos_pkg::XLEN-kronos_pkg::INST_W){1'b0}}, s1_a_q[kronos_pkg::INST_W-1:0]};
       end
     end else begin
       if (ifp_isigned) begin
-        ifp_isneg = s1_a_q[XLEN-1];
-        ifp_imag = ifp_isneg ? (~s1_a_q + XLEN'(1)) : s1_a_q;  // 8xCARRY8 critical path
+        ifp_isneg = s1_a_q[kronos_pkg::XLEN-1];
+        ifp_imag = ifp_isneg ? (~s1_a_q + kronos_pkg::XLEN'(1)) : s1_a_q;  // 8xCARRY8 critical path
       end else begin
         ifp_isneg = 1'b0;
         ifp_imag = s1_a_q;
       end
     end
 
-    ifp_imag_zero = (ifp_imag == {XLEN{1'b0}});
+    ifp_imag_zero = (ifp_imag == {kronos_pkg::XLEN{1'b0}});
 
     ifp_lz = clz64(ifp_imag);
-    ifp_norm = ifp_imag_zero ? {XLEN{1'b0}} : (ifp_imag << ifp_lz);
+    ifp_norm = ifp_imag_zero ? {kronos_pkg::XLEN{1'b0}} : (ifp_imag << ifp_lz);
 
     // Single-precision path
-    ifp_s_exp      = FP_S_EXP_W'(FP_S_BIAS) + 8'd63 - ifp_lz[FP_S_EXP_W-1:0];
-    ifp_s_mant_pre = ifp_norm[XLEN-1 -: (FP_S_MANT_W+1)];   // 24 bits (implicit 1 at [23])
-    s_guard        = ifp_norm[XLEN-1-(FP_S_MANT_W+1)];
-    s_round_sticky = |ifp_norm[XLEN-2-(FP_S_MANT_W+1):0];
+    ifp_s_exp      = kronos_pkg::FP_S_EXP_W'(kronos_pkg::FP_S_BIAS) + 8'd63 - ifp_lz[kronos_pkg::FP_S_EXP_W-1:0];
+    ifp_s_mant_pre = ifp_norm[kronos_pkg::XLEN-1 -: (kronos_pkg::FP_S_MANT_W+1)];   // 24 bits (implicit 1 at [23])
+    s_guard        = ifp_norm[kronos_pkg::XLEN-1-(kronos_pkg::FP_S_MANT_W+1)];
+    s_round_sticky = |ifp_norm[kronos_pkg::XLEN-2-(kronos_pkg::FP_S_MANT_W+1):0];
     s_lsb          = ifp_s_mant_pre[0];
     unique case (s1_rm_q)
       FP_RM_RNE: ifp_s_round_up = s_guard && (s_round_sticky || s_lsb);
@@ -478,10 +478,10 @@ module kronos_fpu_fcvt
     ifp_s_inexact = s_guard | s_round_sticky;
 
     // Double-precision path
-    ifp_d_exp      = FP_D_EXP_W'(FP_D_BIAS) + 11'd63 - {3'd0, ifp_lz[FP_S_EXP_W-1:0]};
-    ifp_d_mant_pre = ifp_norm[XLEN-1 -: (FP_D_MANT_W+1)];   // 53 bits (implicit 1 at [52])
-    d_guard        = ifp_norm[XLEN-1-(FP_D_MANT_W+1)];
-    d_round_sticky = |ifp_norm[XLEN-2-(FP_D_MANT_W+1):0];
+    ifp_d_exp      = kronos_pkg::FP_D_EXP_W'(kronos_pkg::FP_D_BIAS) + 11'd63 - {3'd0, ifp_lz[kronos_pkg::FP_S_EXP_W-1:0]};
+    ifp_d_mant_pre = ifp_norm[kronos_pkg::XLEN-1 -: (kronos_pkg::FP_D_MANT_W+1)];   // 53 bits (implicit 1 at [52])
+    d_guard        = ifp_norm[kronos_pkg::XLEN-1-(kronos_pkg::FP_D_MANT_W+1)];
+    d_round_sticky = |ifp_norm[kronos_pkg::XLEN-2-(kronos_pkg::FP_D_MANT_W+1):0];
     d_lsb          = ifp_d_mant_pre[0];
     unique case (s1_rm_q)
       FP_RM_RNE: ifp_d_round_up = d_guard && (d_round_sticky || d_lsb);
@@ -499,54 +499,54 @@ module kronos_fpu_fcvt
   // ---------------------------------------------------------------------------
   always_comb begin
     fs_flags        = {5{1'b0}};
-    d_result        = {FP_D_TOTAL_W{1'b0}};
-    s_result        = {FP_S_TOTAL_W{1'b0}};
+    d_result        = {kronos_pkg::FP_D_TOTAL_W{1'b0}};
+    s_result        = {kronos_pkg::FP_S_TOTAL_W{1'b0}};
     sd_sign         = 1'b0;
-    sd_sexp         = {FP_S_EXP_W{1'b0}};
-    sd_smant        = {FP_S_MANT_W{1'b0}};
+    sd_sexp         = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    sd_smant        = {kronos_pkg::FP_S_MANT_W{1'b0}};
     ds_sign         = 1'b0;
-    ds_dexp         = {FP_D_EXP_W{1'b0}};
-    ds_dmant        = {FP_D_MANT_W{1'b0}};
-    ds_unbiased     = {FP_EXP_EXT_W{1'b0}};
-    ds_sexp_out     = {FP_S_EXP_W{1'b0}};
-    ds_sig          = {(FP_S_MANT_W+1){1'b0}};
+    ds_dexp         = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    ds_dmant        = {kronos_pkg::FP_D_MANT_W{1'b0}};
+    ds_unbiased     = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
+    ds_sexp_out     = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    ds_sig          = {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
     ds_g            = 1'b0;
     ds_sticky       = 1'b0;
     ds_lsb          = 1'b0;
     ds_round_up     = 1'b0;
-    ds_rounded      = {(FP_S_MANT_W+2){1'b0}};
+    ds_rounded      = {(kronos_pkg::FP_S_MANT_W+2){1'b0}};
     ds_nz_in        = 1'b0;
     subn_shift_amt  = {10{1'b0}};
-    subn_sig24      = {(FP_S_MANT_W+1){1'b0}};
-    subn_sig        = {(FP_S_MANT_W+1){1'b0}};
+    subn_sig24      = {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
+    subn_sig        = {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
     subn_g          = 1'b0;
     subn_sticky     = 1'b0;
     subn_round_up   = 1'b0;
-    subn_rounded    = {(FP_S_MANT_W+1){1'b0}};
-    subn_mant       = {FP_S_MANT_W{1'b0}};
-    subn_exp        = {FP_S_EXP_W{1'b0}};
+    subn_rounded    = {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
+    subn_mant       = {kronos_pkg::FP_S_MANT_W{1'b0}};
+    subn_exp        = {kronos_pkg::FP_S_EXP_W{1'b0}};
     sd_k            = 0;
-    sd_m            = {FP_S_MANT_W{1'b0}};
+    sd_m            = {kronos_pkg::FP_S_MANT_W{1'b0}};
     sd_shift_amt    = 22;
     sd_found_k      = 1'b0;
-    sd_new_mant     = {(FP_D_MANT_W+1){1'b0}};
-    sd_new_exp      = {FP_D_EXP_W{1'b0}};
-    s2c_ds_d        = {FP_D_TOTAL_W{1'b0}};
+    sd_new_mant     = {(kronos_pkg::FP_D_MANT_W+1){1'b0}};
+    sd_new_exp      = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    s2c_ds_d        = {kronos_pkg::FP_D_TOTAL_W{1'b0}};
     s2c_ds_fflags_d = {5{1'b0}};
 
     if (s1_op_q == FP_FCVT_D_S) begin
       // Single -> Double (exact)
-      sd_sign  = s1_a_q[FP_S_TOTAL_W-1];
-      sd_sexp  = s1_a_q[FP_S_TOTAL_W-2 -: FP_S_EXP_W];
-      sd_smant = s1_a_q[FP_S_MANT_W-1:0];
-      if ((sd_sexp == {FP_S_EXP_W{1'b0}}) && (sd_smant == {FP_S_MANT_W{1'b0}})) begin
-        d_result = {sd_sign, {(FP_D_TOTAL_W-1){1'b0}}};
-      end else if ((sd_sexp == FP_S_EXP_MAX) && (sd_smant == {FP_S_MANT_W{1'b0}})) begin
-        d_result = {sd_sign, FP_D_EXP_MAX, {FP_D_MANT_W{1'b0}}};
-      end else if (sd_sexp == FP_S_EXP_MAX) begin
-        if (sd_smant[FP_S_MANT_W-1] == 1'b0) fs_flags[FP_FFLAG_NV] = 1'b1;
-        d_result = FP_CANON_QNAN_D;
-      end else if (sd_sexp == {FP_S_EXP_W{1'b0}}) begin
+      sd_sign  = s1_a_q[kronos_pkg::FP_S_TOTAL_W-1];
+      sd_sexp  = s1_a_q[kronos_pkg::FP_S_TOTAL_W-2 -: kronos_pkg::FP_S_EXP_W];
+      sd_smant = s1_a_q[kronos_pkg::FP_S_MANT_W-1:0];
+      if ((sd_sexp == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (sd_smant == {kronos_pkg::FP_S_MANT_W{1'b0}})) begin
+        d_result = {sd_sign, {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}};
+      end else if ((sd_sexp == kronos_pkg::FP_S_EXP_MAX) && (sd_smant == {kronos_pkg::FP_S_MANT_W{1'b0}})) begin
+        d_result = {sd_sign, kronos_pkg::FP_D_EXP_MAX, {kronos_pkg::FP_D_MANT_W{1'b0}}};
+      end else if (sd_sexp == kronos_pkg::FP_S_EXP_MAX) begin
+        if (sd_smant[kronos_pkg::FP_S_MANT_W-1] == 1'b0) fs_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+        d_result = kronos_pkg::FP_CANON_QNAN_D;
+      end else if (sd_sexp == {kronos_pkg::FP_S_EXP_W{1'b0}}) begin
         sd_m         = sd_smant;
         sd_found_k   = 1'b0;
         sd_shift_amt = 22;
@@ -556,75 +556,75 @@ module kronos_fpu_fcvt
             sd_found_k   = 1'b1;
           end
         end
-        sd_new_mant = {sd_m, {(FP_D_MANT_W+1-FP_S_MANT_W){1'b0}}} << sd_shift_amt;
-        sd_new_exp  = FP_D_EXP_W'(FP_D_BIAS - FP_S_BIAS) - sd_shift_amt[FP_D_EXP_W-1:0];
-        d_result    = {sd_sign, sd_new_exp, sd_new_mant[FP_D_MANT_W-1:0]};
+        sd_new_mant = {sd_m, {(kronos_pkg::FP_D_MANT_W+1-kronos_pkg::FP_S_MANT_W){1'b0}}} << sd_shift_amt;
+        sd_new_exp  = kronos_pkg::FP_D_EXP_W'(kronos_pkg::FP_D_BIAS - kronos_pkg::FP_S_BIAS) - sd_shift_amt[kronos_pkg::FP_D_EXP_W-1:0];
+        d_result    = {sd_sign, sd_new_exp, sd_new_mant[kronos_pkg::FP_D_MANT_W-1:0]};
       end else begin
-        d_result = {sd_sign, ({3'd0, sd_sexp} + FP_D_EXP_W'(FP_D_BIAS - FP_S_BIAS)),
-                    sd_smant, {(FP_D_MANT_W-FP_S_MANT_W){1'b0}}};
+        d_result = {sd_sign, ({3'd0, sd_sexp} + kronos_pkg::FP_D_EXP_W'(kronos_pkg::FP_D_BIAS - kronos_pkg::FP_S_BIAS)),
+                    sd_smant, {(kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W){1'b0}}};
       end
       s2c_ds_d        = d_result;
       s2c_ds_fflags_d = fs_flags;
     end else begin
       // FP_FCVT_S_D: Double -> Single with rounding
-      ds_sign     = s1_a_q[FP_D_TOTAL_W-1];
-      ds_dexp     = s1_a_q[FP_D_TOTAL_W-2 -: FP_D_EXP_W];
-      ds_dmant    = s1_a_q[FP_D_MANT_W-1:0];
-      ds_unbiased = $signed({2'd0, ds_dexp}) - $signed(FP_EXP_EXT_W'(FP_D_BIAS));
+      ds_sign     = s1_a_q[kronos_pkg::FP_D_TOTAL_W-1];
+      ds_dexp     = s1_a_q[kronos_pkg::FP_D_TOTAL_W-2 -: kronos_pkg::FP_D_EXP_W];
+      ds_dmant    = s1_a_q[kronos_pkg::FP_D_MANT_W-1:0];
+      ds_unbiased = $signed({2'd0, ds_dexp}) - $signed(kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_D_BIAS));
 
-      if ((ds_dexp == {FP_D_EXP_W{1'b0}}) && (ds_dmant == {FP_D_MANT_W{1'b0}})) begin
-        s_result = {ds_sign, {(FP_S_TOTAL_W-1){1'b0}}};
-      end else if ((ds_dexp == FP_D_EXP_MAX) && (ds_dmant == {FP_D_MANT_W{1'b0}})) begin
-        s_result = {ds_sign, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
-      end else if (ds_dexp == FP_D_EXP_MAX) begin
-        if (ds_dmant[FP_D_MANT_W-1] == 1'b0) fs_flags[FP_FFLAG_NV] = 1'b1;
-        s_result = FP_CANON_QNAN_S;
+      if ((ds_dexp == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (ds_dmant == {kronos_pkg::FP_D_MANT_W{1'b0}})) begin
+        s_result = {ds_sign, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
+      end else if ((ds_dexp == kronos_pkg::FP_D_EXP_MAX) && (ds_dmant == {kronos_pkg::FP_D_MANT_W{1'b0}})) begin
+        s_result = {ds_sign, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
+      end else if (ds_dexp == kronos_pkg::FP_D_EXP_MAX) begin
+        if (ds_dmant[kronos_pkg::FP_D_MANT_W-1] == 1'b0) fs_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+        s_result = kronos_pkg::FP_CANON_QNAN_S;
       end else begin
-        if (ds_dexp == {FP_D_EXP_W{1'b0}}) begin
+        if (ds_dexp == {kronos_pkg::FP_D_EXP_W{1'b0}}) begin
           ds_nz_in = |ds_dmant;
           unique case (s1_rm_q)
             FP_RM_RDN: s_result = (ds_sign  && ds_nz_in)
-                                  ? {1'b1, {FP_S_EXP_W{1'b0}}, {(FP_S_MANT_W-1){1'b0}}, 1'b1}
-                                  : {ds_sign, {(FP_S_TOTAL_W-1){1'b0}}};
+                                  ? {1'b1, {kronos_pkg::FP_S_EXP_W{1'b0}}, {(kronos_pkg::FP_S_MANT_W-1){1'b0}}, 1'b1}
+                                  : {ds_sign, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
             FP_RM_RUP: s_result = (!ds_sign && ds_nz_in)
-                                  ? {1'b0, {FP_S_EXP_W{1'b0}}, {(FP_S_MANT_W-1){1'b0}}, 1'b1}
-                                  : {ds_sign, {(FP_S_TOTAL_W-1){1'b0}}};
-            default:   s_result = {ds_sign, {(FP_S_TOTAL_W-1){1'b0}}};
+                                  ? {1'b0, {kronos_pkg::FP_S_EXP_W{1'b0}}, {(kronos_pkg::FP_S_MANT_W-1){1'b0}}, 1'b1}
+                                  : {ds_sign, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
+            default:   s_result = {ds_sign, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
           endcase
           if (ds_nz_in) begin
-            fs_flags[FP_FFLAG_UF] = 1'b1;
-            fs_flags[FP_FFLAG_NX] = 1'b1;
+            fs_flags[kronos_pkg::FP_FFLAG_UF] = 1'b1;
+            fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           end
-        end else if (ds_unbiased > $signed(FP_EXP_EXT_W'(FP_S_BIAS))) begin
-          fs_flags[FP_FFLAG_OF] = 1'b1;
-          fs_flags[FP_FFLAG_NX] = 1'b1;
+        end else if (ds_unbiased > $signed(kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_BIAS))) begin
+          fs_flags[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+          fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           unique case (s1_rm_q)
-            FP_RM_RTZ: s_result = {ds_sign, FP_S_EXP_PENULT, 23'h7FFFFF};
-            FP_RM_RDN: s_result = ds_sign ? {1'b1, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}}
-                                          : {1'b0, FP_S_EXP_PENULT, 23'h7FFFFF};
-            FP_RM_RUP: s_result = ds_sign ? {1'b1, FP_S_EXP_PENULT, 23'h7FFFFF}
-                                          : {1'b0, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
-            default:   s_result = {ds_sign, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
+            FP_RM_RTZ: s_result = {ds_sign, kronos_pkg::FP_S_EXP_PENULT, 23'h7FFFFF};
+            FP_RM_RDN: s_result = ds_sign ? {1'b1, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}}
+                                          : {1'b0, kronos_pkg::FP_S_EXP_PENULT, 23'h7FFFFF};
+            FP_RM_RUP: s_result = ds_sign ? {1'b1, kronos_pkg::FP_S_EXP_PENULT, 23'h7FFFFF}
+                                          : {1'b0, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
+            default:   s_result = {ds_sign, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
           endcase
-        end else if (ds_unbiased < $signed(FP_EXP_EXT_W'(FP_S_EMIN_NORM))) begin
-          subn_shift_amt = 10'(-(ds_unbiased + $signed(FP_EXP_EXT_W'(-FP_S_EMIN_NORM))));
-          subn_sig24     = {1'b1, ds_dmant[FP_D_MANT_W-1 -: FP_S_MANT_W]};
+        end else if (ds_unbiased < $signed(kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_EMIN_NORM))) begin
+          subn_shift_amt = 10'(-(ds_unbiased + $signed(kronos_pkg::FP_EXP_EXT_W'(-kronos_pkg::FP_S_EMIN_NORM))));
+          subn_sig24     = {1'b1, ds_dmant[kronos_pkg::FP_D_MANT_W-1 -: kronos_pkg::FP_S_MANT_W]};
 
           if (subn_shift_amt >= 10'd25) begin
-            subn_sig    = {(FP_S_MANT_W+1){1'b0}};
+            subn_sig    = {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
             subn_g      = 1'b0;
-            subn_sticky = (subn_sig24 != {(FP_S_MANT_W+1){1'b0}})
-                          | (|ds_dmant[FP_D_MANT_W-FP_S_MANT_W-1:0]);
+            subn_sticky = (subn_sig24 != {(kronos_pkg::FP_S_MANT_W+1){1'b0}})
+                          | (|ds_dmant[kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W-1:0]);
           end else begin
             subn_sig    = subn_sig24 >> subn_shift_amt;
             subn_g      = (subn_shift_amt == 10'd0)
                           ? 1'b0
                           : subn_sig24[subn_shift_amt[4:0] - 5'd1];
             subn_sticky = (subn_shift_amt < 10'd2)
-                          ? (|ds_dmant[FP_D_MANT_W-FP_S_MANT_W-1:0])
+                          ? (|ds_dmant[kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W-1:0])
                           : (|(subn_sig24
                                  & ((24'd1 << (subn_shift_amt - 10'd1)) - 24'd1)))
-                            | (|ds_dmant[FP_D_MANT_W-FP_S_MANT_W-1:0]);
+                            | (|ds_dmant[kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W-1:0]);
           end
 
           unique case (s1_rm_q)
@@ -637,24 +637,24 @@ module kronos_fpu_fcvt
           endcase
 
           subn_rounded = subn_sig + (subn_round_up ? 24'd1 : 24'd0);
-          if (subn_g | subn_sticky) fs_flags[FP_FFLAG_NX] = 1'b1;
+          if (subn_g | subn_sticky) fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
 
-          if (subn_rounded[FP_S_MANT_W]) begin
-            subn_mant = {FP_S_MANT_W{1'b0}};
+          if (subn_rounded[kronos_pkg::FP_S_MANT_W]) begin
+            subn_mant = {kronos_pkg::FP_S_MANT_W{1'b0}};
             subn_exp  = 8'd1;
           end else begin
-            subn_mant = subn_rounded[FP_S_MANT_W-1:0];
-            subn_exp  = {FP_S_EXP_W{1'b0}};
+            subn_mant = subn_rounded[kronos_pkg::FP_S_MANT_W-1:0];
+            subn_exp  = {kronos_pkg::FP_S_EXP_W{1'b0}};
           end
           s_result = {ds_sign, subn_exp, subn_mant};
 
-          if ((subn_g | subn_sticky) && (subn_exp == {FP_S_EXP_W{1'b0}}))
-            fs_flags[FP_FFLAG_UF] = 1'b1;
+          if ((subn_g | subn_sticky) && (subn_exp == {kronos_pkg::FP_S_EXP_W{1'b0}}))
+            fs_flags[kronos_pkg::FP_FFLAG_UF] = 1'b1;
         end else begin
           // Normal range: round 52-bit mantissa to 23 bits
-          ds_sig    = {1'b1, ds_dmant[FP_D_MANT_W-1 -: FP_S_MANT_W]};
-          ds_g      = ds_dmant[FP_D_MANT_W-FP_S_MANT_W-1];
-          ds_sticky = |ds_dmant[FP_D_MANT_W-FP_S_MANT_W-2:0];
+          ds_sig    = {1'b1, ds_dmant[kronos_pkg::FP_D_MANT_W-1 -: kronos_pkg::FP_S_MANT_W]};
+          ds_g      = ds_dmant[kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W-1];
+          ds_sticky = |ds_dmant[kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W-2:0];
           ds_lsb    = ds_sig[0];
           unique case (s1_rm_q)
             FP_RM_RNE: ds_round_up = ds_g && (ds_sticky || ds_lsb);
@@ -665,22 +665,22 @@ module kronos_fpu_fcvt
             default:   ds_round_up = ds_g && (ds_sticky || ds_lsb);
           endcase
           ds_rounded = {1'b0, ds_sig} + (ds_round_up ? 25'd1 : 25'd0);
-          if (ds_g || ds_sticky) fs_flags[FP_FFLAG_NX] = 1'b1;
+          if (ds_g || ds_sticky) fs_flags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
 
-          ds_sexp_out = ds_unbiased[FP_S_EXP_W-1:0] + FP_S_EXP_W'(FP_S_BIAS);
-          if (ds_rounded[FP_S_MANT_W+1]) begin
-            if ((ds_sexp_out + 8'd1) == FP_S_EXP_MAX) begin
-              s_result = {ds_sign, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
-              fs_flags[FP_FFLAG_OF] = 1'b1;
+          ds_sexp_out = ds_unbiased[kronos_pkg::FP_S_EXP_W-1:0] + kronos_pkg::FP_S_EXP_W'(kronos_pkg::FP_S_BIAS);
+          if (ds_rounded[kronos_pkg::FP_S_MANT_W+1]) begin
+            if ((ds_sexp_out + 8'd1) == kronos_pkg::FP_S_EXP_MAX) begin
+              s_result = {ds_sign, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
+              fs_flags[kronos_pkg::FP_FFLAG_OF] = 1'b1;
             end else begin
-              s_result = {ds_sign, ds_sexp_out + 8'd1, {FP_S_MANT_W{1'b0}}};
+              s_result = {ds_sign, ds_sexp_out + 8'd1, {kronos_pkg::FP_S_MANT_W{1'b0}}};
             end
           end else begin
-            s_result = {ds_sign, ds_sexp_out, ds_rounded[FP_S_MANT_W-1:0]};
+            s_result = {ds_sign, ds_sexp_out, ds_rounded[kronos_pkg::FP_S_MANT_W-1:0]};
           end
         end
       end
-      s2c_ds_d        = {FP_NANBOX_UPPER, s_result};
+      s2c_ds_d        = {kronos_pkg::FP_NANBOX_UPPER, s_result};
       s2c_ds_fflags_d = fs_flags;
     end
   end
@@ -697,10 +697,10 @@ module kronos_fpu_fcvt
 
       s2_ifp_isneg_q      <= 1'b0;
       s2_ifp_imag_zero_q  <= 1'b0;
-      s2_ifp_s_exp_q      <= {FP_S_EXP_W{1'b0}};
-      s2_ifp_d_exp_q      <= {FP_D_EXP_W{1'b0}};
-      s2_ifp_s_mant_pre_q <= {(FP_S_MANT_W+1){1'b0}};
-      s2_ifp_d_mant_pre_q <= {(FP_D_MANT_W+1){1'b0}};
+      s2_ifp_s_exp_q      <= {kronos_pkg::FP_S_EXP_W{1'b0}};
+      s2_ifp_d_exp_q      <= {kronos_pkg::FP_D_EXP_W{1'b0}};
+      s2_ifp_s_mant_pre_q <= {(kronos_pkg::FP_S_MANT_W+1){1'b0}};
+      s2_ifp_d_mant_pre_q <= {(kronos_pkg::FP_D_MANT_W+1){1'b0}};
       s2_ifp_s_round_up_q <= 1'b0;
       s2_ifp_d_round_up_q <= 1'b0;
       s2_ifp_s_inexact_q  <= 1'b0;
@@ -712,13 +712,13 @@ module kronos_fpu_fcvt
       s2_fpi_src_sign_q         <= 1'b0;
       s2_fpi_target_is_32b_q    <= 1'b0;
       s2_fpi_target_is_signed_q <= 1'b0;
-      s2_fpi_target_max_q       <= {XLEN{1'b0}};
-      s2_fpi_target_min_q       <= {XLEN{1'b0}};
-      s2_fpi_int_part_q         <= {XLEN{1'b0}};
+      s2_fpi_target_max_q       <= {kronos_pkg::XLEN{1'b0}};
+      s2_fpi_target_min_q       <= {kronos_pkg::XLEN{1'b0}};
+      s2_fpi_int_part_q         <= {kronos_pkg::XLEN{1'b0}};
       s2_fpi_round_up_q         <= 1'b0;
       s2_fpi_is_inexact_q       <= 1'b0;
 
-      s2_ds_result_q <= {FP_D_TOTAL_W{1'b0}};
+      s2_ds_result_q <= {kronos_pkg::FP_D_TOTAL_W{1'b0}};
       s2_ds_fflags_q <= {5{1'b0}};
     end else begin
       s2_valid_q <= flush_i ? 1'b0 : s1_valid_q;
@@ -760,19 +760,19 @@ module kronos_fpu_fcvt
   // Stage-3 combinational: rounding adders + final assembly
   // ---------------------------------------------------------------------------
   always_comb begin
-    s_rounded        = {(FP_S_MANT_W+2){1'b0}};
-    d_rounded        = {(FP_D_MANT_W+2){1'b0}};
-    s_bits           = {FP_S_TOTAL_W{1'b0}};
-    d_bits           = {FP_D_TOTAL_W{1'b0}};
-    ifp_result       = {FLEN{1'b0}};
+    s_rounded        = {(kronos_pkg::FP_S_MANT_W+2){1'b0}};
+    d_rounded        = {(kronos_pkg::FP_D_MANT_W+2){1'b0}};
+    s_bits           = {kronos_pkg::FP_S_TOTAL_W{1'b0}};
+    d_bits           = {kronos_pkg::FP_D_TOTAL_W{1'b0}};
+    ifp_result       = {kronos_pkg::FLEN{1'b0}};
     ifp_fflags       = {5{1'b0}};
-    int_rounded      = {(XLEN+1){1'b0}};
-    mag              = {XLEN{1'b0}};
+    int_rounded      = {(kronos_pkg::XLEN+1){1'b0}};
+    mag              = {kronos_pkg::XLEN{1'b0}};
     over_after_round = 1'b0;
-    signed_val       = {XLEN{1'b0}};
-    fpi_result       = {XLEN{1'b0}};
+    signed_val       = {kronos_pkg::XLEN{1'b0}};
+    fpi_result       = {kronos_pkg::XLEN{1'b0}};
     fpi_fflags       = {5{1'b0}};
-    s3_final_result  = {FLEN{1'b0}};
+    s3_final_result  = {kronos_pkg::FLEN{1'b0}};
     s3_final_fflags  = {5{1'b0}};
 
     // --- INT -> FP rounding (7xCARRY8 for double; 4xCARRY8 for single) ---
@@ -780,42 +780,42 @@ module kronos_fpu_fcvt
     d_rounded = {1'b0, s2_ifp_d_mant_pre_q} + (s2_ifp_d_round_up_q ? 54'd1 : 54'd0);
 
     if (s2_ifp_imag_zero_q) begin
-      s_bits = {s2_ifp_isneg_q, {(FP_S_TOTAL_W-1){1'b0}}};
-      d_bits = {FP_D_TOTAL_W{1'b0}};
+      s_bits = {s2_ifp_isneg_q, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}};
+      d_bits = {kronos_pkg::FP_D_TOTAL_W{1'b0}};
     end else begin
-      if (s_rounded[FP_S_MANT_W+1]) begin
-        s_bits = {s2_ifp_isneg_q, s2_ifp_s_exp_q + 8'd1, {FP_S_MANT_W{1'b0}}};
+      if (s_rounded[kronos_pkg::FP_S_MANT_W+1]) begin
+        s_bits = {s2_ifp_isneg_q, s2_ifp_s_exp_q + 8'd1, {kronos_pkg::FP_S_MANT_W{1'b0}}};
       end else begin
-        s_bits = {s2_ifp_isneg_q, s2_ifp_s_exp_q, s_rounded[FP_S_MANT_W-1:0]};
+        s_bits = {s2_ifp_isneg_q, s2_ifp_s_exp_q, s_rounded[kronos_pkg::FP_S_MANT_W-1:0]};
       end
-      if (d_rounded[FP_D_MANT_W+1]) begin
-        d_bits = {s2_ifp_isneg_q, s2_ifp_d_exp_q + 11'd1, {FP_D_MANT_W{1'b0}}};
+      if (d_rounded[kronos_pkg::FP_D_MANT_W+1]) begin
+        d_bits = {s2_ifp_isneg_q, s2_ifp_d_exp_q + 11'd1, {kronos_pkg::FP_D_MANT_W{1'b0}}};
       end else begin
-        d_bits = {s2_ifp_isneg_q, s2_ifp_d_exp_q, d_rounded[FP_D_MANT_W-1:0]};
+        d_bits = {s2_ifp_isneg_q, s2_ifp_d_exp_q, d_rounded[kronos_pkg::FP_D_MANT_W-1:0]};
       end
     end
 
     if (s2_fmt_d_q) begin
       ifp_result = d_bits;
-      if (!s2_ifp_imag_zero_q && s2_ifp_d_inexact_q) ifp_fflags[FP_FFLAG_NX] = 1'b1;
+      if (!s2_ifp_imag_zero_q && s2_ifp_d_inexact_q) ifp_fflags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
     end else begin
-      ifp_result = {FP_NANBOX_UPPER, s_bits};
-      if (!s2_ifp_imag_zero_q && s2_ifp_s_inexact_q) ifp_fflags[FP_FFLAG_NX] = 1'b1;
+      ifp_result = {kronos_pkg::FP_NANBOX_UPPER, s_bits};
+      if (!s2_ifp_imag_zero_q && s2_ifp_s_inexact_q) ifp_fflags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
     end
 
     // --- FP -> INT rounding (65-bit conditional increment + sign + range check) ---
 
     int_rounded = {1'b0, s2_fpi_int_part_q} + (s2_fpi_round_up_q ? 65'd1 : 65'd0);
-    mag         = int_rounded[XLEN-1:0];
+    mag         = int_rounded[kronos_pkg::XLEN-1:0];
 
     if (s2_fpi_src_is_nan_q) begin
       fpi_result               = s2_fpi_target_max_q;
-      fpi_fflags[FP_FFLAG_NV]  = 1'b1;
+      fpi_fflags[kronos_pkg::FP_FFLAG_NV]  = 1'b1;
     end else if (s2_fpi_overflow_q) begin
       if (s2_fpi_neg_of_q) fpi_result = s2_fpi_target_is_signed_q ? s2_fpi_target_min_q
-                                                                  : {XLEN{1'b0}};
+                                                                  : {kronos_pkg::XLEN{1'b0}};
       else                 fpi_result = s2_fpi_target_max_q;
-      fpi_fflags[FP_FFLAG_NV] = 1'b1;
+      fpi_fflags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else begin
       if (s2_fpi_target_is_32b_q && s2_fpi_target_is_signed_q) begin
         if (s2_fpi_src_sign_q) begin
@@ -824,7 +824,7 @@ module kronos_fpu_fcvt
           if (int_rounded > 65'h0_0000_0000_7FFF_FFFF) over_after_round = 1'b1;
         end
       end else if (s2_fpi_target_is_32b_q && !s2_fpi_target_is_signed_q) begin
-        if (s2_fpi_src_sign_q && (mag != {XLEN{1'b0}} || s2_fpi_round_up_q)) begin
+        if (s2_fpi_src_sign_q && (mag != {kronos_pkg::XLEN{1'b0}} || s2_fpi_round_up_q)) begin
           over_after_round = 1'b1;
         end else if (int_rounded > 65'h0_0000_0000_FFFF_FFFF) begin
           over_after_round = 1'b1;
@@ -836,9 +836,9 @@ module kronos_fpu_fcvt
           if (int_rounded > 65'h0_7FFF_FFFF_FFFF_FFFF) over_after_round = 1'b1;
         end
       end else begin
-        if (s2_fpi_src_sign_q && (mag != {XLEN{1'b0}} || s2_fpi_round_up_q)) begin
+        if (s2_fpi_src_sign_q && (mag != {kronos_pkg::XLEN{1'b0}} || s2_fpi_round_up_q)) begin
           over_after_round = 1'b1;
-        end else if (int_rounded[XLEN]) begin
+        end else if (int_rounded[kronos_pkg::XLEN]) begin
           // verilator coverage_off
           over_after_round = 1'b1;
           // verilator coverage_on
@@ -847,17 +847,17 @@ module kronos_fpu_fcvt
 
       if (over_after_round) begin
         if (s2_fpi_src_sign_q) fpi_result = s2_fpi_target_is_signed_q ? s2_fpi_target_min_q
-                                                                      : {XLEN{1'b0}};
+                                                                      : {kronos_pkg::XLEN{1'b0}};
         else                   fpi_result = s2_fpi_target_max_q;
-        fpi_fflags[FP_FFLAG_NV] = 1'b1;
+        fpi_fflags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
       end else begin
-        signed_val = s2_fpi_src_sign_q ? (~mag + XLEN'(1)) : mag;
+        signed_val = s2_fpi_src_sign_q ? (~mag + kronos_pkg::XLEN'(1)) : mag;
         if (s2_fpi_target_is_32b_q) begin
-          fpi_result = {{(XLEN-INST_W){signed_val[INST_W-1]}}, signed_val[INST_W-1:0]};
+          fpi_result = {{(kronos_pkg::XLEN-kronos_pkg::INST_W){signed_val[kronos_pkg::INST_W-1]}}, signed_val[kronos_pkg::INST_W-1:0]};
         end else begin
           fpi_result = signed_val;
         end
-        if (s2_fpi_is_inexact_q) fpi_fflags[FP_FFLAG_NX] = 1'b1;
+        if (s2_fpi_is_inexact_q) fpi_fflags[kronos_pkg::FP_FFLAG_NX] = 1'b1;
       end
     end
 
@@ -883,7 +883,7 @@ module kronos_fpu_fcvt
         s3_final_fflags = s2_ds_fflags_q;
       end
       default: begin
-        s3_final_result = {FLEN{1'b0}};
+        s3_final_result = {kronos_pkg::FLEN{1'b0}};
         s3_final_fflags = {5{1'b0}};
       end
     endcase
@@ -895,7 +895,7 @@ module kronos_fpu_fcvt
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       out_valid_o <= 1'b0;
-      result_o    <= {FLEN{1'b0}};
+      result_o    <= {kronos_pkg::FLEN{1'b0}};
       fflags_o    <= {5{1'b0}};
       tag_o       <= '{default: '0};
     end else begin

--- a/rtl/stage6/fpu/kronos_fpu_fdiv_core.sv
+++ b/rtl/stage6/fpu/kronos_fpu_fdiv_core.sv
@@ -33,8 +33,8 @@ module kronos_fpu_fdiv_core
   // Constants
   // -------------------------------------------------------------------------
   // N = mantissa width + 4 guard bits (3 fractional + 1 integer)
-  localparam int unsigned N_S = FP_S_MANT_W + 4;  // 27 iterations for single
-  localparam int unsigned N_D = FP_D_MANT_W + 4;  // 56 iterations for double
+  localparam int unsigned N_S = kronos_pkg::FP_S_MANT_W + 4;  // 27 iterations for single
+  localparam int unsigned N_D = kronos_pkg::FP_D_MANT_W + 4;  // 56 iterations for double
 
   // -------------------------------------------------------------------------
   // FSM encoding

--- a/rtl/stage6/fpu/kronos_fpu_fma.sv
+++ b/rtl/stage6/fpu/kronos_fpu_fma.sv
@@ -33,12 +33,12 @@ module kronos_fpu_fma
   input  fp_op_e          op_i,
   input  logic            fmt_d_i,
   input  logic [2:0]      rm_i,
-  input  logic [FLEN-1:0] a_i,
-  input  logic [FLEN-1:0] b_i,
-  input  logic [FLEN-1:0] c_i,
+  input  logic [kronos_pkg::FLEN-1:0] a_i,
+  input  logic [kronos_pkg::FLEN-1:0] b_i,
+  input  logic [kronos_pkg::FLEN-1:0] c_i,
   input  fpu_tag_t        tag_i,
   output logic            out_valid_o,
-  output logic [FLEN-1:0] result_o,
+  output logic [kronos_pkg::FLEN-1:0] result_o,
   output logic [4:0]      fflags_o,
   output fpu_tag_t        tag_o
 );
@@ -50,7 +50,7 @@ module kronos_fpu_fma
   //   - Aligned addend lane: PROD_W + PAD_W (= 160b), addend sits just under
   //     the product and spills into the low pad for sticky bits.
   // ---------------------------------------------------------------------------
-  localparam int unsigned SIG_W  = FP_D_MANT_W + 1;     // 53 (incl. hidden)
+  localparam int unsigned SIG_W  = kronos_pkg::FP_D_MANT_W + 1;     // 53 (incl. hidden)
   localparam int unsigned PROD_W = 2 * SIG_W;           // 106
   localparam int unsigned PAD_W  = 54;                  // headroom for shift-out
   localparam int unsigned SUM_W  = PROD_W + PAD_W;      // 160
@@ -58,37 +58,37 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   // Helpers: classification
   // ---------------------------------------------------------------------------
-  function automatic logic is_snan_s(logic [FP_S_TOTAL_W-1:0] x);
-    return (x[30:23] == FP_S_EXP_MAX) && (x[22] == 1'b0) && (x[21:0] != 22'd0);
+  function automatic logic is_snan_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
+    return (x[30:23] == kronos_pkg::FP_S_EXP_MAX) && (x[22] == 1'b0) && (x[21:0] != 22'd0);
   endfunction
-  function automatic logic is_qnan_s(logic [FP_S_TOTAL_W-1:0] x);
-    return (x[30:23] == FP_S_EXP_MAX) && (x[22] == 1'b1);
+  function automatic logic is_qnan_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
+    return (x[30:23] == kronos_pkg::FP_S_EXP_MAX) && (x[22] == 1'b1);
   endfunction
-  function automatic logic is_inf_s(logic [FP_S_TOTAL_W-1:0] x);
-    return (x[30:23] == FP_S_EXP_MAX) && (x[22:0] == 23'd0);
+  function automatic logic is_inf_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
+    return (x[30:23] == kronos_pkg::FP_S_EXP_MAX) && (x[22:0] == 23'd0);
   endfunction
-  function automatic logic is_zero_s(logic [FP_S_TOTAL_W-1:0] x);
+  function automatic logic is_zero_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
     return (x[30:0] == 31'd0);
   endfunction
 
-  function automatic logic is_snan_d(logic [FP_D_TOTAL_W-1:0] x);
-    return (x[62:52] == FP_D_EXP_MAX) && (x[51] == 1'b0) && (x[50:0] != 51'd0);
+  function automatic logic is_snan_d(logic [kronos_pkg::FP_D_TOTAL_W-1:0] x);
+    return (x[62:52] == kronos_pkg::FP_D_EXP_MAX) && (x[51] == 1'b0) && (x[50:0] != 51'd0);
   endfunction
-  function automatic logic is_qnan_d(logic [FP_D_TOTAL_W-1:0] x);
-    return (x[62:52] == FP_D_EXP_MAX) && (x[51] == 1'b1);
+  function automatic logic is_qnan_d(logic [kronos_pkg::FP_D_TOTAL_W-1:0] x);
+    return (x[62:52] == kronos_pkg::FP_D_EXP_MAX) && (x[51] == 1'b1);
   endfunction
-  function automatic logic is_inf_d(logic [FP_D_TOTAL_W-1:0] x);
-    return (x[62:52] == FP_D_EXP_MAX) && (x[51:0] == 52'd0);
+  function automatic logic is_inf_d(logic [kronos_pkg::FP_D_TOTAL_W-1:0] x);
+    return (x[62:52] == kronos_pkg::FP_D_EXP_MAX) && (x[51:0] == 52'd0);
   endfunction
-  function automatic logic is_zero_d(logic [FP_D_TOTAL_W-1:0] x);
+  function automatic logic is_zero_d(logic [kronos_pkg::FP_D_TOTAL_W-1:0] x);
     return (x[62:0] == 63'd0);
   endfunction
 
   // ---------------------------------------------------------------------------
   // Stage 1 combinational: decompose, detect specials
   // ---------------------------------------------------------------------------
-  logic [FP_S_TOTAL_W-1:0] a_s, b_s, c_s;
-  logic [FP_D_TOTAL_W-1:0] a_d, b_d, c_d;
+  logic [kronos_pkg::FP_S_TOTAL_W-1:0] a_s, b_s, c_s;
+  logic [kronos_pkg::FP_D_TOTAL_W-1:0] a_d, b_d, c_d;
 
   // Common signal shape per operand
   logic               s1_a_sign, s1_b_sign, s1_c_sign;
@@ -106,14 +106,14 @@ module kronos_fpu_fma
 
   // Special result flags
   logic               s1_special;
-  logic [FLEN-1:0]    s1_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s1_special_result;
   logic [4:0]         s1_special_flags;
 
   always_comb begin
     // NaN-unbox single operands
-    a_s = (a_i[63:32] == FP_NANBOX_UPPER) ? a_i[31:0] : FP_CANON_QNAN_S;
-    b_s = (b_i[63:32] == FP_NANBOX_UPPER) ? b_i[31:0] : FP_CANON_QNAN_S;
-    c_s = (c_i[63:32] == FP_NANBOX_UPPER) ? c_i[31:0] : FP_CANON_QNAN_S;
+    a_s = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    b_s = (b_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    c_s = (c_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? c_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
     a_d = a_i;
     b_d = b_i;
     c_d = c_i;
@@ -184,7 +184,7 @@ module kronos_fpu_fma
 
     // Biased exponent of product (before normalize of significand).
     // Product significand lies in [1,4): we'll handle the extra bit in stage 4.
-    s1_prod_exp = s1_a_exp + s1_b_exp - 13'(fmt_d_i ? FP_D_BIAS : FP_S_BIAS);
+    s1_prod_exp = s1_a_exp + s1_b_exp - 13'(fmt_d_i ? kronos_pkg::FP_D_BIAS : kronos_pkg::FP_S_BIAS);
     s1_prod_zero = s1_a_zero || s1_b_zero;
 
     // ---------- Special-case resolution ----------
@@ -194,42 +194,42 @@ module kronos_fpu_fma
 
     if (s1_a_snan || s1_b_snan || s1_c_snan) begin
       s1_special              = 1'b1;
-      s1_special_result       = fmt_d_i ? FP_CANON_QNAN_D
-                                        : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_special_flags[FP_FFLAG_NV] = 1'b1;
+      s1_special_result       = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                        : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_special_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if ((s1_a_inf && s1_b_zero) || (s1_a_zero && s1_b_inf)) begin
       // 0 * inf -> invalid
       s1_special              = 1'b1;
-      s1_special_result       = fmt_d_i ? FP_CANON_QNAN_D
-                                        : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_special_flags[FP_FFLAG_NV] = 1'b1;
+      s1_special_result       = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                        : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_special_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if ((s1_a_inf || s1_b_inf) && s1_c_inf &&
                  (s1_prod_sign != s1_addend_sign)) begin
       // Inf - Inf -> invalid
       s1_special              = 1'b1;
-      s1_special_result       = fmt_d_i ? FP_CANON_QNAN_D
-                                        : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
-      s1_special_flags[FP_FFLAG_NV] = 1'b1;
+      s1_special_result       = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                        : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
+      s1_special_flags[kronos_pkg::FP_FFLAG_NV] = 1'b1;
     end else if (s1_a_nan || s1_b_nan || s1_c_nan) begin
       // Propagate as canonical qNaN
       s1_special        = 1'b1;
-      s1_special_result = fmt_d_i ? FP_CANON_QNAN_D
-                                  : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s1_special_result = fmt_d_i ? kronos_pkg::FP_CANON_QNAN_D
+                                  : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s1_a_inf || s1_b_inf) begin
       // Inf * finite (+/- finite addend, same sign or c finite)
       s1_special        = 1'b1;
       if (fmt_d_i) begin
-        s1_special_result = {s1_prod_sign, FP_D_EXP_MAX, 52'd0};
+        s1_special_result = {s1_prod_sign, kronos_pkg::FP_D_EXP_MAX, 52'd0};
       end else begin
-        s1_special_result = {FP_NANBOX_UPPER, s1_prod_sign, FP_S_EXP_MAX, 23'd0};
+        s1_special_result = {kronos_pkg::FP_NANBOX_UPPER, s1_prod_sign, kronos_pkg::FP_S_EXP_MAX, 23'd0};
       end
     end else if (s1_c_inf) begin
       // finite * finite + inf -> +/- inf (sign = addend sign)
       s1_special        = 1'b1;
       if (fmt_d_i) begin
-        s1_special_result = {s1_addend_sign, FP_D_EXP_MAX, 52'd0};
+        s1_special_result = {s1_addend_sign, kronos_pkg::FP_D_EXP_MAX, 52'd0};
       end else begin
-        s1_special_result = {FP_NANBOX_UPPER, s1_addend_sign, FP_S_EXP_MAX, 23'd0};
+        s1_special_result = {kronos_pkg::FP_NANBOX_UPPER, s1_addend_sign, kronos_pkg::FP_S_EXP_MAX, 23'd0};
       end
     end
   end
@@ -239,7 +239,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s2_valid;
   logic               s2_special;
-  logic [FLEN-1:0]    s2_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s2_special_result;
   logic [4:0]         s2_special_flags;
   logic               s2_fmt_d;
   logic [2:0]         s2_rm;
@@ -299,7 +299,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s2b_valid;
   logic               s2b_special;
-  logic [FLEN-1:0]    s2b_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s2b_special_result;
   logic [4:0]         s2b_special_flags;
   logic               s2b_fmt_d;
   logic [2:0]         s2b_rm;
@@ -360,7 +360,7 @@ module kronos_fpu_fma
   // Stage 2b -> Stage 3 register
   logic               s3_valid;
   logic               s3_special;
-  logic [FLEN-1:0]    s3_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s3_special_result;
   logic [4:0]         s3_special_flags;
   logic               s3_fmt_d;
   logic [2:0]         s3_rm;
@@ -399,7 +399,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s3b_valid;
   logic               s3b_special;
-  logic [FLEN-1:0]    s3b_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s3b_special_result;
   logic [4:0]         s3b_special_flags;
   logic               s3b_fmt_d;
   logic [2:0]         s3b_rm;
@@ -432,7 +432,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s4_valid;
   logic               s4_special;
-  logic [FLEN-1:0]    s4_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s4_special_result;
   logic [4:0]         s4_special_flags;
   logic               s4_fmt_d;
   logic [2:0]         s4_rm;
@@ -449,7 +449,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s4b_valid;
   logic               s4b_special;
-  logic [FLEN-1:0]    s4b_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s4b_special_result;
   logic [4:0]         s4b_special_flags;
   logic               s4b_fmt_d;
   logic [2:0]         s4b_rm;
@@ -480,7 +480,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s5_valid;
   logic               s5_special;
-  logic [FLEN-1:0]    s5_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s5_special_result;
   logic [4:0]         s5_special_flags;
   logic               s5_fmt_d;
   logic [2:0]         s5_rm;
@@ -520,7 +520,7 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   logic               s5b_valid;
   logic               s5b_special;
-  logic [FLEN-1:0]    s5b_special_result;
+  logic [kronos_pkg::FLEN-1:0]    s5b_special_result;
   logic [4:0]         s5b_special_flags;
   logic               s5b_fmt_d;
   logic [2:0]         s5b_rm;
@@ -540,7 +540,7 @@ module kronos_fpu_fma
   fpu_tag_t           s5b_tag;
 
   // Stage 5b combinational outputs (round, pack)
-  logic [FLEN-1:0]    s5b_result_comb;
+  logic [kronos_pkg::FLEN-1:0]    s5b_result_comb;
   logic [4:0]         s5b_flags_comb;
 
   // S5b scratch
@@ -554,8 +554,8 @@ module kronos_fpu_fma
   logic                       s5b_round_up;
   logic signed [12:0]         s5b_final_exp;
   logic [SIG_W-1:0]           s5b_final_sig;
-  logic [FP_D_EXP_W-1:0]      s5b_exp_field_d;
-  logic [FP_S_EXP_W-1:0]      s5b_exp_field_s;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]      s5b_exp_field_d;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]      s5b_exp_field_s;
   // Tininess-after-rounding scratch ("_n" here = "narrow" per file convention).
   logic [SIG_W-1:0]           s5b_raw_sig_n;
   logic                       s5b_guard_n, s5b_round_n, s5b_sticky_n;
@@ -961,11 +961,11 @@ module kronos_fpu_fma
 
     if (!s5_special && !s5_zero) begin
       if (s5_fmt_d) begin
-        s5_frac_w = FP_D_MANT_W;
-        s5_bias   = FP_D_BIAS;
+        s5_frac_w = kronos_pkg::FP_D_MANT_W;
+        s5_bias   = kronos_pkg::FP_D_BIAS;
       end else begin
-        s5_frac_w = FP_S_MANT_W;
-        s5_bias   = FP_S_BIAS;
+        s5_frac_w = kronos_pkg::FP_S_MANT_W;
+        s5_bias   = kronos_pkg::FP_S_BIAS;
       end
       s5_emin = 13'sd1;
 
@@ -1090,8 +1090,8 @@ module kronos_fpu_fma
     s5b_round_up           = 1'b0;
     s5b_final_exp          = 13'h0;
     s5b_final_sig          = {SIG_W{1'b0}};
-    s5b_exp_field_d        = {FP_D_EXP_W{1'b0}};
-    s5b_exp_field_s        = {FP_S_EXP_W{1'b0}};
+    s5b_exp_field_d        = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    s5b_exp_field_s        = {kronos_pkg::FP_S_EXP_W{1'b0}};
     s5b_raw_sig_n          = {SIG_W{1'b0}};
     s5b_guard_n            = 1'b0;
     s5b_round_n            = 1'b0;
@@ -1111,28 +1111,28 @@ module kronos_fpu_fma
       if (s5b_eff_sub) begin
         if (s5b_rm == FP_RM_RDN) begin
           s5b_result_comb = s5b_fmt_d ? {1'b1, 63'd0}
-                                      : {FP_NANBOX_UPPER, 1'b1, 31'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 31'd0};
         end else begin
           s5b_result_comb = s5b_fmt_d ? 64'd0
-                                      : {FP_NANBOX_UPPER, 32'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 32'd0};
         end
       end else begin
         if (s5b_prod_sign) begin
           s5b_result_comb = s5b_fmt_d ? {1'b1, 63'd0}
-                                      : {FP_NANBOX_UPPER, 1'b1, 31'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 31'd0};
         end else begin
           s5b_result_comb = s5b_fmt_d ? 64'd0
-                                      : {FP_NANBOX_UPPER, 32'd0};
+                                      : {kronos_pkg::FP_NANBOX_UPPER, 32'd0};
         end
       end
     end else begin
       if (s5b_fmt_d) begin
-        s5b_frac_w = FP_D_MANT_W;
-        s5b_bias   = FP_D_BIAS;
+        s5b_frac_w = kronos_pkg::FP_D_MANT_W;
+        s5b_bias   = kronos_pkg::FP_D_BIAS;
         s5b_emax   = 13'sd2046;
       end else begin
-        s5b_frac_w = FP_S_MANT_W;
-        s5b_bias   = FP_S_BIAS;
+        s5b_frac_w = kronos_pkg::FP_S_MANT_W;
+        s5b_bias   = kronos_pkg::FP_S_BIAS;
         s5b_emax   = 13'sd254;
       end
       s5b_emin = 13'sd1;
@@ -1220,61 +1220,61 @@ module kronos_fpu_fma
         endcase
 
         if (s5b_fmt_d) begin
-          s5b_carry_n = s5b_round_up_n & (&s5b_raw_sig_n[FP_D_MANT_W:0]);
+          s5b_carry_n = s5b_round_up_n & (&s5b_raw_sig_n[kronos_pkg::FP_D_MANT_W:0]);
         end else begin
-          s5b_carry_n = s5b_round_up_n & (&s5b_raw_sig_n[FP_S_MANT_W:0]);
+          s5b_carry_n = s5b_round_up_n & (&s5b_raw_sig_n[kronos_pkg::FP_S_MANT_W:0]);
         end
 
         if (!(s5b_carry_n && (s5b_exp_pre_tiny + 13'sd1 == s5b_emin))) begin
-          s5b_flags_comb[FP_FFLAG_UF] = 1'b1;
+          s5b_flags_comb[kronos_pkg::FP_FFLAG_UF] = 1'b1;
         end
       end
 
-      if (s5b_inexact) s5b_flags_comb[FP_FFLAG_NX] = 1'b1;
+      if (s5b_inexact) s5b_flags_comb[kronos_pkg::FP_FFLAG_NX] = 1'b1;
 
       if (s5b_overflow_ovf) begin
-        s5b_flags_comb[FP_FFLAG_OF] = 1'b1;
-        s5b_flags_comb[FP_FFLAG_NX] = 1'b1;
+        s5b_flags_comb[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+        s5b_flags_comb[kronos_pkg::FP_FFLAG_NX] = 1'b1;
         unique case (s5b_rm)
           FP_RM_RTZ: begin
             if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, 11'd2046, {52{1'b1}}};
-            else           s5b_result_comb = {FP_NANBOX_UPPER,
+            else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                               s5b_res_sign, 8'd254, {23{1'b1}}};
           end
           FP_RM_RDN: begin
             if (s5b_res_sign) begin
-              if (s5b_fmt_d) s5b_result_comb = {1'b1, FP_D_EXP_MAX, 52'd0};
-              else           s5b_result_comb = {FP_NANBOX_UPPER, 1'b1, FP_S_EXP_MAX, 23'd0};
+              if (s5b_fmt_d) s5b_result_comb = {1'b1, kronos_pkg::FP_D_EXP_MAX, 52'd0};
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER, 1'b1, kronos_pkg::FP_S_EXP_MAX, 23'd0};
             end else begin
               if (s5b_fmt_d) s5b_result_comb = {1'b0, 11'd2046, {52{1'b1}}};
-              else           s5b_result_comb = {FP_NANBOX_UPPER,
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                                1'b0, 8'd254, {23{1'b1}}};
             end
           end
           FP_RM_RUP: begin
             if (s5b_res_sign) begin
               if (s5b_fmt_d) s5b_result_comb = {1'b1, 11'd2046, {52{1'b1}}};
-              else           s5b_result_comb = {FP_NANBOX_UPPER,
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
                                                1'b1, 8'd254, {23{1'b1}}};
             end else begin
-              if (s5b_fmt_d) s5b_result_comb = {1'b0, FP_D_EXP_MAX, 52'd0};
-              else           s5b_result_comb = {FP_NANBOX_UPPER, 1'b0, FP_S_EXP_MAX, 23'd0};
+              if (s5b_fmt_d) s5b_result_comb = {1'b0, kronos_pkg::FP_D_EXP_MAX, 52'd0};
+              else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER, 1'b0, kronos_pkg::FP_S_EXP_MAX, 23'd0};
             end
           end
           default: begin
-            if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, FP_D_EXP_MAX, 52'd0};
-            else           s5b_result_comb = {FP_NANBOX_UPPER,
-                                             s5b_res_sign, FP_S_EXP_MAX, 23'd0};
+            if (s5b_fmt_d) s5b_result_comb = {s5b_res_sign, kronos_pkg::FP_D_EXP_MAX, 52'd0};
+            else           s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER,
+                                             s5b_res_sign, kronos_pkg::FP_S_EXP_MAX, 23'd0};
           end
         endcase
       end else begin
         if (s5b_fmt_d) begin
-          s5b_exp_field_d = s5b_final_exp[FP_D_EXP_W-1:0];
-          s5b_result_comb = {s5b_res_sign, s5b_exp_field_d, s5b_final_sig[FP_D_MANT_W-1:0]};
+          s5b_exp_field_d = s5b_final_exp[kronos_pkg::FP_D_EXP_W-1:0];
+          s5b_result_comb = {s5b_res_sign, s5b_exp_field_d, s5b_final_sig[kronos_pkg::FP_D_MANT_W-1:0]};
         end else begin
-          s5b_exp_field_s = s5b_final_exp[FP_S_EXP_W-1:0];
-          s5b_result_comb = {FP_NANBOX_UPPER, s5b_res_sign, s5b_exp_field_s,
-                             s5b_final_sig[FP_S_MANT_W-1:0]};
+          s5b_exp_field_s = s5b_final_exp[kronos_pkg::FP_S_EXP_W-1:0];
+          s5b_result_comb = {kronos_pkg::FP_NANBOX_UPPER, s5b_res_sign, s5b_exp_field_s,
+                             s5b_final_sig[kronos_pkg::FP_S_MANT_W-1:0]};
         end
       end
     end

--- a/rtl/stage6/fpu/kronos_fpu_fmisc.sv
+++ b/rtl/stage6/fpu/kronos_fpu_fmisc.sv
@@ -12,11 +12,11 @@ module kronos_fpu_fmisc
   input  fp_op_e          op_i,
   input  logic            fmt_d_i,
   input  logic [2:0]      rm_i,
-  input  logic [FLEN-1:0] a_i,
-  input  logic [FLEN-1:0] b_i,
+  input  logic [kronos_pkg::FLEN-1:0] a_i,
+  input  logic [kronos_pkg::FLEN-1:0] b_i,
   input  fpu_tag_t        tag_i,
   output logic            out_valid_o,
-  output logic [FLEN-1:0] result_o,
+  output logic [kronos_pkg::FLEN-1:0] result_o,
   output logic [4:0]      fflags_o,
   output fpu_tag_t        tag_o
 );
@@ -24,48 +24,48 @@ module kronos_fpu_fmisc
   // -------------------------------------------------------------------------
   // Helper functions: NaN classification for single-precision
   // -------------------------------------------------------------------------
-  function automatic logic is_snan_s(logic [FP_S_TOTAL_W-1:0] x);
-    return (x[FP_S_TOTAL_W-2:FP_S_MANT_W] == FP_S_EXP_MAX) &&
-           (x[FP_S_MANT_W-1] == 1'b0) &&
-           (x[FP_S_MANT_W-2:0] != {(FP_S_MANT_W-1){1'b0}});
+  function automatic logic is_snan_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
+    return (x[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] == kronos_pkg::FP_S_EXP_MAX) &&
+           (x[kronos_pkg::FP_S_MANT_W-1] == 1'b0) &&
+           (x[kronos_pkg::FP_S_MANT_W-2:0] != {(kronos_pkg::FP_S_MANT_W-1){1'b0}});
   endfunction
 
-  function automatic logic is_qnan_s(logic [FP_S_TOTAL_W-1:0] x);
-    return (x[FP_S_TOTAL_W-2:FP_S_MANT_W] == FP_S_EXP_MAX) &&
-           (x[FP_S_MANT_W-1] == 1'b1);
+  function automatic logic is_qnan_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
+    return (x[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] == kronos_pkg::FP_S_EXP_MAX) &&
+           (x[kronos_pkg::FP_S_MANT_W-1] == 1'b1);
   endfunction
 
-  function automatic logic is_nan_s(logic [FP_S_TOTAL_W-1:0] x);
+  function automatic logic is_nan_s(logic [kronos_pkg::FP_S_TOTAL_W-1:0] x);
     return is_snan_s(x) || is_qnan_s(x);
   endfunction
 
   // -------------------------------------------------------------------------
   // Helper functions: NaN classification for double-precision
   // -------------------------------------------------------------------------
-  function automatic logic is_snan_d(logic [FP_D_TOTAL_W-2:0] x);
-    return (x[FP_D_TOTAL_W-2:FP_D_MANT_W] == FP_D_EXP_MAX) &&
-           (x[FP_D_MANT_W-1] == 1'b0) &&
-           (x[FP_D_MANT_W-2:0] != {(FP_D_MANT_W-1){1'b0}});
+  function automatic logic is_snan_d(logic [kronos_pkg::FP_D_TOTAL_W-2:0] x);
+    return (x[kronos_pkg::FP_D_TOTAL_W-2:FP_D_MANT_W] == kronos_pkg::FP_D_EXP_MAX) &&
+           (x[kronos_pkg::FP_D_MANT_W-1] == 1'b0) &&
+           (x[kronos_pkg::FP_D_MANT_W-2:0] != {(kronos_pkg::FP_D_MANT_W-1){1'b0}});
   endfunction
 
-  function automatic logic is_qnan_d(logic [FP_D_TOTAL_W-2:0] x);
-    return (x[FP_D_TOTAL_W-2:FP_D_MANT_W] == FP_D_EXP_MAX) &&
-           (x[FP_D_MANT_W-1] == 1'b1);
+  function automatic logic is_qnan_d(logic [kronos_pkg::FP_D_TOTAL_W-2:0] x);
+    return (x[kronos_pkg::FP_D_TOTAL_W-2:FP_D_MANT_W] == kronos_pkg::FP_D_EXP_MAX) &&
+           (x[kronos_pkg::FP_D_MANT_W-1] == 1'b1);
   endfunction
 
-  function automatic logic is_nan_d(logic [FP_D_TOTAL_W-2:0] x);
+  function automatic logic is_nan_d(logic [kronos_pkg::FP_D_TOTAL_W-2:0] x);
     return is_snan_d(x) || is_qnan_d(x);
   endfunction
 
   // -------------------------------------------------------------------------
   // Combinational signals
   // -------------------------------------------------------------------------
-  logic [FLEN-1:0] result_comb;
+  logic [kronos_pkg::FLEN-1:0] result_comb;
   logic [4:0]      fflags_comb;
 
   // NaN-unboxed operands for single-precision use
-  logic [FP_S_TOTAL_W-1:0] a_s, b_s;
-  logic [FLEN-1:0]         a_eff, b_eff;
+  logic [kronos_pkg::FP_S_TOTAL_W-1:0] a_s, b_s;
+  logic [kronos_pkg::FLEN-1:0]         a_eff, b_eff;
 
   // Intermediate signals for FMIN/FMAX
   logic a_nan_s, b_nan_s, a_snan_s, b_snan_s;
@@ -73,13 +73,13 @@ module kronos_fpu_fmisc
 
   // Single-precision comparison helpers
   logic                    a_sign_s, b_sign_s;
-  logic [FP_S_TOTAL_W-2:0] a_mag_s, b_mag_s;
+  logic [kronos_pkg::FP_S_TOTAL_W-2:0] a_mag_s, b_mag_s;
   logic                    a_zero_s, b_zero_s;
   logic                    a_lt_b_s;     // a < b numerically (single)
 
   // Double-precision comparison helpers
   logic                    a_sign_d, b_sign_d;
-  logic [FP_D_TOTAL_W-2:0] a_mag_d, b_mag_d;
+  logic [kronos_pkg::FP_D_TOTAL_W-2:0] a_mag_d, b_mag_d;
   logic                    a_zero_d, b_zero_d;
   logic                    a_lt_b_d;     // a < b numerically (double)
 
@@ -96,24 +96,24 @@ module kronos_fpu_fmisc
   // -------------------------------------------------------------------------
   always_comb begin
     // Defaults
-    a_s   = FP_CANON_QNAN_S;
-    b_s   = FP_CANON_QNAN_S;
-    a_eff = {FLEN{1'b0}};
-    b_eff = {FLEN{1'b0}};
+    a_s   = kronos_pkg::FP_CANON_QNAN_S;
+    b_s   = kronos_pkg::FP_CANON_QNAN_S;
+    a_eff = {kronos_pkg::FLEN{1'b0}};
+    b_eff = {kronos_pkg::FLEN{1'b0}};
 
     // NaN-unbox single operands
-    a_s = (a_i[FLEN-1:FP_S_TOTAL_W] == FP_NANBOX_UPPER) ? a_i[FP_S_TOTAL_W-1:0]
-                                                        : FP_CANON_QNAN_S;
-    b_s = (b_i[FLEN-1:FP_S_TOTAL_W] == FP_NANBOX_UPPER) ? b_i[FP_S_TOTAL_W-1:0]
-                                                        : FP_CANON_QNAN_S;
+    a_s = (a_i[kronos_pkg::FLEN-1:FP_S_TOTAL_W] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[kronos_pkg::FP_S_TOTAL_W-1:0]
+                                                        : kronos_pkg::FP_CANON_QNAN_S;
+    b_s = (b_i[kronos_pkg::FLEN-1:FP_S_TOTAL_W] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[kronos_pkg::FP_S_TOTAL_W-1:0]
+                                                        : kronos_pkg::FP_CANON_QNAN_S;
 
     // Effective operands for each format
     if (fmt_d_i) begin
       a_eff = a_i;
       b_eff = b_i;
     end else begin
-      a_eff = {FP_NANBOX_UPPER, a_s};
-      b_eff = {FP_NANBOX_UPPER, b_s};
+      a_eff = {kronos_pkg::FP_NANBOX_UPPER, a_s};
+      b_eff = {kronos_pkg::FP_NANBOX_UPPER, b_s};
     end
   end
 
@@ -132,14 +132,14 @@ module kronos_fpu_fmisc
     b_snan_d    = 1'b0;
     a_sign_s    = 1'b0;
     b_sign_s    = 1'b0;
-    a_mag_s     = {(FP_S_TOTAL_W-1){1'b0}};
-    b_mag_s     = {(FP_S_TOTAL_W-1){1'b0}};
+    a_mag_s     = {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}};
+    b_mag_s     = {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}};
     a_zero_s    = 1'b0;
     b_zero_s    = 1'b0;
     a_sign_d    = 1'b0;
     b_sign_d    = 1'b0;
-    a_mag_d     = {(FP_D_TOTAL_W-1){1'b0}};
-    b_mag_d     = {(FP_D_TOTAL_W-1){1'b0}};
+    a_mag_d     = {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}};
+    b_mag_d     = {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}};
     a_zero_d    = 1'b0;
     b_zero_d    = 1'b0;
     a_lt_b_s    = 1'b0;
@@ -159,26 +159,26 @@ module kronos_fpu_fmisc
     b_snan_s = is_snan_s(b_s);
 
     // Double
-    a_nan_d  = is_nan_d(a_i[FLEN-2:0]);
-    b_nan_d  = is_nan_d(b_i[FLEN-2:0]);
-    a_snan_d = is_snan_d(a_i[FLEN-2:0]);
-    b_snan_d = is_snan_d(b_i[FLEN-2:0]);
+    a_nan_d  = is_nan_d(a_i[kronos_pkg::FLEN-2:0]);
+    b_nan_d  = is_nan_d(b_i[kronos_pkg::FLEN-2:0]);
+    a_snan_d = is_snan_d(a_i[kronos_pkg::FLEN-2:0]);
+    b_snan_d = is_snan_d(b_i[kronos_pkg::FLEN-2:0]);
 
     // Single magnitude/sign for comparisons
-    a_sign_s = a_s[FP_S_TOTAL_W-1];
-    b_sign_s = b_s[FP_S_TOTAL_W-1];
-    a_mag_s  = a_s[FP_S_TOTAL_W-2:0];
-    b_mag_s  = b_s[FP_S_TOTAL_W-2:0];
-    a_zero_s = (a_mag_s == {(FP_S_TOTAL_W-1){1'b0}});
-    b_zero_s = (b_mag_s == {(FP_S_TOTAL_W-1){1'b0}});
+    a_sign_s = a_s[kronos_pkg::FP_S_TOTAL_W-1];
+    b_sign_s = b_s[kronos_pkg::FP_S_TOTAL_W-1];
+    a_mag_s  = a_s[kronos_pkg::FP_S_TOTAL_W-2:0];
+    b_mag_s  = b_s[kronos_pkg::FP_S_TOTAL_W-2:0];
+    a_zero_s = (a_mag_s == {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}});
+    b_zero_s = (b_mag_s == {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}});
 
     // Double magnitude/sign for comparisons
-    a_sign_d = a_i[FLEN-1];
-    b_sign_d = b_i[FLEN-1];
-    a_mag_d  = a_i[FLEN-2:0];
-    b_mag_d  = b_i[FLEN-2:0];
-    a_zero_d = (a_mag_d == {(FP_D_TOTAL_W-1){1'b0}});
-    b_zero_d = (b_mag_d == {(FP_D_TOTAL_W-1){1'b0}});
+    a_sign_d = a_i[kronos_pkg::FLEN-1];
+    b_sign_d = b_i[kronos_pkg::FLEN-1];
+    a_mag_d  = a_i[kronos_pkg::FLEN-2:0];
+    b_mag_d  = b_i[kronos_pkg::FLEN-2:0];
+    a_zero_d = (a_mag_d == {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}});
+    b_zero_d = (b_mag_d == {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}});
 
     // Numeric comparison: a < b (single, ignoring NaN)
     // Two negatives: larger magnitude = smaller value
@@ -218,48 +218,48 @@ module kronos_fpu_fmisc
     // RISC-V spec: bit 8 = signalling NaN, bit 9 = quiet NaN.
     if (fmt_d_i) begin
       // Double
-      if (is_snan_d(a_i[FLEN-2:0]))
-        fclass_bits = FCLASS_SNAN;
-      else if (is_qnan_d(a_i[FLEN-2:0]))
-        fclass_bits = FCLASS_QNAN;
-      else if (a_i[FLEN-1] && (a_i[FLEN-2:FP_D_MANT_W] == FP_D_EXP_MAX))
-        fclass_bits = FCLASS_NEG_INF;
-      else if (!a_i[FLEN-1] && (a_i[FLEN-2:FP_D_MANT_W] == FP_D_EXP_MAX))
-        fclass_bits = FCLASS_POS_INF;
-      else if (a_i[FLEN-1] && (a_i[FLEN-2:FP_D_MANT_W] != {FP_D_EXP_W{1'b0}}))
-        fclass_bits = FCLASS_NEG_NORMAL;
-      else if (!a_i[FLEN-1] && (a_i[FLEN-2:FP_D_MANT_W] != {FP_D_EXP_W{1'b0}}))
-        fclass_bits = FCLASS_POS_NORMAL;
-      else if (a_i[FLEN-1] && (a_i[FLEN-2:FP_D_MANT_W] == {FP_D_EXP_W{1'b0}}) && (a_i[FP_D_MANT_W-1:0] != {FP_D_MANT_W{1'b0}}))
-        fclass_bits = FCLASS_NEG_SUBNORMAL;
-      else if (!a_i[FLEN-1] && (a_i[FLEN-2:FP_D_MANT_W] == {FP_D_EXP_W{1'b0}}) && (a_i[FP_D_MANT_W-1:0] != {FP_D_MANT_W{1'b0}}))
-        fclass_bits = FCLASS_POS_SUBNORMAL;
-      else if (a_i[FLEN-1])
-        fclass_bits = FCLASS_NEG_ZERO;
+      if (is_snan_d(a_i[kronos_pkg::FLEN-2:0]))
+        fclass_bits = kronos_pkg::FCLASS_SNAN;
+      else if (is_qnan_d(a_i[kronos_pkg::FLEN-2:0]))
+        fclass_bits = kronos_pkg::FCLASS_QNAN;
+      else if (a_i[kronos_pkg::FLEN-1] && (a_i[kronos_pkg::FLEN-2:FP_D_MANT_W] == kronos_pkg::FP_D_EXP_MAX))
+        fclass_bits = kronos_pkg::FCLASS_NEG_INF;
+      else if (!a_i[kronos_pkg::FLEN-1] && (a_i[kronos_pkg::FLEN-2:FP_D_MANT_W] == kronos_pkg::FP_D_EXP_MAX))
+        fclass_bits = kronos_pkg::FCLASS_POS_INF;
+      else if (a_i[kronos_pkg::FLEN-1] && (a_i[kronos_pkg::FLEN-2:FP_D_MANT_W] != {kronos_pkg::FP_D_EXP_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_NEG_NORMAL;
+      else if (!a_i[kronos_pkg::FLEN-1] && (a_i[kronos_pkg::FLEN-2:FP_D_MANT_W] != {kronos_pkg::FP_D_EXP_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_POS_NORMAL;
+      else if (a_i[kronos_pkg::FLEN-1] && (a_i[kronos_pkg::FLEN-2:FP_D_MANT_W] == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (a_i[kronos_pkg::FP_D_MANT_W-1:0] != {kronos_pkg::FP_D_MANT_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_NEG_SUBNORMAL;
+      else if (!a_i[kronos_pkg::FLEN-1] && (a_i[kronos_pkg::FLEN-2:FP_D_MANT_W] == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (a_i[kronos_pkg::FP_D_MANT_W-1:0] != {kronos_pkg::FP_D_MANT_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_POS_SUBNORMAL;
+      else if (a_i[kronos_pkg::FLEN-1])
+        fclass_bits = kronos_pkg::FCLASS_NEG_ZERO;
       else
-        fclass_bits = FCLASS_POS_ZERO;
+        fclass_bits = kronos_pkg::FCLASS_POS_ZERO;
     end else begin
       // Single (use unboxed a_s)
       if (is_snan_s(a_s))
-        fclass_bits = FCLASS_SNAN;
+        fclass_bits = kronos_pkg::FCLASS_SNAN;
       else if (is_qnan_s(a_s))
-        fclass_bits = FCLASS_QNAN;
-      else if (a_s[FP_S_TOTAL_W-1] && (a_s[FP_S_TOTAL_W-2:FP_S_MANT_W] == FP_S_EXP_MAX))
-        fclass_bits = FCLASS_NEG_INF;
-      else if (!a_s[FP_S_TOTAL_W-1] && (a_s[FP_S_TOTAL_W-2:FP_S_MANT_W] == FP_S_EXP_MAX))
-        fclass_bits = FCLASS_POS_INF;
-      else if (a_s[FP_S_TOTAL_W-1] && (a_s[FP_S_TOTAL_W-2:FP_S_MANT_W] != {FP_S_EXP_W{1'b0}}))
-        fclass_bits = FCLASS_NEG_NORMAL;
-      else if (!a_s[FP_S_TOTAL_W-1] && (a_s[FP_S_TOTAL_W-2:FP_S_MANT_W] != {FP_S_EXP_W{1'b0}}))
-        fclass_bits = FCLASS_POS_NORMAL;
-      else if (a_s[FP_S_TOTAL_W-1] && (a_s[FP_S_TOTAL_W-2:FP_S_MANT_W] == {FP_S_EXP_W{1'b0}}) && (a_s[FP_S_MANT_W-1:0] != {FP_S_MANT_W{1'b0}}))
-        fclass_bits = FCLASS_NEG_SUBNORMAL;
-      else if (!a_s[FP_S_TOTAL_W-1] && (a_s[FP_S_TOTAL_W-2:FP_S_MANT_W] == {FP_S_EXP_W{1'b0}}) && (a_s[FP_S_MANT_W-1:0] != {FP_S_MANT_W{1'b0}}))
-        fclass_bits = FCLASS_POS_SUBNORMAL;
-      else if (a_s[FP_S_TOTAL_W-1])
-        fclass_bits = FCLASS_NEG_ZERO;
+        fclass_bits = kronos_pkg::FCLASS_QNAN;
+      else if (a_s[kronos_pkg::FP_S_TOTAL_W-1] && (a_s[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] == kronos_pkg::FP_S_EXP_MAX))
+        fclass_bits = kronos_pkg::FCLASS_NEG_INF;
+      else if (!a_s[kronos_pkg::FP_S_TOTAL_W-1] && (a_s[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] == kronos_pkg::FP_S_EXP_MAX))
+        fclass_bits = kronos_pkg::FCLASS_POS_INF;
+      else if (a_s[kronos_pkg::FP_S_TOTAL_W-1] && (a_s[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] != {kronos_pkg::FP_S_EXP_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_NEG_NORMAL;
+      else if (!a_s[kronos_pkg::FP_S_TOTAL_W-1] && (a_s[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] != {kronos_pkg::FP_S_EXP_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_POS_NORMAL;
+      else if (a_s[kronos_pkg::FP_S_TOTAL_W-1] && (a_s[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (a_s[kronos_pkg::FP_S_MANT_W-1:0] != {kronos_pkg::FP_S_MANT_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_NEG_SUBNORMAL;
+      else if (!a_s[kronos_pkg::FP_S_TOTAL_W-1] && (a_s[kronos_pkg::FP_S_TOTAL_W-2:FP_S_MANT_W] == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (a_s[kronos_pkg::FP_S_MANT_W-1:0] != {kronos_pkg::FP_S_MANT_W{1'b0}}))
+        fclass_bits = kronos_pkg::FCLASS_POS_SUBNORMAL;
+      else if (a_s[kronos_pkg::FP_S_TOTAL_W-1])
+        fclass_bits = kronos_pkg::FCLASS_NEG_ZERO;
       else
-        fclass_bits = FCLASS_POS_ZERO;
+        fclass_bits = kronos_pkg::FCLASS_POS_ZERO;
     end
   end
 
@@ -267,32 +267,32 @@ module kronos_fpu_fmisc
   // Main combinational result computation
   // -------------------------------------------------------------------------
   always_comb begin
-    result_comb = {FLEN{1'b0}};
+    result_comb = {kronos_pkg::FLEN{1'b0}};
     fflags_comb = 5'h0;
 
     unique case (op_i)
       // --- Sign injection ---
       FP_FSGNJ: begin
         if (fmt_d_i) begin
-          result_comb = {b_eff[FLEN-1], a_eff[FLEN-2:0]};
+          result_comb = {b_eff[kronos_pkg::FLEN-1], a_eff[kronos_pkg::FLEN-2:0]};
         end else begin
-          result_comb = {FP_NANBOX_UPPER, b_s[FP_S_TOTAL_W-1], a_s[FP_S_TOTAL_W-2:0]};
+          result_comb = {kronos_pkg::FP_NANBOX_UPPER, b_s[kronos_pkg::FP_S_TOTAL_W-1], a_s[kronos_pkg::FP_S_TOTAL_W-2:0]};
         end
       end
 
       FP_FSGNJN: begin
         if (fmt_d_i) begin
-          result_comb = {~b_eff[FLEN-1], a_eff[FLEN-2:0]};
+          result_comb = {~b_eff[kronos_pkg::FLEN-1], a_eff[kronos_pkg::FLEN-2:0]};
         end else begin
-          result_comb = {FP_NANBOX_UPPER, ~b_s[FP_S_TOTAL_W-1], a_s[FP_S_TOTAL_W-2:0]};
+          result_comb = {kronos_pkg::FP_NANBOX_UPPER, ~b_s[kronos_pkg::FP_S_TOTAL_W-1], a_s[kronos_pkg::FP_S_TOTAL_W-2:0]};
         end
       end
 
       FP_FSGNJX: begin
         if (fmt_d_i) begin
-          result_comb = {a_eff[FLEN-1] ^ b_eff[FLEN-1], a_eff[FLEN-2:0]};
+          result_comb = {a_eff[kronos_pkg::FLEN-1] ^ b_eff[kronos_pkg::FLEN-1], a_eff[kronos_pkg::FLEN-2:0]};
         end else begin
-          result_comb = {FP_NANBOX_UPPER, a_s[FP_S_TOTAL_W-1] ^ b_s[FP_S_TOTAL_W-1], a_s[FP_S_TOTAL_W-2:0]};
+          result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_s[kronos_pkg::FP_S_TOTAL_W-1] ^ b_s[kronos_pkg::FP_S_TOTAL_W-1], a_s[kronos_pkg::FP_S_TOTAL_W-2:0]};
         end
       end
 
@@ -304,9 +304,9 @@ module kronos_fpu_fmisc
       //   - Quiet NaN on one operand silently returns the other.
       FP_FMIN: begin
         if (fmt_d_i) begin
-          if (a_snan_d || b_snan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_d || b_snan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_d && b_nan_d) begin
-            result_comb = FP_CANON_QNAN_D;
+            result_comb = kronos_pkg::FP_CANON_QNAN_D;
           end else if (a_nan_d) begin
             result_comb = b_i;
           end else if (b_nan_d) begin
@@ -314,26 +314,26 @@ module kronos_fpu_fmisc
           end else begin
             // Both numeric: min(-0,+0) = -0
             if (a_zero_d && b_zero_d) begin
-              result_comb = (a_sign_d || b_sign_d) ? {1'b1, {(FP_D_TOTAL_W-1){1'b0}}} : a_i;
+              result_comb = (a_sign_d || b_sign_d) ? {1'b1, {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}} : a_i;
             end else begin
               result_comb = a_lt_b_d ? a_i : b_i;
             end
           end
         end else begin
-          if (a_snan_s || b_snan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_s || b_snan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_s && b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
           end else if (a_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, b_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, b_s};
           end else if (b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, a_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_s};
           end else begin
             // Both numeric: min(-0,+0) = -0
             if (a_zero_s && b_zero_s) begin
-              result_comb = (a_sign_s || b_sign_s) ? {FP_NANBOX_UPPER, 1'b1, {(FP_S_TOTAL_W-1){1'b0}}}
-                                                   : {FP_NANBOX_UPPER, a_s};
+              result_comb = (a_sign_s || b_sign_s) ? {kronos_pkg::FP_NANBOX_UPPER, 1'b1, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}}
+                                                   : {kronos_pkg::FP_NANBOX_UPPER, a_s};
             end else begin
-              result_comb = a_lt_b_s ? {FP_NANBOX_UPPER, a_s} : {FP_NANBOX_UPPER, b_s};
+              result_comb = a_lt_b_s ? {kronos_pkg::FP_NANBOX_UPPER, a_s} : {kronos_pkg::FP_NANBOX_UPPER, b_s};
             end
           end
         end
@@ -341,9 +341,9 @@ module kronos_fpu_fmisc
 
       FP_FMAX: begin
         if (fmt_d_i) begin
-          if (a_snan_d || b_snan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_d || b_snan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_d && b_nan_d) begin
-            result_comb = FP_CANON_QNAN_D;
+            result_comb = kronos_pkg::FP_CANON_QNAN_D;
           end else if (a_nan_d) begin
             result_comb = b_i;
           end else if (b_nan_d) begin
@@ -351,26 +351,26 @@ module kronos_fpu_fmisc
           end else begin
             // Both numeric: max(-0,+0) = +0
             if (a_zero_d && b_zero_d) begin
-              result_comb = (!a_sign_d || !b_sign_d) ? {1'b0, {(FP_D_TOTAL_W-1){1'b0}}} : a_i;
+              result_comb = (!a_sign_d || !b_sign_d) ? {1'b0, {(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}} : a_i;
             end else begin
               result_comb = a_lt_b_d ? b_i : a_i;
             end
           end
         end else begin
-          if (a_snan_s || b_snan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
+          if (a_snan_s || b_snan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
           if (a_nan_s && b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
           end else if (a_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, b_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, b_s};
           end else if (b_nan_s) begin
-            result_comb = {FP_NANBOX_UPPER, a_s};
+            result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_s};
           end else begin
             // Both numeric: max(-0,+0) = +0
             if (a_zero_s && b_zero_s) begin
-              result_comb = (!a_sign_s || !b_sign_s) ? {FP_NANBOX_UPPER, 1'b0, {(FP_S_TOTAL_W-1){1'b0}}}
-                                                     : {FP_NANBOX_UPPER, a_s};
+              result_comb = (!a_sign_s || !b_sign_s) ? {kronos_pkg::FP_NANBOX_UPPER, 1'b0, {(kronos_pkg::FP_S_TOTAL_W-1){1'b0}}}
+                                                     : {kronos_pkg::FP_NANBOX_UPPER, a_s};
             end else begin
-              result_comb = a_lt_b_s ? {FP_NANBOX_UPPER, b_s} : {FP_NANBOX_UPPER, a_s};
+              result_comb = a_lt_b_s ? {kronos_pkg::FP_NANBOX_UPPER, b_s} : {kronos_pkg::FP_NANBOX_UPPER, a_s};
             end
           end
         end
@@ -378,52 +378,52 @@ module kronos_fpu_fmisc
 
       // --- FCLASS ---
       FP_FCLASS: begin
-        result_comb = {{(FLEN-10){1'b0}}, fclass_bits};
+        result_comb = {{(kronos_pkg::FLEN-10){1'b0}}, fclass_bits};
       end
 
       // --- Comparisons ---
       FP_FEQ: begin
         if (fmt_d_i) begin
           // FEQ: only raises NV on sNaN
-          if (a_snan_d || b_snan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
-          result_comb = {{(FP_D_TOTAL_W-1){1'b0}}, cmp_eq_d};
+          if (a_snan_d || b_snan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+          result_comb = {{(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}, cmp_eq_d};
         end else begin
-          if (a_snan_s || b_snan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
-          result_comb = {{(FP_D_TOTAL_W-1){1'b0}}, cmp_eq_s};
+          if (a_snan_s || b_snan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+          result_comb = {{(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}, cmp_eq_s};
         end
       end
 
       FP_FLT: begin
         if (fmt_d_i) begin
           // FLT: raises NV on any NaN
-          if (a_nan_d || b_nan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
-          result_comb = {{(FP_D_TOTAL_W-1){1'b0}}, cmp_lt_d};
+          if (a_nan_d || b_nan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+          result_comb = {{(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}, cmp_lt_d};
         end else begin
-          if (a_nan_s || b_nan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
-          result_comb = {{(FP_D_TOTAL_W-1){1'b0}}, cmp_lt_s};
+          if (a_nan_s || b_nan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+          result_comb = {{(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}, cmp_lt_s};
         end
       end
 
       FP_FLE: begin
         if (fmt_d_i) begin
           // FLE: raises NV on any NaN
-          if (a_nan_d || b_nan_d) fflags_comb[FP_FFLAG_NV] = 1'b1;
-          result_comb = {{(FP_D_TOTAL_W-1){1'b0}}, cmp_le_d};
+          if (a_nan_d || b_nan_d) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+          result_comb = {{(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}, cmp_le_d};
         end else begin
-          if (a_nan_s || b_nan_s) fflags_comb[FP_FFLAG_NV] = 1'b1;
-          result_comb = {{(FP_D_TOTAL_W-1){1'b0}}, cmp_le_s};
+          if (a_nan_s || b_nan_s) fflags_comb[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+          result_comb = {{(kronos_pkg::FP_D_TOTAL_W-1){1'b0}}, cmp_le_s};
         end
       end
 
       // --- Move operations ---
       FP_FMV_X_W: begin
         // Sign-extend low 32 bits to 64
-        result_comb = {{(FLEN-FP_S_TOTAL_W){a_i[FP_S_TOTAL_W-1]}}, a_i[FP_S_TOTAL_W-1:0]};
+        result_comb = {{(kronos_pkg::FLEN-kronos_pkg::FP_S_TOTAL_W){a_i[kronos_pkg::FP_S_TOTAL_W-1]}}, a_i[kronos_pkg::FP_S_TOTAL_W-1:0]};
       end
 
       FP_FMV_W_X: begin
         // NaN-box low 32 bits of integer source
-        result_comb = {FP_NANBOX_UPPER, a_i[FP_S_TOTAL_W-1:0]};
+        result_comb = {kronos_pkg::FP_NANBOX_UPPER, a_i[kronos_pkg::FP_S_TOTAL_W-1:0]};
       end
 
       FP_FMV_X_D: begin
@@ -437,7 +437,7 @@ module kronos_fpu_fmisc
       end
 
       default: begin
-        result_comb = {FLEN{1'b0}};
+        result_comb = {kronos_pkg::FLEN{1'b0}};
         fflags_comb = 5'h0;
       end
     endcase
@@ -449,7 +449,7 @@ module kronos_fpu_fmisc
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       out_valid_o <= 1'b0;
-      result_o    <= {FLEN{1'b0}};
+      result_o    <= {kronos_pkg::FLEN{1'b0}};
       fflags_o    <= 5'h0;
       tag_o       <= '{default: '0};
     end else begin

--- a/rtl/stage6/fpu/kronos_fpu_fmul.sv
+++ b/rtl/stage6/fpu/kronos_fpu_fmul.sv
@@ -65,32 +65,32 @@ module kronos_fpu_fmul
   // Classification helpers
   // -------------------------------------------------------------------------
   function automatic logic is_snan_s(logic [31:0] x);
-    return (x[30:23] == FP_S_EXP_MAX) && (x[22] == 1'b0) && (x[21:0] != 22'd0);
+    return (x[30:23] == kronos_pkg::FP_S_EXP_MAX) && (x[22] == 1'b0) && (x[21:0] != 22'd0);
   endfunction
   function automatic logic is_qnan_s(logic [31:0] x);
-    return (x[30:23] == FP_S_EXP_MAX) && (x[22] == 1'b1);
+    return (x[30:23] == kronos_pkg::FP_S_EXP_MAX) && (x[22] == 1'b1);
   endfunction
   function automatic logic is_nan_s(logic [31:0] x);
     return is_snan_s(x) || is_qnan_s(x);
   endfunction
   function automatic logic is_inf_s(logic [31:0] x);
-    return (x[30:23] == FP_S_EXP_MAX) && (x[22:0] == 23'd0);
+    return (x[30:23] == kronos_pkg::FP_S_EXP_MAX) && (x[22:0] == 23'd0);
   endfunction
   function automatic logic is_zero_s(logic [31:0] x);
     return (x[30:0] == 31'd0);
   endfunction
 
   function automatic logic is_snan_d(logic [63:0] x);
-    return (x[62:52] == FP_D_EXP_MAX) && (x[51] == 1'b0) && (x[50:0] != 51'd0);
+    return (x[62:52] == kronos_pkg::FP_D_EXP_MAX) && (x[51] == 1'b0) && (x[50:0] != 51'd0);
   endfunction
   function automatic logic is_qnan_d(logic [63:0] x);
-    return (x[62:52] == FP_D_EXP_MAX) && (x[51] == 1'b1);
+    return (x[62:52] == kronos_pkg::FP_D_EXP_MAX) && (x[51] == 1'b1);
   endfunction
   function automatic logic is_nan_d(logic [63:0] x);
     return is_snan_d(x) || is_qnan_d(x);
   endfunction
   function automatic logic is_inf_d(logic [63:0] x);
-    return (x[62:52] == FP_D_EXP_MAX) && (x[51:0] == 52'd0);
+    return (x[62:52] == kronos_pkg::FP_D_EXP_MAX) && (x[51:0] == 52'd0);
   endfunction
   function automatic logic is_zero_d(logic [63:0] x);
     return (x[62:0] == 63'd0);
@@ -311,10 +311,10 @@ module kronos_fpu_fmul
   logic                        s1_b_is_zero;
   logic                        s1_a_sub;
   logic                        s1_b_sub;
-  logic [FP_S_EXP_W-1:0]       s1_ea_s;
-  logic [FP_S_EXP_W-1:0]       s1_eb_s;
-  logic [FP_D_EXP_W-1:0]       s1_ea_d;
-  logic [FP_D_EXP_W-1:0]       s1_eb_d;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]       s1_ea_s;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]       s1_eb_s;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]       s1_ea_d;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]       s1_eb_d;
   logic signed [EXP_EXT_W-1:0] s1_ea_ext;
   logic signed [EXP_EXT_W-1:0] s1_eb_ext;
 
@@ -374,10 +374,10 @@ module kronos_fpu_fmul
   logic                        s5_inexact;
   logic                        s5_overflow;
   logic                        s5_underflow_tiny;   // subnormal before rounding
-  logic [FP_S_EXP_W-1:0]       s5_pack_exp_s;
-  logic [FP_D_EXP_W-1:0]       s5_pack_exp_d;
-  logic [FP_S_MANT_W-1:0]      s5_pack_frac_s;
-  logic [FP_D_MANT_W-1:0]      s5_pack_frac_d;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]       s5_pack_exp_s;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]       s5_pack_exp_d;
+  logic [kronos_pkg::FP_S_MANT_W-1:0]      s5_pack_frac_s;
+  logic [kronos_pkg::FP_D_MANT_W-1:0]      s5_pack_frac_d;
 
   // -------------------------------------------------------------------------
   // S1 combinational: decompose, classify, prepare multiplicands
@@ -396,10 +396,10 @@ module kronos_fpu_fmul
     s1_b_is_zero        = 1'b0;
     s1_a_sub            = 1'b0;
     s1_b_sub            = 1'b0;
-    s1_ea_s             = {FP_S_EXP_W{1'b0}};
-    s1_eb_s             = {FP_S_EXP_W{1'b0}};
-    s1_ea_d             = {FP_D_EXP_W{1'b0}};
-    s1_eb_d             = {FP_D_EXP_W{1'b0}};
+    s1_ea_s             = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    s1_eb_s             = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    s1_ea_d             = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    s1_eb_d             = {kronos_pkg::FP_D_EXP_W{1'b0}};
     s1_ea_ext           = {EXP_EXT_W{1'b0}};
     s1_eb_ext           = {EXP_EXT_W{1'b0}};
     s1_siga_d           = {SIG_W{1'b0}};
@@ -408,8 +408,8 @@ module kronos_fpu_fmul
     s1_sign_d           = 1'b0;
 
     // NaN-unbox single operands (mirrors kronos_fpu_fmisc).
-    s1_a_s_l = (a_i[63:32] == FP_NANBOX_UPPER) ? a_i[31:0] : FP_CANON_QNAN_S;
-    s1_b_s_l = (b_i[63:32] == FP_NANBOX_UPPER) ? b_i[31:0] : FP_CANON_QNAN_S;
+    s1_a_s_l = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
+    s1_b_s_l = (b_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? b_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
     a_s_unb = s1_a_s_l;
     b_s_unb = s1_b_s_l;
 
@@ -454,23 +454,23 @@ module kronos_fpu_fmul
     s1_eb_d = b_i[62:52];
 
     if (fmt_d_i) begin
-      s1_a_sub = (s1_ea_d == {FP_D_EXP_W{1'b0}}) && (a_i[51:0] != 52'd0);
-      s1_b_sub = (s1_eb_d == {FP_D_EXP_W{1'b0}}) && (b_i[51:0] != 52'd0);
+      s1_a_sub = (s1_ea_d == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (a_i[51:0] != 52'd0);
+      s1_b_sub = (s1_eb_d == {kronos_pkg::FP_D_EXP_W{1'b0}}) && (b_i[51:0] != 52'd0);
       s1_siga_d = {~s1_a_sub ? 1'b1 : 1'b0, a_i[51:0]};
       s1_sigb_d = {~s1_b_sub ? 1'b1 : 1'b0, b_i[51:0]};
       // Subnormals use true exponent 1 instead of 0.
-      s1_ea_ext = s1_a_sub ? 13'sd1 : {{(EXP_EXT_W-FP_D_EXP_W){1'b0}}, s1_ea_d};
-      s1_eb_ext = s1_b_sub ? 13'sd1 : {{(EXP_EXT_W-FP_D_EXP_W){1'b0}}, s1_eb_d};
+      s1_ea_ext = s1_a_sub ? 13'sd1 : {{(EXP_EXT_W-kronos_pkg::FP_D_EXP_W){1'b0}}, s1_ea_d};
+      s1_eb_ext = s1_b_sub ? 13'sd1 : {{(EXP_EXT_W-kronos_pkg::FP_D_EXP_W){1'b0}}, s1_eb_d};
       s1_exp_sum_d = s1_ea_ext + s1_eb_ext - 13'sd1023;
     end else begin
-      s1_a_sub = (s1_ea_s == {FP_S_EXP_W{1'b0}}) && (s1_a_s_l[22:0] != 23'd0);
-      s1_b_sub = (s1_eb_s == {FP_S_EXP_W{1'b0}}) && (s1_b_s_l[22:0] != 23'd0);
+      s1_a_sub = (s1_ea_s == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (s1_a_s_l[22:0] != 23'd0);
+      s1_b_sub = (s1_eb_s == {kronos_pkg::FP_S_EXP_W{1'b0}}) && (s1_b_s_l[22:0] != 23'd0);
       // Left-align single mantissa at bit [52:29]: hidden bit at 52, fraction
       // at 51:29, low 29 bits zero.
       s1_siga_d = {~s1_a_sub ? 1'b1 : 1'b0, s1_a_s_l[22:0], 29'd0};
       s1_sigb_d = {~s1_b_sub ? 1'b1 : 1'b0, s1_b_s_l[22:0], 29'd0};
-      s1_ea_ext = s1_a_sub ? 13'sd1 : {{(EXP_EXT_W-FP_S_EXP_W){1'b0}}, s1_ea_s};
-      s1_eb_ext = s1_b_sub ? 13'sd1 : {{(EXP_EXT_W-FP_S_EXP_W){1'b0}}, s1_eb_s};
+      s1_ea_ext = s1_a_sub ? 13'sd1 : {{(EXP_EXT_W-kronos_pkg::FP_S_EXP_W){1'b0}}, s1_ea_s};
+      s1_eb_ext = s1_b_sub ? 13'sd1 : {{(EXP_EXT_W-kronos_pkg::FP_S_EXP_W){1'b0}}, s1_eb_s};
       s1_exp_sum_d = s1_ea_ext + s1_eb_ext - 13'sd127;
     end
 
@@ -901,10 +901,10 @@ module kronos_fpu_fmul
     s5_inexact        = 1'b0;
     s5_overflow       = 1'b0;
     s5_underflow_tiny = 1'b0;
-    s5_pack_exp_s     = {FP_S_EXP_W{1'b0}};
-    s5_pack_exp_d     = {FP_D_EXP_W{1'b0}};
-    s5_pack_frac_s    = {FP_S_MANT_W{1'b0}};
-    s5_pack_frac_d    = {FP_D_MANT_W{1'b0}};
+    s5_pack_exp_s     = {kronos_pkg::FP_S_EXP_W{1'b0}};
+    s5_pack_exp_d     = {kronos_pkg::FP_D_EXP_W{1'b0}};
+    s5_pack_frac_s    = {kronos_pkg::FP_S_MANT_W{1'b0}};
+    s5_pack_frac_d    = {kronos_pkg::FP_D_MANT_W{1'b0}};
 
     s5_exp_in  = s4_exp_q;
     s5_mant_in = s4_mant_q;
@@ -922,7 +922,7 @@ module kronos_fpu_fmul
       s5_s_eff = s5_s_in;
     end else begin
       // Single: keep bits [52:29] (hidden + 23 frac). Next bit [28] is guard.
-      s5_mant_kept = {{(SIG_W - (1 + FP_S_MANT_W)){1'b0}}, s5_mant_in[52:29]};
+      s5_mant_kept = {{(SIG_W - (1 + kronos_pkg::FP_S_MANT_W)){1'b0}}, s5_mant_in[52:29]};
       s5_g_eff = s5_mant_in[28];
       s5_r_eff = s5_mant_in[27];
       s5_s_eff = |s5_mant_in[26:0] | s5_g_in | s5_r_in | s5_s_in;
@@ -955,13 +955,13 @@ module kronos_fpu_fmul
     end else begin
       // For single: kept field is low 24 bits of mant_rnd.
       // verilator coverage_off
-      if (s5_mant_rnd[1 + FP_S_MANT_W]) begin
+      if (s5_mant_rnd[1 + kronos_pkg::FP_S_MANT_W]) begin
         // carry out into bit 24
         s5_mant_rnd = s5_mant_rnd >> 1;
         s5_exp_rnd  = s5_exp_rnd + 13'sd1;
       end
       // verilator coverage_on
-      if ((s5_exp_in == 13'sd0) && s5_mant_rnd[FP_S_MANT_W]) begin
+      if ((s5_exp_in == 13'sd0) && s5_mant_rnd[kronos_pkg::FP_S_MANT_W]) begin
         s5_exp_rnd = 13'sd1;
       end
     end
@@ -971,97 +971,97 @@ module kronos_fpu_fmul
     // -------- Build result --------
     if (s4_any_snan_q) begin
       // sNaN operand → invalid, canonical qNaN
-      s5_fflags_d[FP_FFLAG_NV] = 1'b1;
-      s5_result_d = s4_fmt_d_q ? FP_CANON_QNAN_D
-                                : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s5_fflags_d[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+      s5_result_d = s4_fmt_d_q ? kronos_pkg::FP_CANON_QNAN_D
+                                : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s4_inf_times_zero_q) begin
       // inf * 0 → invalid, canonical qNaN
-      s5_fflags_d[FP_FFLAG_NV] = 1'b1;
-      s5_result_d = s4_fmt_d_q ? FP_CANON_QNAN_D
-                                : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s5_fflags_d[kronos_pkg::FP_FFLAG_NV] = 1'b1;
+      s5_result_d = s4_fmt_d_q ? kronos_pkg::FP_CANON_QNAN_D
+                                : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s4_any_nan_q) begin
       // qNaN propagation → canonical qNaN, no flag
-      s5_result_d = s4_fmt_d_q ? FP_CANON_QNAN_D
-                                : {FP_NANBOX_UPPER, FP_CANON_QNAN_S};
+      s5_result_d = s4_fmt_d_q ? kronos_pkg::FP_CANON_QNAN_D
+                                : {kronos_pkg::FP_NANBOX_UPPER, kronos_pkg::FP_CANON_QNAN_S};
     end else if (s4_res_is_inf_q) begin
       // inf * finite(non-zero) → signed infinity, no flag
       if (s4_fmt_d_q) begin
-        s5_result_d = {s4_sign_q, FP_D_EXP_MAX, 52'd0};
+        s5_result_d = {s4_sign_q, kronos_pkg::FP_D_EXP_MAX, 52'd0};
       end else begin
-        s5_result_d = {FP_NANBOX_UPPER, s4_sign_q, FP_S_EXP_MAX, 23'd0};
+        s5_result_d = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, kronos_pkg::FP_S_EXP_MAX, 23'd0};
       end
     end else if (s4_res_is_zero_q) begin
       // zero * finite → signed zero, no flag
       if (s4_fmt_d_q) begin
         s5_result_d = {s4_sign_q, 63'd0};
       end else begin
-        s5_result_d = {FP_NANBOX_UPPER, s4_sign_q, 31'd0};
+        s5_result_d = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, 31'd0};
       end
     end else begin
       // Normal numeric path — check overflow/underflow against format range.
       if (s4_fmt_d_q) begin
         s5_overflow = (s5_exp_rnd >= 13'sd2047);
         if (s5_overflow) begin
-          s5_fflags_d[FP_FFLAG_OF] = 1'b1;
-          s5_fflags_d[FP_FFLAG_NX] = 1'b1;
+          s5_fflags_d[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+          s5_fflags_d[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           // Rounding mode controls whether we produce inf or max-finite.
           unique case (s4_rm_q)
             3'b001: // RTZ → max-finite
-              s5_result_d = {s4_sign_q, 11'h7FE, {FP_D_MANT_W{1'b1}}};
+              s5_result_d = {s4_sign_q, 11'h7FE, {kronos_pkg::FP_D_MANT_W{1'b1}}};
             3'b010: // RDN
-              s5_result_d = s4_sign_q ? {1'b1, FP_D_EXP_MAX, 52'd0}
-                                       : {1'b0, 11'h7FE, {FP_D_MANT_W{1'b1}}};
+              s5_result_d = s4_sign_q ? {1'b1, kronos_pkg::FP_D_EXP_MAX, 52'd0}
+                                       : {1'b0, 11'h7FE, {kronos_pkg::FP_D_MANT_W{1'b1}}};
             3'b011: // RUP
-              s5_result_d = s4_sign_q ? {1'b1, 11'h7FE, {FP_D_MANT_W{1'b1}}}
-                                       : {1'b0, FP_D_EXP_MAX, 52'd0};
+              s5_result_d = s4_sign_q ? {1'b1, 11'h7FE, {kronos_pkg::FP_D_MANT_W{1'b1}}}
+                                       : {1'b0, kronos_pkg::FP_D_EXP_MAX, 52'd0};
             default: // RNE, RMM → inf
-              s5_result_d = {s4_sign_q, FP_D_EXP_MAX, 52'd0};
+              s5_result_d = {s4_sign_q, kronos_pkg::FP_D_EXP_MAX, 52'd0};
           endcase
         end else begin
           // Pack exponent and fraction
           if (s5_exp_rnd <= 13'sd0) begin
-            s5_pack_exp_d = {FP_D_EXP_W{1'b0}};
+            s5_pack_exp_d = {kronos_pkg::FP_D_EXP_W{1'b0}};
           end else begin
-            s5_pack_exp_d = s5_exp_rnd[FP_D_EXP_W-1:0];
+            s5_pack_exp_d = s5_exp_rnd[kronos_pkg::FP_D_EXP_W-1:0];
           end
-          s5_pack_frac_d = s5_mant_rnd[FP_D_MANT_W-1:0];
+          s5_pack_frac_d = s5_mant_rnd[kronos_pkg::FP_D_MANT_W-1:0];
           s5_result_d = {s4_sign_q, s5_pack_exp_d, s5_pack_frac_d};
-          s5_fflags_d[FP_FFLAG_NX] = s5_inexact;
+          s5_fflags_d[kronos_pkg::FP_FFLAG_NX] = s5_inexact;
           // Underflow: tiny before rounding AND inexact after rounding
           // (IEEE 754 "after rounding" underflow flag semantics).
-          s5_fflags_d[FP_FFLAG_UF] = s5_underflow_tiny & s5_inexact
-                                   & (s5_pack_exp_d == {FP_D_EXP_W{1'b0}});
+          s5_fflags_d[kronos_pkg::FP_FFLAG_UF] = s5_underflow_tiny & s5_inexact
+                                   & (s5_pack_exp_d == {kronos_pkg::FP_D_EXP_W{1'b0}});
         end
       end else begin
         s5_overflow = (s5_exp_rnd >= 13'sd255);
         if (s5_overflow) begin
-          s5_fflags_d[FP_FFLAG_OF] = 1'b1;
-          s5_fflags_d[FP_FFLAG_NX] = 1'b1;
+          s5_fflags_d[kronos_pkg::FP_FFLAG_OF] = 1'b1;
+          s5_fflags_d[kronos_pkg::FP_FFLAG_NX] = 1'b1;
           unique case (s4_rm_q)
             3'b001:
-              s5_result_d = {FP_NANBOX_UPPER, s4_sign_q, 8'hFE, {FP_S_MANT_W{1'b1}}};
+              s5_result_d = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, 8'hFE, {kronos_pkg::FP_S_MANT_W{1'b1}}};
             3'b010:
               s5_result_d = s4_sign_q
-                ? {FP_NANBOX_UPPER, 1'b1, FP_S_EXP_MAX, 23'd0}
-                : {FP_NANBOX_UPPER, 1'b0, 8'hFE, {FP_S_MANT_W{1'b1}}};
+                ? {kronos_pkg::FP_NANBOX_UPPER, 1'b1, kronos_pkg::FP_S_EXP_MAX, 23'd0}
+                : {kronos_pkg::FP_NANBOX_UPPER, 1'b0, 8'hFE, {kronos_pkg::FP_S_MANT_W{1'b1}}};
             3'b011:
               s5_result_d = s4_sign_q
-                ? {FP_NANBOX_UPPER, 1'b1, 8'hFE, {FP_S_MANT_W{1'b1}}}
-                : {FP_NANBOX_UPPER, 1'b0, FP_S_EXP_MAX, 23'd0};
+                ? {kronos_pkg::FP_NANBOX_UPPER, 1'b1, 8'hFE, {kronos_pkg::FP_S_MANT_W{1'b1}}}
+                : {kronos_pkg::FP_NANBOX_UPPER, 1'b0, kronos_pkg::FP_S_EXP_MAX, 23'd0};
             default:
-              s5_result_d = {FP_NANBOX_UPPER, s4_sign_q, FP_S_EXP_MAX, 23'd0};
+              s5_result_d = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, kronos_pkg::FP_S_EXP_MAX, 23'd0};
           endcase
         end else begin
           if (s5_exp_rnd <= 13'sd0) begin
-            s5_pack_exp_s = {FP_S_EXP_W{1'b0}};
+            s5_pack_exp_s = {kronos_pkg::FP_S_EXP_W{1'b0}};
           end else begin
-            s5_pack_exp_s = s5_exp_rnd[FP_S_EXP_W-1:0];
+            s5_pack_exp_s = s5_exp_rnd[kronos_pkg::FP_S_EXP_W-1:0];
           end
-          s5_pack_frac_s = s5_mant_rnd[FP_S_MANT_W-1:0];
-          s5_result_d = {FP_NANBOX_UPPER, s4_sign_q, s5_pack_exp_s, s5_pack_frac_s};
-          s5_fflags_d[FP_FFLAG_NX] = s5_inexact;
-          s5_fflags_d[FP_FFLAG_UF] = s5_underflow_tiny & s5_inexact
-                                   & (s5_pack_exp_s == {FP_S_EXP_W{1'b0}});
+          s5_pack_frac_s = s5_mant_rnd[kronos_pkg::FP_S_MANT_W-1:0];
+          s5_result_d = {kronos_pkg::FP_NANBOX_UPPER, s4_sign_q, s5_pack_exp_s, s5_pack_frac_s};
+          s5_fflags_d[kronos_pkg::FP_FFLAG_NX] = s5_inexact;
+          s5_fflags_d[kronos_pkg::FP_FFLAG_UF] = s5_underflow_tiny & s5_inexact
+                                   & (s5_pack_exp_s == {kronos_pkg::FP_S_EXP_W{1'b0}});
         end
       end
     end

--- a/rtl/stage6/fpu/kronos_fpu_iter.sv
+++ b/rtl/stage6/fpu/kronos_fpu_iter.sv
@@ -30,13 +30,13 @@ module kronos_fpu_iter
   input  fp_op_e          op_i,
   input  logic            fmt_d_i,
   input  logic [2:0]      rm_i,
-  input  logic [FLEN-1:0] a_i,
-  input  logic [FLEN-1:0] b_i,
+  input  logic [kronos_pkg::FLEN-1:0] a_i,
+  input  logic [kronos_pkg::FLEN-1:0] b_i,
   input  fpu_tag_t        tag_i,
 
   output logic            busy_o,
   output logic            out_valid_o,
-  output logic [FLEN-1:0] result_o,
+  output logic [kronos_pkg::FLEN-1:0] result_o,
   output logic [4:0]      fflags_o,
   output fpu_tag_t        tag_o,
 
@@ -50,22 +50,22 @@ module kronos_fpu_iter
   // 1. Constants
   // -----------------------------------------------------------------------
   // Canonical bit patterns for double precision
-  localparam logic [FLEN-1:0] D_QNAN  = 64'h7FF8_0000_0000_0000;
-  localparam logic [FLEN-1:0] D_PINF  = 64'h7FF0_0000_0000_0000;
-  localparam logic [FLEN-1:0] D_NINF  = 64'hFFF0_0000_0000_0000;
-  localparam logic [FLEN-1:0] D_PZERO = {FLEN{1'b0}};
-  localparam logic [FLEN-1:0] D_NZERO = 64'h8000_0000_0000_0000;
+  localparam logic [kronos_pkg::FLEN-1:0] D_QNAN  = 64'h7FF8_0000_0000_0000;
+  localparam logic [kronos_pkg::FLEN-1:0] D_PINF  = 64'h7FF0_0000_0000_0000;
+  localparam logic [kronos_pkg::FLEN-1:0] D_NINF  = 64'hFFF0_0000_0000_0000;
+  localparam logic [kronos_pkg::FLEN-1:0] D_PZERO = {kronos_pkg::FLEN{1'b0}};
+  localparam logic [kronos_pkg::FLEN-1:0] D_NZERO = 64'h8000_0000_0000_0000;
 
   // Canonical bit patterns for single precision (NaN-boxed to 64 bits)
-  localparam logic [FLEN-1:0] S_QNAN  = {FP_NANBOX_UPPER, 32'h7FC0_0000};
-  localparam logic [FLEN-1:0] S_PINF  = {FP_NANBOX_UPPER, 32'h7F80_0000};
-  localparam logic [FLEN-1:0] S_NINF  = {FP_NANBOX_UPPER, 32'hFF80_0000};
-  localparam logic [FLEN-1:0] S_PZERO = {FP_NANBOX_UPPER, 32'h0000_0000};
-  localparam logic [FLEN-1:0] S_NZERO = {FP_NANBOX_UPPER, 32'h8000_0000};
+  localparam logic [kronos_pkg::FLEN-1:0] S_QNAN  = {kronos_pkg::FP_NANBOX_UPPER, 32'h7FC0_0000};
+  localparam logic [kronos_pkg::FLEN-1:0] S_PINF  = {kronos_pkg::FP_NANBOX_UPPER, 32'h7F80_0000};
+  localparam logic [kronos_pkg::FLEN-1:0] S_NINF  = {kronos_pkg::FP_NANBOX_UPPER, 32'hFF80_0000};
+  localparam logic [kronos_pkg::FLEN-1:0] S_PZERO = {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000};
+  localparam logic [kronos_pkg::FLEN-1:0] S_NZERO = {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000};
 
   // Flag bits
-  localparam logic [4:0] FL_NV = 5'(1) << FP_FFLAG_NV;
-  localparam logic [4:0] FL_DZ = 5'(1) << FP_FFLAG_DZ;
+  localparam logic [4:0] FL_NV = 5'(1) << kronos_pkg::FP_FFLAG_NV;
+  localparam logic [4:0] FL_DZ = 5'(1) << kronos_pkg::FP_FFLAG_DZ;
 
   // -----------------------------------------------------------------------
   // 2. Types
@@ -116,8 +116,8 @@ module kronos_fpu_iter
   logic               fmt_d_q;
   logic [2:0]         rm_q;
   fpu_tag_t           tag_q;
-  logic [FLEN-1:0]    a_raw_q;
-  logic [FLEN-1:0]    b_raw_q;
+  logic [kronos_pkg::FLEN-1:0]    a_raw_q;
+  logic [kronos_pkg::FLEN-1:0]    b_raw_q;
 
   // Classified operands (registered in UNPACK1 -> UNPACK2 transition)
   fp_class_t          a_class_q;
@@ -129,18 +129,18 @@ module kronos_fpu_iter
   logic [53:0]        a_sqrt_q;     // fsqrt: 54-bit normalized sig
 
   // Unbiased true exponents (latched UNPACK1 -> UNPACK2)
-  logic signed [FP_EXP_EXT_W-1:0] a_true_exp_q;
-  logic signed [FP_EXP_EXT_W-1:0] b_true_exp_q;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] a_true_exp_q;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] b_true_exp_q;
 
   // Specials result/flags latched in UNPACK1, consumed in UNPACK2
   logic               is_special_q;
-  logic [FLEN-1:0]    special_result_q;
+  logic [kronos_pkg::FLEN-1:0]    special_result_q;
   logic [4:0]         special_fflags_q;
 
   // Final biased result exponent + sign (computed in UNPACK2 combinationally,
   // latched UNPACK2 -> ITER into result_sign_q / result_exp_q)
   logic               result_sign_q;
-  logic signed [FP_EXP_EXT_W-1:0] result_exp_q;        // signed intermediate exponent
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] result_exp_q;        // signed intermediate exponent
 
   // Raw quotient from core (latched on core_done)
   logic [55:0]        raw_q;
@@ -152,7 +152,7 @@ module kronos_fpu_iter
   logic               rnd_new_g_q;
   logic               rnd_new_r_q;
   logic               rnd_new_s_q;
-  logic signed [FP_EXP_EXT_W-1:0] rnd_final_exp_q;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] rnd_final_exp_q;
   logic               rnd_tiny_q;
 
   // core_start: delayed by one cycle from UNPACK2 -> ITER so that
@@ -161,7 +161,7 @@ module kronos_fpu_iter
   logic               core_start_q;
 
   // Result / fflags registers
-  logic [FLEN-1:0]    result_q;
+  logic [kronos_pkg::FLEN-1:0]    result_q;
   logic [4:0]         fflags_q;
 
   // -----------------------------------------------------------------------
@@ -173,16 +173,16 @@ module kronos_fpu_iter
 
   // Specials
   logic               is_special;
-  logic [FLEN-1:0]    special_result;
+  logic [kronos_pkg::FLEN-1:0]    special_result;
   logic [4:0]         special_fflags;
   logic               sp_result_sign;
-  logic [FLEN-1:0]    sp_qnan;
-  logic [FLEN-1:0]    sp_pinf;
-  logic [FLEN-1:0]    sp_ninf;
-  logic [FLEN-1:0]    sp_pzero;
-  logic [FLEN-1:0]    sp_nzero;
-  logic [FLEN-1:0]    sp_signed_inf;
-  logic [FLEN-1:0]    sp_signed_zero;
+  logic [kronos_pkg::FLEN-1:0]    sp_qnan;
+  logic [kronos_pkg::FLEN-1:0]    sp_pinf;
+  logic [kronos_pkg::FLEN-1:0]    sp_ninf;
+  logic [kronos_pkg::FLEN-1:0]    sp_pzero;
+  logic [kronos_pkg::FLEN-1:0]    sp_nzero;
+  logic [kronos_pkg::FLEN-1:0]    sp_signed_inf;
+  logic [kronos_pkg::FLEN-1:0]    sp_signed_zero;
   logic               sp_a_nan;
   logic               sp_b_nan;
   logic               sp_any_snan;
@@ -192,21 +192,21 @@ module kronos_fpu_iter
   logic [52:0]        a_norm;       // fdiv normalized significand
   logic [52:0]        b_norm;       // fdiv normalized significand
   logic [53:0]        a_sqrt;       // fsqrt normalized significand
-  logic signed [FP_EXP_EXT_W-1:0] a_true_exp;
-  logic signed [FP_EXP_EXT_W-1:0] b_true_exp;
-  logic signed [FP_EXP_EXT_W-1:0] bias;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] a_true_exp;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] b_true_exp;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] bias;
 
   // UNPACK2 result-exp / sign
-  logic signed [FP_EXP_EXT_W-1:0] result_exp_comb;    // biased result exponent
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] result_exp_comb;    // biased result exponent
   logic               result_sign_comb;   // result sign
 
   // ROUND state - rounding logic (combinational)
-  logic [FLEN-1:0]    round_result;
+  logic [kronos_pkg::FLEN-1:0]    round_result;
   logic [4:0]         round_fflags;
 
   // Post-normalization shift signals
   logic [55:0]        rnd_shifted;
-  logic signed [FP_EXP_EXT_W-1:0] rnd_adj_exp;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] rnd_adj_exp;
   logic               rnd_sticky_shift;
 
   // Mantissa extraction
@@ -223,7 +223,7 @@ module kronos_fpu_iter
   logic               rnd_new_g;
   logic               rnd_new_r;
   logic               rnd_new_s;
-  logic signed [FP_EXP_EXT_W-1:0] rnd_final_exp;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] rnd_final_exp;
   logic [6:0]         rnd_shift_amt;
   logic [55:0]        rnd_combined_d;
   logic [55:0]        rnd_shifted_out_d;
@@ -241,7 +241,7 @@ module kronos_fpu_iter
   logic               rnd_carry;
 
   // Pack helpers (hoisted out of inner begin block)
-  logic signed [FP_EXP_EXT_W-1:0] rnd_exp_pack;
+  logic signed [kronos_pkg::FP_EXP_EXT_W-1:0] rnd_exp_pack;
   logic [52:0]        rnd_mant_pack;
 
   // Overflow
@@ -286,14 +286,14 @@ module kronos_fpu_iter
       a_class.sig  = a_raw_q[51:0];
     end else begin
       // Single precision -- check NaN-boxing
-      if (a_raw_q[63:32] == FP_NANBOX_UPPER) begin
+      if (a_raw_q[63:32] == kronos_pkg::FP_NANBOX_UPPER) begin
         a_class.sign = a_raw_q[31];
         a_class.exp  = {3'b0, a_raw_q[30:23]};
         a_class.sig  = {a_raw_q[22:0], 29'b0};
       end else begin
         // Not properly NaN-boxed: treat as canonical qNaN
         a_class.sign    = 1'b0;
-        a_class.exp     = FP_D_EXP_MAX;
+        a_class.exp     = kronos_pkg::FP_D_EXP_MAX;
         a_class.sig     = {1'b1, 51'b0};
         a_class.is_qnan = 1'b1;
       end
@@ -302,27 +302,27 @@ module kronos_fpu_iter
     // Classification (only if not already forced to qNaN by NaN-box check)
     if (!a_class.is_qnan) begin
       if (fmt_d_q) begin
-        a_class.is_zero    = (a_class.exp == 11'h000) && (a_class.sig == {FP_D_MANT_W{1'b0}});
-        a_class.is_subnorm = (a_class.exp == 11'h000) && (a_class.sig != {FP_D_MANT_W{1'b0}});
-        a_class.is_inf     = (a_class.exp == FP_D_EXP_MAX) && (a_class.sig == {FP_D_MANT_W{1'b0}});
-        a_class.is_snan    = (a_class.exp == FP_D_EXP_MAX) && (a_class.sig != {FP_D_MANT_W{1'b0}})
+        a_class.is_zero    = (a_class.exp == 11'h000) && (a_class.sig == {kronos_pkg::FP_D_MANT_W{1'b0}});
+        a_class.is_subnorm = (a_class.exp == 11'h000) && (a_class.sig != {kronos_pkg::FP_D_MANT_W{1'b0}});
+        a_class.is_inf     = (a_class.exp == kronos_pkg::FP_D_EXP_MAX) && (a_class.sig == {kronos_pkg::FP_D_MANT_W{1'b0}});
+        a_class.is_snan    = (a_class.exp == kronos_pkg::FP_D_EXP_MAX) && (a_class.sig != {kronos_pkg::FP_D_MANT_W{1'b0}})
                              && !a_class.sig[51];
-        a_class.is_qnan    = (a_class.exp == FP_D_EXP_MAX) && a_class.sig[51];
+        a_class.is_qnan    = (a_class.exp == kronos_pkg::FP_D_EXP_MAX) && a_class.sig[51];
         a_class.is_normal  = !a_class.is_zero && !a_class.is_subnorm
                              && !a_class.is_inf && !a_class.is_snan
                              && !a_class.is_qnan;
       end else begin
         // Single: exponent is in [7:0] of a_class.exp, sig in [51:29]
         a_class.is_zero    = (a_class.exp[7:0] == 8'h00)
-                             && (a_class.sig[51:29] == {FP_S_MANT_W{1'b0}});
+                             && (a_class.sig[51:29] == {kronos_pkg::FP_S_MANT_W{1'b0}});
         a_class.is_subnorm = (a_class.exp[7:0] == 8'h00)
-                             && (a_class.sig[51:29] != {FP_S_MANT_W{1'b0}});
-        a_class.is_inf     = (a_class.exp[7:0] == FP_S_EXP_MAX)
-                             && (a_class.sig[51:29] == {FP_S_MANT_W{1'b0}});
-        a_class.is_snan    = (a_class.exp[7:0] == FP_S_EXP_MAX)
-                             && (a_class.sig[51:29] != {FP_S_MANT_W{1'b0}})
+                             && (a_class.sig[51:29] != {kronos_pkg::FP_S_MANT_W{1'b0}});
+        a_class.is_inf     = (a_class.exp[7:0] == kronos_pkg::FP_S_EXP_MAX)
+                             && (a_class.sig[51:29] == {kronos_pkg::FP_S_MANT_W{1'b0}});
+        a_class.is_snan    = (a_class.exp[7:0] == kronos_pkg::FP_S_EXP_MAX)
+                             && (a_class.sig[51:29] != {kronos_pkg::FP_S_MANT_W{1'b0}})
                              && !a_class.sig[51];
-        a_class.is_qnan    = (a_class.exp[7:0] == FP_S_EXP_MAX)
+        a_class.is_qnan    = (a_class.exp[7:0] == kronos_pkg::FP_S_EXP_MAX)
                              && a_class.sig[51];
         a_class.is_normal  = !a_class.is_zero && !a_class.is_subnorm
                              && !a_class.is_inf && !a_class.is_snan
@@ -347,14 +347,14 @@ module kronos_fpu_iter
       b_class.sig  = b_raw_q[51:0];
     end else begin
       // Single precision -- check NaN-boxing
-      if (b_raw_q[63:32] == FP_NANBOX_UPPER) begin
+      if (b_raw_q[63:32] == kronos_pkg::FP_NANBOX_UPPER) begin
         b_class.sign = b_raw_q[31];
         b_class.exp  = {3'b0, b_raw_q[30:23]};
         b_class.sig  = {b_raw_q[22:0], 29'b0};
       end else begin
         // Not properly NaN-boxed: treat as canonical qNaN
         b_class.sign    = 1'b0;
-        b_class.exp     = FP_D_EXP_MAX;
+        b_class.exp     = kronos_pkg::FP_D_EXP_MAX;
         b_class.sig     = {1'b1, 51'b0};
         b_class.is_qnan = 1'b1;
       end
@@ -363,27 +363,27 @@ module kronos_fpu_iter
     // Classification
     if (!b_class.is_qnan) begin
       if (fmt_d_q) begin
-        b_class.is_zero    = (b_class.exp == 11'h000) && (b_class.sig == {FP_D_MANT_W{1'b0}});
-        b_class.is_subnorm = (b_class.exp == 11'h000) && (b_class.sig != {FP_D_MANT_W{1'b0}});
-        b_class.is_inf     = (b_class.exp == FP_D_EXP_MAX) && (b_class.sig == {FP_D_MANT_W{1'b0}});
-        b_class.is_snan    = (b_class.exp == FP_D_EXP_MAX) && (b_class.sig != {FP_D_MANT_W{1'b0}})
+        b_class.is_zero    = (b_class.exp == 11'h000) && (b_class.sig == {kronos_pkg::FP_D_MANT_W{1'b0}});
+        b_class.is_subnorm = (b_class.exp == 11'h000) && (b_class.sig != {kronos_pkg::FP_D_MANT_W{1'b0}});
+        b_class.is_inf     = (b_class.exp == kronos_pkg::FP_D_EXP_MAX) && (b_class.sig == {kronos_pkg::FP_D_MANT_W{1'b0}});
+        b_class.is_snan    = (b_class.exp == kronos_pkg::FP_D_EXP_MAX) && (b_class.sig != {kronos_pkg::FP_D_MANT_W{1'b0}})
                              && !b_class.sig[51];
-        b_class.is_qnan    = (b_class.exp == FP_D_EXP_MAX) && b_class.sig[51];
+        b_class.is_qnan    = (b_class.exp == kronos_pkg::FP_D_EXP_MAX) && b_class.sig[51];
         b_class.is_normal  = !b_class.is_zero && !b_class.is_subnorm
                              && !b_class.is_inf && !b_class.is_snan
                              && !b_class.is_qnan;
       end else begin
         // Single: exponent is in [7:0] of b_class.exp, sig in [51:29]
         b_class.is_zero    = (b_class.exp[7:0] == 8'h00)
-                             && (b_class.sig[51:29] == {FP_S_MANT_W{1'b0}});
+                             && (b_class.sig[51:29] == {kronos_pkg::FP_S_MANT_W{1'b0}});
         b_class.is_subnorm = (b_class.exp[7:0] == 8'h00)
-                             && (b_class.sig[51:29] != {FP_S_MANT_W{1'b0}});
-        b_class.is_inf     = (b_class.exp[7:0] == FP_S_EXP_MAX)
-                             && (b_class.sig[51:29] == {FP_S_MANT_W{1'b0}});
-        b_class.is_snan    = (b_class.exp[7:0] == FP_S_EXP_MAX)
-                             && (b_class.sig[51:29] != {FP_S_MANT_W{1'b0}})
+                             && (b_class.sig[51:29] != {kronos_pkg::FP_S_MANT_W{1'b0}});
+        b_class.is_inf     = (b_class.exp[7:0] == kronos_pkg::FP_S_EXP_MAX)
+                             && (b_class.sig[51:29] == {kronos_pkg::FP_S_MANT_W{1'b0}});
+        b_class.is_snan    = (b_class.exp[7:0] == kronos_pkg::FP_S_EXP_MAX)
+                             && (b_class.sig[51:29] != {kronos_pkg::FP_S_MANT_W{1'b0}})
                              && !b_class.sig[51];
-        b_class.is_qnan    = (b_class.exp[7:0] == FP_S_EXP_MAX)
+        b_class.is_qnan    = (b_class.exp[7:0] == kronos_pkg::FP_S_EXP_MAX)
                              && b_class.sig[51];
         b_class.is_normal  = !b_class.is_zero && !b_class.is_subnorm
                              && !b_class.is_inf && !b_class.is_snan
@@ -404,16 +404,16 @@ module kronos_fpu_iter
   // -----------------------------------------------------------------------
   always_comb begin : proc_specials
     is_special     = 1'b0;
-    special_result = {FLEN{1'b0}};
+    special_result = {kronos_pkg::FLEN{1'b0}};
     special_fflags = 5'h0;
     sp_result_sign = 1'b0;
-    sp_qnan        = {FLEN{1'b0}};
-    sp_pinf        = {FLEN{1'b0}};
-    sp_ninf        = {FLEN{1'b0}};
-    sp_pzero       = {FLEN{1'b0}};
-    sp_nzero       = {FLEN{1'b0}};
-    sp_signed_inf  = {FLEN{1'b0}};
-    sp_signed_zero = {FLEN{1'b0}};
+    sp_qnan        = {kronos_pkg::FLEN{1'b0}};
+    sp_pinf        = {kronos_pkg::FLEN{1'b0}};
+    sp_ninf        = {kronos_pkg::FLEN{1'b0}};
+    sp_pzero       = {kronos_pkg::FLEN{1'b0}};
+    sp_nzero       = {kronos_pkg::FLEN{1'b0}};
+    sp_signed_inf  = {kronos_pkg::FLEN{1'b0}};
+    sp_signed_zero = {kronos_pkg::FLEN{1'b0}};
     sp_a_nan       = 1'b0;
     sp_b_nan       = 1'b0;
     sp_any_snan    = 1'b0;
@@ -521,26 +521,26 @@ module kronos_fpu_iter
     a_norm     = 53'h0;
     b_norm     = 53'h0;
     a_sqrt     = 54'h0;
-    a_true_exp = {FP_EXP_EXT_W{1'b0}};
-    b_true_exp = {FP_EXP_EXT_W{1'b0}};
+    a_true_exp = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
+    b_true_exp = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
 
-    bias = fmt_d_q ? FP_EXP_EXT_W'(FP_D_BIAS) : FP_EXP_EXT_W'(FP_S_BIAS);
+    bias = fmt_d_q ? kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_D_BIAS) : kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_BIAS);
 
     // --- Operand A normalization ---
     if (a_class.is_subnorm) begin
-      a_true_exp = $signed(FP_EXP_EXT_W'(1)) - bias - $signed(FP_EXP_EXT_W'(a_class.clz));
+      a_true_exp = $signed(kronos_pkg::FP_EXP_EXT_W'(1)) - bias - $signed(kronos_pkg::FP_EXP_EXT_W'(a_class.clz));
       a_norm     = {1'b0, a_class.sig} << a_class.clz;
     end else begin
-      a_true_exp = $signed(FP_EXP_EXT_W'(a_class.exp)) - bias;
+      a_true_exp = $signed(kronos_pkg::FP_EXP_EXT_W'(a_class.exp)) - bias;
       a_norm     = {1'b1, a_class.sig};
     end
 
     // --- Operand B normalization (FDIV only; harmless for FSQRT) ---
     if (b_class.is_subnorm) begin
-      b_true_exp = $signed(FP_EXP_EXT_W'(1)) - bias - $signed(FP_EXP_EXT_W'(b_class.clz));
+      b_true_exp = $signed(kronos_pkg::FP_EXP_EXT_W'(1)) - bias - $signed(kronos_pkg::FP_EXP_EXT_W'(b_class.clz));
       b_norm     = {1'b0, b_class.sig} << b_class.clz;
     end else begin
-      b_true_exp = $signed(FP_EXP_EXT_W'(b_class.exp)) - bias;
+      b_true_exp = $signed(kronos_pkg::FP_EXP_EXT_W'(b_class.exp)) - bias;
       b_norm     = {1'b1, b_class.sig};
     end
 
@@ -560,7 +560,7 @@ module kronos_fpu_iter
   // classify+normalize+exp-compute cone into two cycles is the C4 fix.
   // -----------------------------------------------------------------------
   always_comb begin : proc_result_exp
-    result_exp_comb  = {FP_EXP_EXT_W{1'b0}};
+    result_exp_comb  = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
     result_sign_comb = 1'b0;
 
     // Result sign: FDIV = sign_a ^ sign_b, FSQRT = 0 (negative caught as special).
@@ -571,14 +571,14 @@ module kronos_fpu_iter
     if (op_q == FP_FDIV) begin
       // FDIV: result_exp (biased) = (a_true - b_true) + bias
       result_exp_comb = a_true_exp_q - b_true_exp_q
-                        + (fmt_d_q ? FP_EXP_EXT_W'(FP_D_BIAS)
-                                   : FP_EXP_EXT_W'(FP_S_BIAS));
+                        + (fmt_d_q ? kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_D_BIAS)
+                                   : kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_BIAS));
     end else begin
       // FSQRT: result_exp (biased) = floor(a_true / 2) + bias
       // arithmetic right shift by 1 gives floor(x/2) for signed x
       result_exp_comb = (a_true_exp_q >>> 1)
-                        + (fmt_d_q ? FP_EXP_EXT_W'(FP_D_BIAS)
-                                   : FP_EXP_EXT_W'(FP_S_BIAS));
+                        + (fmt_d_q ? kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_D_BIAS)
+                                   : kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_BIAS));
     end
   end
 
@@ -588,20 +588,20 @@ module kronos_fpu_iter
   always_comb begin : proc_round1
     // Defaults
     rnd_shifted            = 56'h0;
-    rnd_adj_exp            = {FP_EXP_EXT_W{1'b0}};
+    rnd_adj_exp            = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
     rnd_sticky_shift       = 1'b0;
-    rnd_mantissa           = {FP_D_MANT_W{1'b0}};
+    rnd_mantissa           = {kronos_pkg::FP_D_MANT_W{1'b0}};
     rnd_lsb                = 1'b0;
     rnd_g                  = 1'b0;
     rnd_r                  = 1'b0;
     rnd_s                  = 1'b0;
     rnd_tiny               = 1'b0;
-    rnd_mant_shifted       = {FP_D_MANT_W{1'b0}};
+    rnd_mant_shifted       = {kronos_pkg::FP_D_MANT_W{1'b0}};
     rnd_new_lsb            = 1'b0;
     rnd_new_g              = 1'b0;
     rnd_new_r              = 1'b0;
     rnd_new_s              = 1'b0;
-    rnd_final_exp          = {FP_EXP_EXT_W{1'b0}};
+    rnd_final_exp          = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
     rnd_shift_amt          = 7'h0;
     rnd_combined_d         = 56'h0;
     rnd_shifted_out_d      = 56'h0;
@@ -618,7 +618,7 @@ module kronos_fpu_iter
       rnd_need_shift = fmt_d_q ? !raw_q[55] : !raw_q[26];
       if (rnd_need_shift) begin
         rnd_shifted = {raw_q[54:0], raw_sticky_q};
-        rnd_adj_exp = result_exp_q - $signed(FP_EXP_EXT_W'(1));
+        rnd_adj_exp = result_exp_q - $signed(kronos_pkg::FP_EXP_EXT_W'(1));
         rnd_sticky_shift = 1'b0;
       end else begin
         rnd_shifted = raw_q;
@@ -641,7 +641,7 @@ module kronos_fpu_iter
       rnd_r        = rnd_shifted[1];
       rnd_s        = rnd_sticky_shift | rnd_shifted[0];
     end else begin
-      rnd_mantissa = {{(FP_D_MANT_W-FP_S_MANT_W){1'b0}}, rnd_shifted[25:3]};
+      rnd_mantissa = {{(kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W){1'b0}}, rnd_shifted[25:3]};
       rnd_lsb      = rnd_shifted[3];
       rnd_g        = rnd_shifted[2];
       rnd_r        = rnd_shifted[1];
@@ -651,15 +651,15 @@ module kronos_fpu_iter
     // ------------------------------------------------------------------
     // 3. Tininess detection and subnormal shift (before rounding)
     // ------------------------------------------------------------------
-    rnd_tiny = (rnd_adj_exp <= $signed({FP_EXP_EXT_W{1'b0}}));
+    rnd_tiny = (rnd_adj_exp <= $signed({kronos_pkg::FP_EXP_EXT_W{1'b0}}));
 
     if (rnd_tiny) begin
       if (fmt_d_q) begin
-        rnd_shift_amt = (($signed(FP_EXP_EXT_W'(1)) - rnd_adj_exp) > 13'sd56)
-                        ? 7'd56 : 7'($signed(FP_EXP_EXT_W'(1)) - rnd_adj_exp);
+        rnd_shift_amt = (($signed(kronos_pkg::FP_EXP_EXT_W'(1)) - rnd_adj_exp) > 13'sd56)
+                        ? 7'd56 : 7'($signed(kronos_pkg::FP_EXP_EXT_W'(1)) - rnd_adj_exp);
       end else begin
-        rnd_shift_amt = (($signed(FP_EXP_EXT_W'(1)) - rnd_adj_exp) > 13'sd27)
-                        ? 7'd27 : 7'($signed(FP_EXP_EXT_W'(1)) - rnd_adj_exp);
+        rnd_shift_amt = (($signed(kronos_pkg::FP_EXP_EXT_W'(1)) - rnd_adj_exp) > 13'sd27)
+                        ? 7'd27 : 7'($signed(kronos_pkg::FP_EXP_EXT_W'(1)) - rnd_adj_exp);
       end
 
       if (fmt_d_q) begin
@@ -675,14 +675,14 @@ module kronos_fpu_iter
         rnd_combined_s = rnd_shifted[26:0];
         rnd_shifted_out_s = rnd_combined_s & ((27'd1 << rnd_shift_amt) - 27'd1);
         rnd_combined_shifted_s = rnd_combined_s >> rnd_shift_amt;
-        rnd_mant_shifted = {{(FP_D_MANT_W-FP_S_MANT_W){1'b0}}, rnd_combined_shifted_s[25:3]};
+        rnd_mant_shifted = {{(kronos_pkg::FP_D_MANT_W-kronos_pkg::FP_S_MANT_W){1'b0}}, rnd_combined_shifted_s[25:3]};
         rnd_new_lsb = rnd_combined_shifted_s[3];
         rnd_new_g   = rnd_combined_shifted_s[2];
         rnd_new_r   = rnd_combined_shifted_s[1];
         rnd_new_s   = rnd_s | rnd_combined_shifted_s[0] | (|rnd_shifted_out_s);
       end
 
-      rnd_final_exp = $signed({FP_EXP_EXT_W{1'b0}});
+      rnd_final_exp = $signed({kronos_pkg::FP_EXP_EXT_W{1'b0}});
     end else begin
       rnd_mant_shifted = rnd_mantissa;
       rnd_new_lsb = rnd_lsb;
@@ -698,12 +698,12 @@ module kronos_fpu_iter
   // -----------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_round1_latch
     if (!rst_ni) begin
-      rnd_mant_shifted_q <= {FP_D_MANT_W{1'b0}};
+      rnd_mant_shifted_q <= {kronos_pkg::FP_D_MANT_W{1'b0}};
       rnd_new_lsb_q      <= 1'b0;
       rnd_new_g_q        <= 1'b0;
       rnd_new_r_q        <= 1'b0;
       rnd_new_s_q        <= 1'b0;
-      rnd_final_exp_q    <= {FP_EXP_EXT_W{1'b0}};
+      rnd_final_exp_q    <= {kronos_pkg::FP_EXP_EXT_W{1'b0}};
       rnd_tiny_q         <= 1'b0;
     end else if (state_q == ROUND1) begin
       rnd_mant_shifted_q <= rnd_mant_shifted;
@@ -721,13 +721,13 @@ module kronos_fpu_iter
   // Reads ROUND1 latches; writes round_result / round_fflags
   // -----------------------------------------------------------------------
   always_comb begin : proc_round2
-    round_result        = {FLEN{1'b0}};
+    round_result        = {kronos_pkg::FLEN{1'b0}};
     round_fflags        = 5'h0;
     rnd_round_up        = 1'b0;
     rnd_inexact         = 1'b0;
     rnd_rounded_mant    = 53'h0;
     rnd_carry           = 1'b0;
-    rnd_exp_pack        = {FP_EXP_EXT_W{1'b0}};
+    rnd_exp_pack        = {kronos_pkg::FP_EXP_EXT_W{1'b0}};
     rnd_mant_pack       = 53'h0;
     rnd_overflow        = 1'b0;
     rnd_overflow_to_inf = 1'b0;
@@ -754,10 +754,10 @@ module kronos_fpu_iter
     // 5. Add rounding increment
     // ------------------------------------------------------------------
     if (fmt_d_q) begin
-      rnd_rounded_mant = {1'b0, rnd_mant_shifted_q} + {{FP_D_MANT_W{1'b0}}, rnd_round_up};
+      rnd_rounded_mant = {1'b0, rnd_mant_shifted_q} + {{kronos_pkg::FP_D_MANT_W{1'b0}}, rnd_round_up};
     end else begin
-      rnd_rounded_mant = {{(FP_D_MANT_W+1-FP_S_MANT_W){1'b0}}, rnd_mant_shifted_q[22:0]}
-                       + {{FP_D_MANT_W{1'b0}}, rnd_round_up};
+      rnd_rounded_mant = {{(kronos_pkg::FP_D_MANT_W+1-kronos_pkg::FP_S_MANT_W){1'b0}}, rnd_mant_shifted_q[22:0]}
+                       + {{kronos_pkg::FP_D_MANT_W{1'b0}}, rnd_round_up};
     end
 
     rnd_carry = fmt_d_q ? rnd_rounded_mant[52] : rnd_rounded_mant[23];
@@ -766,15 +766,15 @@ module kronos_fpu_iter
     rnd_exp_pack  = rnd_final_exp_q;
     rnd_mant_pack = rnd_rounded_mant;
     if (rnd_carry) begin
-      rnd_exp_pack  = rnd_final_exp_q + $signed(FP_EXP_EXT_W'(1));
+      rnd_exp_pack  = rnd_final_exp_q + $signed(kronos_pkg::FP_EXP_EXT_W'(1));
       rnd_mant_pack = 53'h0;
     end
 
     // ----------------------------------------------------------------
     // 6. Overflow detection
     // ----------------------------------------------------------------
-    rnd_overflow = fmt_d_q ? (rnd_exp_pack >= FP_EXP_EXT_W'(FP_D_EXP_MAX))
-                           : (rnd_exp_pack >= FP_EXP_EXT_W'(FP_S_EXP_MAX));
+    rnd_overflow = fmt_d_q ? (rnd_exp_pack >= kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_D_EXP_MAX))
+                           : (rnd_exp_pack >= kronos_pkg::FP_EXP_EXT_W'(kronos_pkg::FP_S_EXP_MAX));
 
     if (rnd_overflow) begin
       unique case (rm_q)
@@ -800,22 +800,22 @@ module kronos_fpu_iter
     if (rnd_overflow) begin
       if (rnd_overflow_to_inf) begin
         if (fmt_d_q) begin
-          round_result = {result_sign_q, FP_D_EXP_MAX, {FP_D_MANT_W{1'b0}}};
+          round_result = {result_sign_q, kronos_pkg::FP_D_EXP_MAX, {kronos_pkg::FP_D_MANT_W{1'b0}}};
         end else begin
-          round_result = {FP_NANBOX_UPPER, result_sign_q, FP_S_EXP_MAX, {FP_S_MANT_W{1'b0}}};
+          round_result = {kronos_pkg::FP_NANBOX_UPPER, result_sign_q, kronos_pkg::FP_S_EXP_MAX, {kronos_pkg::FP_S_MANT_W{1'b0}}};
         end
       end else begin
         if (fmt_d_q) begin
-          round_result = {result_sign_q, FP_D_EXP_PENULT, {FP_D_MANT_W{1'b1}}};
+          round_result = {result_sign_q, kronos_pkg::FP_D_EXP_PENULT, {kronos_pkg::FP_D_MANT_W{1'b1}}};
         end else begin
-          round_result = {FP_NANBOX_UPPER, result_sign_q, FP_S_EXP_PENULT, {FP_S_MANT_W{1'b1}}};
+          round_result = {kronos_pkg::FP_NANBOX_UPPER, result_sign_q, kronos_pkg::FP_S_EXP_PENULT, {kronos_pkg::FP_S_MANT_W{1'b1}}};
         end
       end
     end else begin
       if (fmt_d_q) begin
-        round_result = {result_sign_q, rnd_exp_pack[FP_D_EXP_W-1:0], rnd_mant_pack[FP_D_MANT_W-1:0]};
+        round_result = {result_sign_q, rnd_exp_pack[kronos_pkg::FP_D_EXP_W-1:0], rnd_mant_pack[kronos_pkg::FP_D_MANT_W-1:0]};
       end else begin
-        round_result = {FP_NANBOX_UPPER, result_sign_q, rnd_exp_pack[FP_S_EXP_W-1:0], rnd_mant_pack[FP_S_MANT_W-1:0]};
+        round_result = {kronos_pkg::FP_NANBOX_UPPER, result_sign_q, rnd_exp_pack[kronos_pkg::FP_S_EXP_W-1:0], rnd_mant_pack[kronos_pkg::FP_S_MANT_W-1:0]};
       end
     end
   end
@@ -909,8 +909,8 @@ module kronos_fpu_iter
       fmt_d_q <= 1'b0;
       rm_q    <= 3'b0;
       tag_q   <= '{default: '0};
-      a_raw_q <= {FLEN{1'b0}};
-      b_raw_q <= {FLEN{1'b0}};
+      a_raw_q <= {kronos_pkg::FLEN{1'b0}};
+      b_raw_q <= {kronos_pkg::FLEN{1'b0}};
     end else if (state_q == IDLE && in_valid_i) begin
       op_q    <= op_i;
       fmt_d_q <= fmt_d_i;
@@ -942,10 +942,10 @@ module kronos_fpu_iter
       a_norm_q         <= 53'h0;
       b_norm_q         <= 53'h0;
       a_sqrt_q         <= 54'h0;
-      a_true_exp_q     <= {FP_EXP_EXT_W{1'b0}};
-      b_true_exp_q     <= {FP_EXP_EXT_W{1'b0}};
+      a_true_exp_q     <= {kronos_pkg::FP_EXP_EXT_W{1'b0}};
+      b_true_exp_q     <= {kronos_pkg::FP_EXP_EXT_W{1'b0}};
       is_special_q     <= 1'b0;
-      special_result_q <= {FLEN{1'b0}};
+      special_result_q <= {kronos_pkg::FLEN{1'b0}};
       special_fflags_q <= 5'h0;
     end else if (state_q == UNPACK1) begin
       a_norm_q         <= a_norm;
@@ -965,7 +965,7 @@ module kronos_fpu_iter
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_unpack2_latch
     if (!rst_ni) begin
       result_sign_q <= 1'b0;
-      result_exp_q  <= {FP_EXP_EXT_W{1'b0}};
+      result_exp_q  <= {kronos_pkg::FP_EXP_EXT_W{1'b0}};
     end else if (state_q == UNPACK2 && !is_special_q) begin
       result_sign_q <= result_sign_comb;
       result_exp_q  <= result_exp_comb;
@@ -990,7 +990,7 @@ module kronos_fpu_iter
   // -----------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_result_latch
     if (!rst_ni) begin
-      result_q <= {FLEN{1'b0}};
+      result_q <= {kronos_pkg::FLEN{1'b0}};
       fflags_q <= 5'h0;
     end else if (state_q == UNPACK2 && is_special_q) begin
       result_q <= special_result_q;

--- a/rtl/stage6/fpu/kronos_fpu_top.sv
+++ b/rtl/stage6/fpu/kronos_fpu_top.sv
@@ -30,13 +30,13 @@ module kronos_fpu_top
   input  fp_op_e      op_i,
   input  logic        fmt_d_i,
   input  logic [2:0]  rm_i,
-  input  logic [FLEN-1:0] a_i,
-  input  logic [FLEN-1:0] b_i,
-  input  logic [FLEN-1:0] c_i,
+  input  logic [kronos_pkg::FLEN-1:0] a_i,
+  input  logic [kronos_pkg::FLEN-1:0] b_i,
+  input  logic [kronos_pkg::FLEN-1:0] c_i,
   input  fpu_tag_t    tag_i,
   output logic        busy_o,
   output logic        out_valid_o,
-  output logic [FLEN-1:0] result_o,
+  output logic [kronos_pkg::FLEN-1:0] result_o,
   output logic [4:0]  fflags_o,
   output fpu_tag_t    tag_o
 );
@@ -69,12 +69,12 @@ module kronos_fpu_top
   logic        fmul_out_valid;
   logic        fma_out_valid;
   logic        iter_out_valid;
-  logic [FLEN-1:0] fmisc_result;
-  logic [FLEN-1:0] fcvt_result;
-  logic [FLEN-1:0] fadd_result;
-  logic [FLEN-1:0] fmul_result;
-  logic [FLEN-1:0] fma_result;
-  logic [FLEN-1:0] iter_result;
+  logic [kronos_pkg::FLEN-1:0] fmisc_result;
+  logic [kronos_pkg::FLEN-1:0] fcvt_result;
+  logic [kronos_pkg::FLEN-1:0] fadd_result;
+  logic [kronos_pkg::FLEN-1:0] fmul_result;
+  logic [kronos_pkg::FLEN-1:0] fma_result;
+  logic [kronos_pkg::FLEN-1:0] iter_result;
   logic [4:0]  fmisc_fflags;
   logic [4:0]  fcvt_fflags;
   logic [4:0]  fadd_fflags;
@@ -289,7 +289,7 @@ module kronos_fpu_top
   always_comb begin
     out_valid_o = fmisc_out_valid | fcvt_out_valid | fadd_out_valid
                 | fmul_out_valid  | fma_out_valid  | iter_out_valid;
-    result_o = {FLEN{1'b0}};
+    result_o = {kronos_pkg::FLEN{1'b0}};
     fflags_o = 5'h0;
     tag_o    = fpu_tag_t'(0);
     if (fmisc_out_valid) begin

--- a/rtl/stage6/kronos_align.sv
+++ b/rtl/stage6/kronos_align.sv
@@ -22,7 +22,7 @@ module kronos_align
   input  logic              clk_i,
   input  logic              rst_ni,
   input  logic [31:0]       pc_i,           // current fetch PC (used for cross-page detection)
-  input  logic [INST_W-1:0] rdata_i,
+  input  logic [kronos_pkg::INST_W-1:0] rdata_i,
   input  logic              rvalid_i,
   input  logic              stall_i,        // hold state when pipeline can't accept output
   input  logic              flush_i,
@@ -36,7 +36,7 @@ module kronos_align
   // fetch.  When translate_fetch_i=1 the cross-page fetch is conservatively
   // converted to an instruction-page fault.
   input  logic              translate_fetch_i,
-  output logic [INST_W-1:0] instr_o,
+  output logic [kronos_pkg::INST_W-1:0] instr_o,
   output logic              instr_valid_o,
   output logic              is_16b_o,
   output logic              align_stall_o,
@@ -70,10 +70,10 @@ module kronos_align
   // Prevents a permanent deadlock where need_upper_q gets stuck at 1 when a
   // muldiv (or other multi-cycle) stall coincides with the r_valid pulse.
   logic              span_valid_q;
-  logic [INST_W-1:0] span_instr_q;
+  logic [kronos_pkg::INST_W-1:0] span_instr_q;
 
   // Combinational from decompress instances
-  logic [INST_W-1:0] decomp_lower, decomp_upper, decomp_buf;
+  logic [kronos_pkg::INST_W-1:0] decomp_lower, decomp_upper, decomp_buf;
   logic              decomp_lower_ill, decomp_upper_ill, decomp_buf_ill;
 
   // cross-page 32-bit fetch detection
@@ -100,7 +100,7 @@ module kronos_align
   // Output logic (combinational)
   // -------------------------------------------------------------------------
   always_comb begin
-    instr_o            = {INST_W{1'b0}};
+    instr_o            = {kronos_pkg::INST_W{1'b0}};
     instr_valid_o      = 1'b0;
     is_16b_o           = 1'b0;
     align_stall_o      = need_upper_q;
@@ -186,7 +186,7 @@ module kronos_align
       need_upper_q <= 1'b0;
       skip_lower_q <= 1'b0;
       span_valid_q <= 1'b0;
-      span_instr_q <= {INST_W{1'b0}};
+      span_instr_q <= {kronos_pkg::INST_W{1'b0}};
     end else if (flush_i) begin
       buf_valid_q  <= 1'b0;
       buf_data_q   <= {16{1'b0}};

--- a/rtl/stage6/kronos_alu.sv
+++ b/rtl/stage6/kronos_alu.sv
@@ -8,73 +8,73 @@ module kronos_alu
   import kronos_pkg::*;
 (
   input  alu_op_e            op_i,
-  input  logic [XLEN-1:0]    a_i,
-  input  logic [XLEN-1:0]    b_i,
+  input  logic [kronos_pkg::XLEN-1:0]    a_i,
+  input  logic [kronos_pkg::XLEN-1:0]    b_i,
   input  logic               word_op_i,
-  output logic [XLEN-1:0]    result_o
+  output logic [kronos_pkg::XLEN-1:0]    result_o
 );
 
   // Combinational signals
-  logic [XLEN-1:0]      result_64;
-  logic [INST_W-1:0]    result_32;
+  logic [kronos_pkg::XLEN-1:0]      result_64;
+  logic [kronos_pkg::INST_W-1:0]    result_32;
 
   always_comb begin
-    result_64 = {XLEN{1'b0}};
-    result_32 = {INST_W{1'b0}};
-    result_o  = {XLEN{1'b0}};
+    result_64 = {kronos_pkg::XLEN{1'b0}};
+    result_32 = {kronos_pkg::INST_W{1'b0}};
+    result_o  = {kronos_pkg::XLEN{1'b0}};
 
     unique case (op_i)
       ALU_ADD: begin
         result_64 = a_i + b_i;
-        result_32 = a_i[INST_W-1:0] + b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] + b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_SUB: begin
         result_64 = a_i - b_i;
-        result_32 = a_i[INST_W-1:0] - b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] - b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_SLL: begin
-        result_64 = a_i << b_i[$clog2(XLEN)-1:0];
-        result_32 = a_i[INST_W-1:0] << b_i[$clog2(INST_W)-1:0];
+        result_64 = a_i << b_i[$clog2(kronos_pkg::XLEN)-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] << b_i[$clog2(kronos_pkg::INST_W)-1:0];
       end
       ALU_SLT: begin
-        result_64 = {{(XLEN-1){1'b0}}, $signed(a_i) < $signed(b_i)};
-        result_32 = result_64[INST_W-1:0];
+        result_64 = {{(kronos_pkg::XLEN-1){1'b0}}, $signed(a_i) < $signed(b_i)};
+        result_32 = result_64[kronos_pkg::INST_W-1:0];
       end
       ALU_SLTU: begin
-        result_64 = {{(XLEN-1){1'b0}}, a_i < b_i};
-        result_32 = result_64[INST_W-1:0];
+        result_64 = {{(kronos_pkg::XLEN-1){1'b0}}, a_i < b_i};
+        result_32 = result_64[kronos_pkg::INST_W-1:0];
       end
       ALU_XOR: begin
         result_64 = a_i ^ b_i;
-        result_32 = a_i[INST_W-1:0] ^ b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] ^ b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_SRL: begin
-        result_64 = a_i >> b_i[$clog2(XLEN)-1:0];
-        result_32 = a_i[INST_W-1:0] >> b_i[$clog2(INST_W)-1:0];
+        result_64 = a_i >> b_i[$clog2(kronos_pkg::XLEN)-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] >> b_i[$clog2(kronos_pkg::INST_W)-1:0];
       end
       ALU_SRA: begin
-        result_64 = XLEN'($signed(a_i) >>> b_i[$clog2(XLEN)-1:0]);
-        result_32 = INST_W'($signed(a_i[INST_W-1:0]) >>> b_i[$clog2(INST_W)-1:0]);
+        result_64 = kronos_pkg::XLEN'($signed(a_i) >>> b_i[$clog2(kronos_pkg::XLEN)-1:0]);
+        result_32 = kronos_pkg::INST_W'($signed(a_i[kronos_pkg::INST_W-1:0]) >>> b_i[$clog2(kronos_pkg::INST_W)-1:0]);
       end
       ALU_OR: begin
         result_64 = a_i | b_i;
-        result_32 = a_i[INST_W-1:0] | b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] | b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_AND: begin
         result_64 = a_i & b_i;
-        result_32 = a_i[INST_W-1:0] & b_i[INST_W-1:0];
+        result_32 = a_i[kronos_pkg::INST_W-1:0] & b_i[kronos_pkg::INST_W-1:0];
       end
       ALU_PASSB: begin
         result_64 = b_i;
-        result_32 = b_i[INST_W-1:0];
+        result_32 = b_i[kronos_pkg::INST_W-1:0];
       end
       default: begin
-        result_64 = {XLEN{1'b0}};
-        result_32 = {INST_W{1'b0}};
+        result_64 = {kronos_pkg::XLEN{1'b0}};
+        result_32 = {kronos_pkg::INST_W{1'b0}};
       end
     endcase
 
-    result_o = word_op_i ? {{(XLEN-INST_W){result_32[INST_W-1]}}, result_32} : result_64;
+    result_o = word_op_i ? {{(kronos_pkg::XLEN-kronos_pkg::INST_W){result_32[kronos_pkg::INST_W-1]}}, result_32} : result_64;
   end
 
 endmodule

--- a/rtl/stage6/kronos_csr.sv
+++ b/rtl/stage6/kronos_csr.sv
@@ -6,7 +6,7 @@
 // Implements mstatus, misa, mie, mtvec, mscratch, mepc, mcause, mip.
 // Handles trap entry (ECALL/EBREAK/illegal), MRET, and CSR read/write.
 // Stage 5a adds FFLAGS/FRM/FCSR floating-point CSRs and mstatus.FS storage.
-// All CSR data paths are 64 bits wide (MXL=10, XLEN=64).
+// All CSR data paths are 64 bits wide (MXL=10, kronos_pkg::XLEN=64).
 module kronos_csr
   import kronos_pkg::*;
 #(
@@ -19,9 +19,9 @@ module kronos_csr
   input  logic [11:0] addr_i,
   input  logic [2:0]  funct3_i,
   input  logic        use_imm_i,
-  input  logic [XLEN-1:0] rs1_data_i,
+  input  logic [kronos_pkg::XLEN-1:0] rs1_data_i,
   input  logic [4:0]      rs1_addr_i,
-  output logic [XLEN-1:0] rdata_o,
+  output logic [kronos_pkg::XLEN-1:0] rdata_o,
   output logic        valid_o,
   // Trap interface
   input  logic        trap_i,
@@ -35,12 +35,12 @@ module kronos_csr
   // both TLBs (I-TLB and D-TLB) via the matching *_o ports.  Pure combinational
   // passthrough — no architectural state involved.
   input  logic              sfence_vma_i,
-  input  logic [XLEN-1:0]   sfence_va_i,
+  input  logic [kronos_pkg::XLEN-1:0]   sfence_va_i,
   input  logic [15:0]       sfence_asid_i,
   input  logic              sfence_va_valid_i,
   input  logic              sfence_asid_valid_i,
   output logic              sfence_vma_o,
-  output logic [XLEN-1:0]   sfence_va_o,
+  output logic [kronos_pkg::XLEN-1:0]   sfence_va_o,
   output logic [15:0]       sfence_asid_o,
   output logic              sfence_va_valid_o,
   output logic              sfence_asid_valid_o,
@@ -49,15 +49,15 @@ module kronos_csr
   output logic [3:0]        satp_mode_o,
   output logic [15:0]       satp_asid_o,
   output logic [43:0]       satp_ppn_o,
-  output logic [XLEN-1:0] trap_vector_o,
-  output logic [XLEN-1:0] mepc_o,
+  output logic [kronos_pkg::XLEN-1:0] trap_vector_o,
+  output logic [kronos_pkg::XLEN-1:0] mepc_o,
   // sepc output for sret target redirection (kronos_top reads this
   // when an SRET advances out of EX).
-  output logic [XLEN-1:0] sepc_o,
+  output logic [kronos_pkg::XLEN-1:0] sepc_o,
   // current privilege level (M/S/U)
   output priv_e           priv_o,
   // full mstatus exposed for top-level (TW/TSR/TVM consultation).
-  output logic [XLEN-1:0] mstatus_o,
+  output logic [kronos_pkg::XLEN-1:0] mstatus_o,
   // Interrupts
   input  logic        irq_timer_i,
   input  logic [14:0] irq_fast_i,
@@ -89,14 +89,14 @@ module kronos_csr
   // is high, the trigger module owns this CSR read; csr_rdata is sourced from
   // trig_csr_rdata_i instead of the local mux.  Writes are forwarded to the
   // trigger module via trig_csr_we_o below.
-  input  logic [XLEN-1:0] trig_csr_rdata_i,
+  input  logic [kronos_pkg::XLEN-1:0] trig_csr_rdata_i,
   input  logic            trig_csr_match_i,
   output logic            trig_csr_we_o,    // 1 = current cycle is a trigger CSR write
   // post-write CSR value (combinational, valid for any csrrs/csrrc/csrrw).
   // Routed to retire_csr_wdata_o at top so the Sail-vs-Kronos trace diff sees
   // the new CSR value rather than the RS1 operand.
-  output logic [XLEN-1:0] csr_new_val_o,
-  output logic [XLEN-1:0] trig_csr_wdata_o, // CSR new value (after CSRRS/CSRRC)
+  output logic [kronos_pkg::XLEN-1:0] csr_new_val_o,
+  output logic [kronos_pkg::XLEN-1:0] trig_csr_wdata_o, // CSR new value (after CSRRS/CSRRC)
   // illegal-CSR-access aggregate output.  Currently driven by the
   // counter-access gate (mcounteren/scounteren).  T11 will OR additional
   // sources (privilege/RO-write checks) into this signal.  Top-level wiring
@@ -113,15 +113,15 @@ module kronos_csr
   // -------------------------------------------------------------------------
   // S-mode interrupt bits (SSIE/STIE/SEIE → SSIP/STIP/SEIP).  Used by mideleg
   // WARL mask, the SIE/SIP windows, and the irq_eff S-mode IRQ path.
-  localparam logic [XLEN-1:0] SMODE_IRQ_MASK   = 64'h0000_0000_0000_0222;
+  localparam logic [kronos_pkg::XLEN-1:0] SMODE_IRQ_MASK   = 64'h0000_0000_0000_0222;
   // mstatus M-mode writable-bit mask (Stage 6a-implemented bits; see decode).
-  localparam logic [XLEN-1:0] MSTATUS_M_MASK   = 64'h0000_0000_007E_79AA;
+  localparam logic [kronos_pkg::XLEN-1:0] MSTATUS_M_MASK   = 64'h0000_0000_007E_79AA;
   // sstatus S-visible writable-bit mask (used for both write-decode and read).
-  localparam logic [XLEN-1:0] SSTATUS_RW_MASK  = 64'h8000_0003_000D_E162;
+  localparam logic [kronos_pkg::XLEN-1:0] SSTATUS_RW_MASK  = 64'h8000_0003_000D_E162;
   // SSTATUS read mask without SD (bit 63) — SD is recomputed from FS == 11.
-  localparam logic [XLEN-2:0] SSTATUS_RD_MASK  = 63'h0000_0003_000D_E162;
+  localparam logic [kronos_pkg::XLEN-2:0] SSTATUS_RD_MASK  = 63'h0000_0003_000D_E162;
   // medeleg WARL mask (bits 0..15 except 11/14 hardwired 0).
-  localparam logic [XLEN-1:0] MEDELEG_MASK     = 64'h0000_0000_0000_B7FF;
+  localparam logic [kronos_pkg::XLEN-1:0] MEDELEG_MASK     = 64'h0000_0000_0000_B7FF;
 
   // -------------------------------------------------------------------------
   // 3. State registers (driven by always_ff)
@@ -131,33 +131,33 @@ module kronos_csr
   priv_e priv_q;
 
   // Machine-mode CSRs
-  logic [XLEN-1:0] mstatus;   // 0x300
-  logic [XLEN-1:0] mie;       // 0x304
-  logic [XLEN-1:0] mtvec;     // 0x305
-  logic [XLEN-1:0] mscratch;  // 0x340
-  logic [XLEN-1:0] mepc;      // 0x341
-  logic [XLEN-1:0] mcause;    // 0x342
-  logic [XLEN-1:0] mtval;     // 0x343
-  logic [XLEN-1:0] medeleg;   // 0x302  -- per-cause sync exception delegation
-  logic [XLEN-1:0] mideleg;   // 0x303  -- per-cause interrupt delegation
+  logic [kronos_pkg::XLEN-1:0] mstatus;   // 0x300
+  logic [kronos_pkg::XLEN-1:0] mie;       // 0x304
+  logic [kronos_pkg::XLEN-1:0] mtvec;     // 0x305
+  logic [kronos_pkg::XLEN-1:0] mscratch;  // 0x340
+  logic [kronos_pkg::XLEN-1:0] mepc;      // 0x341
+  logic [kronos_pkg::XLEN-1:0] mcause;    // 0x342
+  logic [kronos_pkg::XLEN-1:0] mtval;     // 0x343
+  logic [kronos_pkg::XLEN-1:0] medeleg;   // 0x302  -- per-cause sync exception delegation
+  logic [kronos_pkg::XLEN-1:0] mideleg;   // 0x303  -- per-cause interrupt delegation
   // software-written shadow of the SSIP/STIP/SEIP bits.
   // We keep `mip` itself as a continuous assign for hardware-driven bits
   // (irq_timer/irq_fast).  CSR writes (M-mode: SSIP/STIP/SEIP, S-mode: SSIP)
   // land in mip_sw; the read mux/path uses (mip | mip_sw).  This is the less
   // invasive of the two T7 options — no register conversion of mip required.
-  logic [XLEN-1:0] mip_sw;
+  logic [kronos_pkg::XLEN-1:0] mip_sw;
 
   // S-mode CSRs.
   // sstatus / sip / sie are *windows* into mstatus/mip/mie — handled in
   // the read mux and write decode below.
-  logic [XLEN-1:0] stvec;          // bit[1:0] hardwired 00 (Direct)
-  logic [XLEN-1:0] sscratch;
-  logic [XLEN-1:0] sepc;           // bit[0] hardwired 0
-  logic [XLEN-1:0] scause;
-  logic [XLEN-1:0] stval;
-  logic [XLEN-1:0] satp;           // MODE reads as 0 in 6a
+  logic [kronos_pkg::XLEN-1:0] stvec;          // bit[1:0] hardwired 00 (Direct)
+  logic [kronos_pkg::XLEN-1:0] sscratch;
+  logic [kronos_pkg::XLEN-1:0] sepc;           // bit[0] hardwired 0
+  logic [kronos_pkg::XLEN-1:0] scause;
+  logic [kronos_pkg::XLEN-1:0] stval;
+  logic [kronos_pkg::XLEN-1:0] satp;           // MODE reads as 0 in 6a
   logic [31:0]     scounteren;
-  logic [XLEN-1:0] senvcfg;        // hardwired 0 in 6a
+  logic [kronos_pkg::XLEN-1:0] senvcfg;        // hardwired 0 in 6a
 
   // FCSR = {FRM[2:0], FFLAGS[4:0]} — 8 bits, zero-extended to 64 for reads.
   logic [7:0]  fcsr_q;    // 0x001/0x002/0x003
@@ -165,8 +165,8 @@ module kronos_csr
   // Zicntr counters — read-only user-mode counters (mirrored from m-mode
   // mcycle/minstret in a full implementation; here we just expose free-running
   // counters at 0xC00/0xC02 so ACT4 Zicntr tests pass).
-  logic [XLEN-1:0] mcycle;    // 0xB00 / 0xC00 (U-mode alias)
-  logic [XLEN-1:0] minstret;  // 0xB02 / 0xC02 (U-mode alias)
+  logic [kronos_pkg::XLEN-1:0] mcycle;    // 0xB00 / 0xC00 (U-mode alias)
+  logic [kronos_pkg::XLEN-1:0] minstret;  // 0xB02 / 0xC02 (U-mode alias)
 
   // Zihpm counter-control + event counters (Stage 5c).
   // mcountinhibit (0x320) — bit X gates increment of counter X:
@@ -186,7 +186,7 @@ module kronos_csr
   // mhpmcounter3..10 — 8 programmable 64-bit event counters.
   // Indexed as mhpmcounter[3]..mhpmcounter[10]; entries [0..2] are unused
   // (their CSR slots are mcycle/reserved/minstret which live above).
-  logic [XLEN-1:0] mhpmcounter [3:10];
+  logic [kronos_pkg::XLEN-1:0] mhpmcounter [3:10];
 
   // mhpmevent3..10 — paired event-select registers (only bits [7:0] used).
   logic [7:0]  mhpmevent   [3:10];
@@ -195,12 +195,12 @@ module kronos_csr
   // 4. Combinational signals
   // -------------------------------------------------------------------------
   // Read-only / hardware-driven CSR views
-  logic [XLEN-1:0] misa;
-  logic [XLEN-1:0] mip;
+  logic [kronos_pkg::XLEN-1:0] misa;
+  logic [kronos_pkg::XLEN-1:0] mip;
 
   // CSR write-data path
-  logic [XLEN-1:0] csr_wdata;
-  logic [XLEN-1:0] csr_new_val;
+  logic [kronos_pkg::XLEN-1:0] csr_wdata;
+  logic [kronos_pkg::XLEN-1:0] csr_new_val;
   logic            fp_csr_sw_write;
 
   // trap delegation routing.  When priv != M and the cause's
@@ -210,7 +210,7 @@ module kronos_csr
   logic [4:0] cause_idx;
 
   // interrupt-priority encoder outputs (see always_comb below).
-  logic [XLEN-1:0] irq_eff;
+  logic [kronos_pkg::XLEN-1:0] irq_eff;
   logic [4:0]      irq_cause_int;
   logic            irq_pending_int;
 
@@ -346,11 +346,11 @@ module kronos_csr
       12'h003: rdata_o = {56'b0, fcsr_q};                 // FCSR
       12'h300: rdata_o = {(mstatus[14:13] == 2'b11), mstatus[62:0]}; // bit63=SD, derived from FS
       12'h301: rdata_o = misa;
-      CSR_MEDELEG: rdata_o = medeleg;
-      CSR_MIDELEG: rdata_o = mideleg;
+      kronos_pkg::CSR_MEDELEG: rdata_o = medeleg;
+      kronos_pkg::CSR_MIDELEG: rdata_o = mideleg;
       12'h304: rdata_o = mie;
       12'h305: rdata_o = mtvec;
-      CSR_MCOUNTEREN: rdata_o = {32'd0, mcounteren};
+      kronos_pkg::CSR_MCOUNTEREN: rdata_o = {32'd0, mcounteren};
       12'h320: rdata_o = {53'b0, mcountinhibit};         // mcountinhibit
       12'h323: rdata_o = {56'b0, mhpmevent[3]};
       12'h324: rdata_o = {56'b0, mhpmevent[4]};
@@ -366,9 +366,9 @@ module kronos_csr
       12'h343: rdata_o = mtval;
       12'h344: rdata_o = mip | mip_sw;
       // PMP CSRs.  pmpcfg0 packs cfg bytes 0..7; pmpcfg2 packs 8..15.
-      CSR_PMPCFG0: rdata_o = {pmpcfg_q[7], pmpcfg_q[6], pmpcfg_q[5], pmpcfg_q[4],
+      kronos_pkg::CSR_PMPCFG0: rdata_o = {pmpcfg_q[7], pmpcfg_q[6], pmpcfg_q[5], pmpcfg_q[4],
                               pmpcfg_q[3], pmpcfg_q[2], pmpcfg_q[1], pmpcfg_q[0]};
-      CSR_PMPCFG2: rdata_o = {pmpcfg_q[15], pmpcfg_q[14], pmpcfg_q[13], pmpcfg_q[12],
+      kronos_pkg::CSR_PMPCFG2: rdata_o = {pmpcfg_q[15], pmpcfg_q[14], pmpcfg_q[13], pmpcfg_q[12],
                               pmpcfg_q[11], pmpcfg_q[10], pmpcfg_q[9],  pmpcfg_q[8]};
       12'h3B0: rdata_o = {10'd0, pmpaddr_q[0]};
       12'h3B1: rdata_o = {10'd0, pmpaddr_q[1]};
@@ -400,21 +400,21 @@ module kronos_csr
       12'hB09, 12'hC09: rdata_o = mhpmcounter[9];
       12'hB0A, 12'hC0A: rdata_o = mhpmcounter[10];
       // S-mode CSRs
-      CSR_STVEC:      rdata_o = {stvec[63:2], 2'b00};
-      CSR_SSCRATCH:   rdata_o = sscratch;
-      CSR_SEPC:       rdata_o = {sepc[63:1], 1'b0};
-      CSR_SCAUSE:     rdata_o = scause;
-      CSR_STVAL:      rdata_o = stval;
-      CSR_SATP:       rdata_o = satp;
-      CSR_SCOUNTEREN: rdata_o = {32'd0, scounteren};
-      CSR_SENVCFG:    rdata_o = senvcfg;
+      kronos_pkg::CSR_STVEC:      rdata_o = {stvec[63:2], 2'b00};
+      kronos_pkg::CSR_SSCRATCH:   rdata_o = sscratch;
+      kronos_pkg::CSR_SEPC:       rdata_o = {sepc[63:1], 1'b0};
+      kronos_pkg::CSR_SCAUSE:     rdata_o = scause;
+      kronos_pkg::CSR_STVAL:      rdata_o = stval;
+      kronos_pkg::CSR_SATP:       rdata_o = satp;
+      kronos_pkg::CSR_SCOUNTEREN: rdata_o = {32'd0, scounteren};
+      kronos_pkg::CSR_SENVCFG:    rdata_o = senvcfg;
       // SSTATUS: S-visible bits + SD computed from FS (mstatus[63] is never
       // written; the SD bit must be derived from FS == 2'b11 just like the
       // master mstatus read above).
-      CSR_SSTATUS:    rdata_o = {(mstatus[14:13] == 2'b11),
+      kronos_pkg::CSR_SSTATUS:    rdata_o = {(mstatus[14:13] == 2'b11),
                                   63'(mstatus[62:0] & SSTATUS_RD_MASK)};
-      CSR_SIE:        rdata_o = mie & SMODE_IRQ_MASK;            // SSIE/STIE/SEIE
-      CSR_SIP:        rdata_o = (mip | mip_sw) & SMODE_IRQ_MASK;
+      kronos_pkg::CSR_SIE:        rdata_o = mie & SMODE_IRQ_MASK;            // SSIE/STIE/SEIE
+      kronos_pkg::CSR_SIP:        rdata_o = (mip | mip_sw) & SMODE_IRQ_MASK;
       default: rdata_o = trig_csr_match_i ? trig_csr_rdata_i : 64'hDEAD_C5A0_DEAD_C5A0;
     endcase
   end
@@ -491,32 +491,32 @@ module kronos_csr
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       mstatus  <= 64'h0000_0000_0000_1800; // MPP=11, FS=00 (Off) — matches Sail; common.S sets FS=Dirty in prologue
-      mie      <= {XLEN{1'b0}};
-      mtvec    <= {XLEN{1'b0}};
-      mscratch <= {XLEN{1'b0}};
-      mepc     <= {XLEN{1'b0}};
-      mcause   <= {XLEN{1'b0}};
-      mtval    <= {XLEN{1'b0}};
-      medeleg  <= {XLEN{1'b0}};
-      mideleg  <= {XLEN{1'b0}};
-      mip_sw   <= {XLEN{1'b0}};
+      mie      <= {kronos_pkg::XLEN{1'b0}};
+      mtvec    <= {kronos_pkg::XLEN{1'b0}};
+      mscratch <= {kronos_pkg::XLEN{1'b0}};
+      mepc     <= {kronos_pkg::XLEN{1'b0}};
+      mcause   <= {kronos_pkg::XLEN{1'b0}};
+      mtval    <= {kronos_pkg::XLEN{1'b0}};
+      medeleg  <= {kronos_pkg::XLEN{1'b0}};
+      mideleg  <= {kronos_pkg::XLEN{1'b0}};
+      mip_sw   <= {kronos_pkg::XLEN{1'b0}};
       fcsr_q   <= 8'h00;
-      mcycle   <= {XLEN{1'b0}};
-      minstret <= {XLEN{1'b0}};
+      mcycle   <= {kronos_pkg::XLEN{1'b0}};
+      minstret <= {kronos_pkg::XLEN{1'b0}};
       mcountinhibit <= 11'b0;
       mcounteren    <= 32'b0;
       priv_q   <= PRIV_M;
       // S-mode CSRs reset
-      stvec       <= {XLEN{1'b0}};
-      sscratch    <= {XLEN{1'b0}};
-      sepc        <= {XLEN{1'b0}};
-      scause      <= {XLEN{1'b0}};
-      stval       <= {XLEN{1'b0}};
-      satp        <= {XLEN{1'b0}};
+      stvec       <= {kronos_pkg::XLEN{1'b0}};
+      sscratch    <= {kronos_pkg::XLEN{1'b0}};
+      sepc        <= {kronos_pkg::XLEN{1'b0}};
+      scause      <= {kronos_pkg::XLEN{1'b0}};
+      stval       <= {kronos_pkg::XLEN{1'b0}};
+      satp        <= {kronos_pkg::XLEN{1'b0}};
       scounteren  <= 32'b0;
-      senvcfg     <= {XLEN{1'b0}};
+      senvcfg     <= {kronos_pkg::XLEN{1'b0}};
       for (int i = 3; i <= 10; i++) begin
-        mhpmcounter[i] <= {XLEN{1'b0}};
+        mhpmcounter[i] <= {kronos_pkg::XLEN{1'b0}};
         mhpmevent[i]   <= 8'b0;
       end
       // PMP reset — all regions OFF (A=00) and unlocked.
@@ -600,12 +600,12 @@ module kronos_csr
           end
           // medeleg WARL: bits 0..15 writable except bit 11 (M-ecall, hardwired 0);
           // bits 14 and 16+ also hardwired 0.
-          CSR_MEDELEG: medeleg <= csr_new_val & MEDELEG_MASK;
+          kronos_pkg::CSR_MEDELEG: medeleg <= csr_new_val & MEDELEG_MASK;
           // mideleg WARL: only SSIE/STIE/SEIE delegation bits writable.
-          CSR_MIDELEG: mideleg <= csr_new_val & SMODE_IRQ_MASK;
+          kronos_pkg::CSR_MIDELEG: mideleg <= csr_new_val & SMODE_IRQ_MASK;
           12'h304: mie      <= csr_new_val;
           12'h305: mtvec    <= csr_new_val;
-          CSR_MCOUNTEREN: mcounteren <= csr_new_val[31:0];
+          kronos_pkg::CSR_MCOUNTEREN: mcounteren <= csr_new_val[31:0];
           12'h320: mcountinhibit <= csr_new_val[10:0];
           12'h323: mhpmevent[3]  <= csr_new_val[7:0];
           12'h324: mhpmevent[4]  <= csr_new_val[7:0];
@@ -629,7 +629,7 @@ module kronos_csr
           //  - L=1 ⇒ drop write to that byte AND its paired pmpaddr.
           //  - A=01 (TOR) collapses to A=00 (OFF) — Stage 6 supports OFF/NAPOT only.
           //  - WPRI bits [6:5] read 0.
-          CSR_PMPCFG0: begin
+          kronos_pkg::CSR_PMPCFG0: begin
             for (int i = 0; i < 8; i++) begin
               if (~pmpcfg_q[i][7]) begin
                 // WARL: WPRI bits [6:5] clear; A=01 (TOR) collapses to A=00 (OFF).
@@ -641,7 +641,7 @@ module kronos_csr
               end
             end
           end
-          CSR_PMPCFG2: begin
+          kronos_pkg::CSR_PMPCFG2: begin
             for (int i = 0; i < 8; i++) begin
               if (~pmpcfg_q[i+8][7]) begin
                 // WARL: WPRI bits [6:5] clear; A=01 (TOR) collapses to A=00 (OFF).
@@ -682,36 +682,36 @@ module kronos_csr
           12'hB09: mhpmcounter[9]  <= csr_new_val;
           12'hB0A: mhpmcounter[10] <= csr_new_val;
           // S-mode CSRs
-          CSR_STVEC:      stvec       <= {csr_new_val[63:2], 2'b00};
-          CSR_SSCRATCH:   sscratch    <= csr_new_val;
-          CSR_SEPC:       sepc        <= {csr_new_val[63:1], 1'b0};
-          CSR_SCAUSE:     scause      <= csr_new_val;
-          CSR_STVAL:      stval       <= csr_new_val;
-          CSR_SATP: begin
+          kronos_pkg::CSR_STVEC:      stvec       <= {csr_new_val[63:2], 2'b00};
+          kronos_pkg::CSR_SSCRATCH:   sscratch    <= csr_new_val;
+          kronos_pkg::CSR_SEPC:       sepc        <= {csr_new_val[63:1], 1'b0};
+          kronos_pkg::CSR_SCAUSE:     scause      <= csr_new_val;
+          kronos_pkg::CSR_STVAL:      stval       <= csr_new_val;
+          kronos_pkg::CSR_SATP: begin
             // WARL on MODE.  Only Bare/Sv39/Sv48 are supported; on
             // any other MODE the *entire* write is dropped (per priv-spec WARL
             // rules — we choose to keep the legal previous value rather than
             // accept a partially-modified satp).
-            if (csr_new_val[63:60] == SATP_MODE_BARE |
-                csr_new_val[63:60] == SATP_MODE_SV39 |
-                csr_new_val[63:60] == SATP_MODE_SV48) begin
+            if (csr_new_val[63:60] == kronos_pkg::SATP_MODE_BARE |
+                csr_new_val[63:60] == kronos_pkg::SATP_MODE_SV39 |
+                csr_new_val[63:60] == kronos_pkg::SATP_MODE_SV48) begin
               satp <= csr_new_val;
             end
           end
-          CSR_SCOUNTEREN: scounteren  <= csr_new_val[31:0];
-          CSR_SENVCFG:    /* WARL=0 in 6a; ignore writes */ ;
-          CSR_SSTATUS: begin
+          kronos_pkg::CSR_SCOUNTEREN: scounteren  <= csr_new_val[31:0];
+          kronos_pkg::CSR_SENVCFG:    /* WARL=0 in 6a; ignore writes */ ;
+          kronos_pkg::CSR_SSTATUS: begin
             // Only S-visible bits writable; preserve the rest of mstatus.
             mstatus <= (mstatus & ~SSTATUS_RW_MASK)
                      | (csr_new_val & SSTATUS_RW_MASK);
           end
-          CSR_SIE: begin
+          kronos_pkg::CSR_SIE: begin
             mie <= (mie & ~SMODE_IRQ_MASK)
                  | (csr_new_val & SMODE_IRQ_MASK);
           end
-          CSR_SIP: begin
+          kronos_pkg::CSR_SIP: begin
             // S-mode view of mip: only SSIP (bit 1) is writable from S-mode.
-            // Land the write in the mip_sw shadow register; the CSR_SIP read
+            // Land the write in the mip_sw shadow register; the kronos_pkg::CSR_SIP read
             // path returns (mip | mip_sw) masked to the S-visible bits.
             // M-mode software can write SSIP/STIP/SEIP via 0x344 above.
             mip_sw <= (mip_sw & ~64'h0000_0000_0000_0002)

--- a/rtl/stage6/kronos_dcache.sv
+++ b/rtl/stage6/kronos_dcache.sv
@@ -19,8 +19,8 @@ module kronos_dcache
   parameter int unsigned PHYS_ADDR_W = 64,
   // PMA: non-cacheable region list. Default matches issue #67 (0x4000_0000-0x4FFF_FFFF).
   parameter int unsigned NUM_NC_REGIONS = 1,
-  parameter logic [XLEN-1:0] NC_REGION_BASE  [NUM_NC_REGIONS] = '{MMIO_BASE},
-  parameter logic [XLEN-1:0] NC_REGION_LIMIT [NUM_NC_REGIONS] = '{64'h0000_0000_4FFF_FFFF}
+  parameter logic [kronos_pkg::XLEN-1:0] NC_REGION_BASE  [NUM_NC_REGIONS] = '{kronos_pkg::MMIO_BASE},
+  parameter logic [kronos_pkg::XLEN-1:0] NC_REGION_LIMIT [NUM_NC_REGIONS] = '{64'h0000_0000_4FFF_FFFF}
 ) (
   input  logic                   clk_i,
   input  logic                   rst_ni,
@@ -30,12 +30,12 @@ module kronos_dcache
   input  logic [PHYS_ADDR_W-1:0] addr_i,
   input  logic [2:0]             size_i,
   input  logic                   we_i,
-  input  logic [XLEN-1:0]        wdata_i,
+  input  logic [kronos_pkg::XLEN-1:0]        wdata_i,
   input  logic                   amo_req_i,
   input  logic [4:0]             amo_op_i,
   input  logic                   rsrv_clear_i,
   output logic                   data_valid_o,
-  output logic [XLEN-1:0]        rdata_o,
+  output logic [kronos_pkg::XLEN-1:0]        rdata_o,
   output logic                   sc_success_o,
   output logic                   stall_o,
 
@@ -43,11 +43,11 @@ module kronos_dcache
   input  logic                   ptw_req_valid_i,
   input  logic [55:0]            ptw_req_addr_i,
   input  logic                   ptw_req_we_i,
-  input  logic [XLEN-1:0]        ptw_req_wdata_i,
+  input  logic [kronos_pkg::XLEN-1:0]        ptw_req_wdata_i,
   input  logic                   ptw_req_is_lr_i,
   input  logic                   ptw_req_is_sc_i,
   output logic                   ptw_rsp_valid_o,
-  output logic [XLEN-1:0]        ptw_rsp_rdata_o,
+  output logic [kronos_pkg::XLEN-1:0]        ptw_rsp_rdata_o,
   output logic                   ptw_rsp_sc_ok_o,
 
   // FENCE.I full flush: writeback every dirty line and invalidate.  Hold
@@ -100,7 +100,7 @@ module kronos_dcache
   logic             valid_q [NUM_SETS][NUM_WAYS];
   logic             dirty_q [NUM_SETS][NUM_WAYS];
   logic [2:0]       plru_q  [NUM_SETS];
-  logic [XLEN-1:0]  data_q  [NUM_WAYS][NUM_SETS][BEATS];
+  logic [kronos_pkg::XLEN-1:0]  data_q  [NUM_WAYS][NUM_SETS][BEATS];
 
   // Top-level FSM state
   dcache_state_e state_q;
@@ -115,10 +115,10 @@ module kronos_dcache
   logic [$clog2(NUM_WAYS)-1:0]     victim_q;
   logic [3:0]                      beat_cnt_q;
   logic                            bypass_valid_q;
-  logic [XLEN-1:0]                 bypass_data_q;
+  logic [kronos_pkg::XLEN-1:0]                 bypass_data_q;
   logic                            miss_was_store_q;
-  logic [XLEN-1:0]                 miss_store_data_q;
-  logic [XLEN_BYTES-1:0]           miss_store_strobes_q;
+  logic [kronos_pkg::XLEN-1:0]                 miss_store_data_q;
+  logic [kronos_pkg::XLEN_BYTES-1:0]           miss_store_strobes_q;
   logic [2:0]                      miss_store_off_q;
   logic                            store_done_q;
   logic [3:0]                      wb_beat_cnt_q;
@@ -129,13 +129,13 @@ module kronos_dcache
   logic [PHYS_ADDR_W-1:0] nc_addr_q;
   logic [2:0]             nc_size_q;
   logic                   nc_we_q;
-  logic [XLEN-1:0]        nc_wdata_q;
+  logic [kronos_pkg::XLEN-1:0]        nc_wdata_q;
   logic                   nc_is_ptw_q;     // routes the response back to PTW
 
   // NC read response — captured one cycle in DC_NC_R; used by the
   // load-extension mux for one cycle.
   logic            nc_rsp_valid_q;
-  logic [XLEN-1:0] nc_rsp_data_q;
+  logic [kronos_pkg::XLEN-1:0] nc_rsp_data_q;
   logic         nc_rsp_err_q;     // r.resp != OKAY captured at the same time
 
   // NC write completion — pulses for one cycle when B arrives.
@@ -145,8 +145,8 @@ module kronos_dcache
   // AMO state registers
   logic            amo_pending_q;
   logic [4:0]      amo_op_q;
-  logic [XLEN-1:0] amo_src_q;
-  logic [XLEN-1:0] amo_old_val_q;
+  logic [kronos_pkg::XLEN-1:0] amo_src_q;
+  logic [kronos_pkg::XLEN-1:0] amo_old_val_q;
   logic        amo_done_q;
   logic        amo_is_word_q;     // size_i == 3'd2
   logic [2:0]  amo_addr_off_q;    // addr_i[2:0] captured at AMO issue
@@ -174,7 +174,7 @@ module kronos_dcache
   logic                   eff_req_valid;
   logic [PHYS_ADDR_W-1:0] eff_req_addr;
   logic                   eff_req_we;
-  logic [XLEN-1:0]        eff_req_wdata;
+  logic [kronos_pkg::XLEN-1:0]        eff_req_wdata;
   logic                   eff_req_is_lr;
   logic                   eff_req_is_sc;
   logic [2:0]             eff_req_size;
@@ -204,40 +204,40 @@ module kronos_dcache
   logic dirty_pending;
 
   // AMO intermediate signals for DC_AMO_RMW
-  logic [XLEN-1:0]       amo_cur_beat;
-  logic [XLEN-1:0]       amo_result;
-  logic [XLEN_BYTES-1:0] amo_be;
-  logic [XLEN-1:0]       amo_aligned;
+  logic [kronos_pkg::XLEN-1:0]       amo_cur_beat;
+  logic [kronos_pkg::XLEN-1:0]       amo_result;
+  logic [kronos_pkg::XLEN_BYTES-1:0] amo_be;
+  logic [kronos_pkg::XLEN-1:0]       amo_aligned;
 
   // hit_way_idx: binary encoding of hit way for AMO/SC use
   logic [$clog2(NUM_WAYS)-1:0] hit_way_idx;
 
-  // hit_beat: full XLEN-wide beat from the hit way (consumed by the AMO RMW
+  // hit_beat: full kronos_pkg::XLEN-wide beat from the hit way (consumed by the AMO RMW
   // capture inside the always_ff block below). Declared here so synthesis
   // sees it before its first use (Synth 8-6901).
-  logic [XLEN-1:0] hit_beat;
+  logic [kronos_pkg::XLEN-1:0] hit_beat;
 
   // Pre-computed strobes/aligned-data for store-hit and SC-success write
   // paths.  Promoted from `automatic` block-locals (R2) so the FSM can
   // index them directly inside the per-way write loops.
-  logic [XLEN_BYTES-1:0] st_strobes;
-  logic [XLEN-1:0]       st_aligned;
-  logic [XLEN_BYTES-1:0] sc_strobes;
-  logic [XLEN-1:0]       sc_aligned;
+  logic [kronos_pkg::XLEN_BYTES-1:0] st_strobes;
+  logic [kronos_pkg::XLEN-1:0]       st_aligned;
+  logic [kronos_pkg::XLEN_BYTES-1:0] sc_strobes;
+  logic [kronos_pkg::XLEN-1:0]       sc_aligned;
 
   // Hit data path: select between cache hit and refill bypass
-  logic [XLEN-1:0] beat_for_load;
+  logic [kronos_pkg::XLEN-1:0] beat_for_load;
 
   // Inputs to load_data_full: prefer the in-flight NC request when active.
   logic [2:0] eff_size_for_load;
   logic [2:0] eff_off_for_load;
 
   // Size/sign extension on loads
-  logic [XLEN-1:0] load_data_full;
+  logic [kronos_pkg::XLEN-1:0] load_data_full;
 
   // Aggregate response signal (before LSU/PTW demux)
   logic            rsp_valid_int;
-  logic [XLEN-1:0] rsp_rdata_int;
+  logic [kronos_pkg::XLEN-1:0] rsp_rdata_int;
   logic            sc_success_int;
 
   // route the response to either LSU or PTW
@@ -249,7 +249,7 @@ module kronos_dcache
   // ==========================================================================
   // Functions (kept in-module so they can use parameters)
   // ==========================================================================
-  function automatic logic [XLEN_BYTES-1:0] store_strobes(input logic [2:0] sz, input logic [2:0] off);
+  function automatic logic [kronos_pkg::XLEN_BYTES-1:0] store_strobes(input logic [2:0] sz, input logic [2:0] off);
     case (sz)
       3'd0: return 8'b00000001 << off;
       3'd1: return 8'b00000011 << {off[2:1], 1'b0};
@@ -259,12 +259,12 @@ module kronos_dcache
     endcase
   endfunction
 
-  function automatic logic [XLEN-1:0] store_data_aligned(
+  function automatic logic [kronos_pkg::XLEN-1:0] store_data_aligned(
     input logic [2:0]      sz,
     input logic [2:0]      off,
-    input logic [XLEN-1:0] data
+    input logic [kronos_pkg::XLEN-1:0] data
   );
-    logic [XLEN-1:0] r;
+    logic [kronos_pkg::XLEN-1:0] r;
     case (sz)
       3'd0: r = {8{data[7:0]}};
       3'd1: r = {4{data[15:0]}};
@@ -276,15 +276,15 @@ module kronos_dcache
 
   // funct5 → AMO operation (RISC-V A-extension).  is_word=1 for AMO.W
   // (treat as 32-bit signed/unsigned, sign-extend the result).
-  function automatic logic [XLEN-1:0] amo_compute(
+  function automatic logic [kronos_pkg::XLEN-1:0] amo_compute(
     input logic [4:0]      funct5,
-    input logic [XLEN-1:0] old_val,
-    input logic [XLEN-1:0] src_val,
+    input logic [kronos_pkg::XLEN-1:0] old_val,
+    input logic [kronos_pkg::XLEN-1:0] src_val,
     input logic            is_word
   );
-    logic [XLEN-1:0] a;
-    logic [XLEN-1:0] b;
-    logic [XLEN-1:0] r;
+    logic [kronos_pkg::XLEN-1:0] a;
+    logic [kronos_pkg::XLEN-1:0] b;
+    logic [kronos_pkg::XLEN-1:0] r;
     a = is_word ? {{32{old_val[31]}}, old_val[31:0]} : old_val;
     b = is_word ? {{32{src_val[31]}}, src_val[31:0]} : src_val;
     unique case (funct5)
@@ -334,7 +334,7 @@ module kronos_dcache
     eff_req_valid = 1'b0;
     eff_req_addr  = {PHYS_ADDR_W{1'b0}};
     eff_req_we    = 1'b0;
-    eff_req_wdata = {XLEN{1'b0}};
+    eff_req_wdata = {kronos_pkg::XLEN{1'b0}};
     eff_req_is_lr = 1'b0;
     eff_req_is_sc = 1'b0;
     eff_req_size  = 3'd0;
@@ -442,7 +442,7 @@ module kronos_dcache
   // hit_beat: full 64-bit beat from the hit way (consumed by the AMO RMW
   // capture inside the always_ff block below).
   always_comb begin
-    hit_beat = {XLEN{1'b0}};
+    hit_beat = {kronos_pkg::XLEN{1'b0}};
     for (int w = 0; w < NUM_WAYS; w++) begin
       if (hit_way_oh[w]) hit_beat = data_q[w][set_idx][beat_idx];
     end
@@ -471,18 +471,18 @@ module kronos_dcache
       victim_q       <= {$clog2(NUM_WAYS){1'b0}};
       beat_cnt_q     <= 4'd0;
       bypass_valid_q       <= 1'b0;
-      bypass_data_q        <= {XLEN{1'b0}};
+      bypass_data_q        <= {kronos_pkg::XLEN{1'b0}};
       miss_was_store_q     <= 1'b0;
-      miss_store_data_q    <= {XLEN{1'b0}};
-      miss_store_strobes_q <= {XLEN_BYTES{1'b0}};
+      miss_store_data_q    <= {kronos_pkg::XLEN{1'b0}};
+      miss_store_strobes_q <= {kronos_pkg::XLEN_BYTES{1'b0}};
       miss_store_off_q     <= 3'b0;
       store_done_q         <= 1'b0;
       wb_beat_cnt_q        <= 4'd0;
       evict_tag_q          <= {TAG_W{1'b0}};
       amo_pending_q        <= 1'b0;
       amo_op_q             <= 5'b0;
-      amo_src_q            <= {XLEN{1'b0}};
-      amo_old_val_q        <= {XLEN{1'b0}};
+      amo_src_q            <= {kronos_pkg::XLEN{1'b0}};
+      amo_old_val_q        <= {kronos_pkg::XLEN{1'b0}};
       amo_done_q           <= 1'b0;
       amo_is_word_q        <= 1'b0;
       amo_addr_off_q       <= 3'b0;
@@ -496,10 +496,10 @@ module kronos_dcache
       nc_addr_q            <= {PHYS_ADDR_W{1'b0}};
       nc_size_q            <= 3'b0;
       nc_we_q              <= 1'b0;
-      nc_wdata_q           <= {XLEN{1'b0}};
+      nc_wdata_q           <= {kronos_pkg::XLEN{1'b0}};
       nc_is_ptw_q          <= 1'b0;
       nc_rsp_valid_q       <= 1'b0;
-      nc_rsp_data_q        <= {XLEN{1'b0}};
+      nc_rsp_data_q        <= {kronos_pkg::XLEN{1'b0}};
       nc_rsp_err_q         <= 1'b0;
       nc_b_done_q          <= 1'b0;
       nc_b_err_q           <= 1'b0;
@@ -518,7 +518,7 @@ module kronos_dcache
       for (int w = 0; w < NUM_WAYS; w++) begin
         for (int s = 0; s < NUM_SETS; s++) begin
           for (int b = 0; b < BEATS; b++) begin
-            data_q[w][s][b] <= {XLEN{1'b0}};
+            data_q[w][s][b] <= {kronos_pkg::XLEN{1'b0}};
           end
         end
       end
@@ -947,7 +947,7 @@ module kronos_dcache
     axi_req_o.aw_valid = (state_q == DC_WB_AW) | (state_q == DC_FLUSH_AW);
 
     axi_req_o.w.data   = data_q[victim_q][miss_set_q][wb_beat_cnt_q[BEAT_IDX_W-1:0]];
-    axi_req_o.w.strb   = {XLEN_BYTES{1'b1}};
+    axi_req_o.w.strb   = {kronos_pkg::XLEN_BYTES{1'b1}};
     axi_req_o.w.last   = (wb_beat_cnt_q == 4'd7);
     axi_req_o.w_valid  = (state_q == DC_WB_W) | (state_q == DC_FLUSH_W);
 
@@ -983,7 +983,7 @@ module kronos_dcache
     amo_result   = amo_compute(amo_op_q, amo_old_val_q, amo_src_q, amo_is_word_q);
     amo_be       = amo_is_word_q
                      ? store_strobes(3'd2, amo_addr_off_q)
-                     : {XLEN_BYTES{1'b1}};
+                     : {kronos_pkg::XLEN_BYTES{1'b1}};
     amo_aligned  = amo_is_word_q
                      ? store_data_aligned(3'd2, amo_addr_off_q, amo_result)
                      : amo_result;

--- a/rtl/stage6/kronos_decode.sv
+++ b/rtl/stage6/kronos_decode.sv
@@ -15,7 +15,7 @@
 module kronos_decode
   import kronos_pkg::*;
 (
-  input  logic [INST_W-1:0] instr_i,
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
   input  logic [2:0]        frm_i,        // current FRM from FCSR (for dynamic rm)
   output decoded_instr_t    decoded_o,
   output logic              illegal_insn_o
@@ -68,7 +68,7 @@ module kronos_decode
   assign funct7 = instr_i[31:25];
 
   always_comb begin
-    decoded_o          = DECODED_INSTR_ZERO;
+    decoded_o          = kronos_pkg::DECODED_INSTR_ZERO;
     decoded_o.rs1      = rs1;
     decoded_o.rs2      = rs2;
     decoded_o.rd       = rd;

--- a/rtl/stage6/kronos_decompress.sv
+++ b/rtl/stage6/kronos_decompress.sv
@@ -9,7 +9,7 @@ module kronos_decompress
   import kronos_pkg::*;
 (
   input  logic [15:0]        instr16_i,
-  output logic [INST_W-1:0]  instr32_o,
+  output logic [kronos_pkg::INST_W-1:0]  instr32_o,
   output logic               illegal_o
 );
   // ---------------------------------------------------------------
@@ -42,9 +42,9 @@ module kronos_decompress
 
   // Temporary signals for immediate assembly (shared across case arms — only one active at a time)
   logic [11:0]        uimm;
-  logic [INST_W-1:0]  nzimm;
-  logic [INST_W-1:0]  imm;
-  logic [INST_W-1:0]  off;
+  logic [kronos_pkg::INST_W-1:0]  nzimm;
+  logic [kronos_pkg::INST_W-1:0]  imm;
+  logic [kronos_pkg::INST_W-1:0]  off;
   logic [5:0]         shamt;
 
   // ---------------------------------------------------------------
@@ -67,12 +67,12 @@ module kronos_decompress
   // ---------------------------------------------------------------
   always_comb begin
     // Defaults
-    instr32_o = {INST_W{1'b0}};
+    instr32_o = {kronos_pkg::INST_W{1'b0}};
     illegal_o = 1'b0;
     uimm      = 12'd0;
-    nzimm     = {INST_W{1'b0}};
-    imm       = {INST_W{1'b0}};
-    off       = {INST_W{1'b0}};
+    nzimm     = {kronos_pkg::INST_W{1'b0}};
+    imm       = {kronos_pkg::INST_W{1'b0}};
+    off       = {kronos_pkg::INST_W{1'b0}};
     shamt     = 6'd0;
 
     unique case (instr16_i[1:0])
@@ -153,11 +153,11 @@ module kronos_decompress
             if (rd == REG_X2) begin  // C.ADDI16SP → ADDI x2, x2, nzimm
               nzimm = {{23{instr16_i[12]}}, instr16_i[4:3], instr16_i[5],
                        instr16_i[2], instr16_i[6], 4'b0};
-              if (nzimm == {INST_W{1'b0}}) illegal_o = 1'b1;
+              if (nzimm == {kronos_pkg::INST_W{1'b0}}) illegal_o = 1'b1;
               else instr32_o = {nzimm[11:0], REG_X2, 3'b000, REG_X2, OP_IMM};
             end else begin  // C.LUI → LUI rd, nzimm
               nzimm = {{15{instr16_i[12]}}, instr16_i[6:2], 12'b0};
-              if (nzimm == {INST_W{1'b0}}) illegal_o = 1'b1;
+              if (nzimm == {kronos_pkg::INST_W{1'b0}}) illegal_o = 1'b1;
               else instr32_o = {nzimm[31:12], rd, OP_LUI};
             end
           end

--- a/rtl/stage6/kronos_icache.sv
+++ b/rtl/stage6/kronos_icache.sv
@@ -26,7 +26,7 @@ module kronos_icache
   input  logic                   pmp_fault_i,
   input  logic                   tlb_miss_i,
   output logic                   data_valid_o,
-  output logic [INST_W-1:0]      data_o,
+  output logic [kronos_pkg::INST_W-1:0]      data_o,
   output logic                   stall_o,
 
   // Downstream AXI4 read master
@@ -41,10 +41,10 @@ module kronos_icache
   localparam int unsigned NUM_SETS    = CACHE_BYTES / (NUM_WAYS * LINE_BYTES);
   localparam int unsigned SET_IDX_W   = $clog2(NUM_SETS);
   localparam int unsigned OFFSET_W    = $clog2(LINE_BYTES);
-  localparam int unsigned WORD_IDX_W  = OFFSET_W - $clog2(INST_W/8); // 32-bit words/line
+  localparam int unsigned WORD_IDX_W  = OFFSET_W - $clog2(kronos_pkg::INST_W/8); // 32-bit words/line
   localparam int unsigned TAG_W       = PHYS_ADDR_W - SET_IDX_W - OFFSET_W;
-  localparam int unsigned WORDS       = LINE_BYTES / (INST_W/8);     // INST_W words/line = 16
-  localparam int unsigned BEATS       = LINE_BYTES / XLEN_BYTES;     // XLEN-beats/line = 8
+  localparam int unsigned WORDS       = LINE_BYTES / (kronos_pkg::INST_W/8);     // kronos_pkg::INST_W words/line = 16
+  localparam int unsigned BEATS       = LINE_BYTES / kronos_pkg::XLEN_BYTES;     // kronos_pkg::XLEN-beats/line = 8
   localparam int unsigned BEAT_CNT_W  = $clog2(BEATS);               // 3 bits
 
   // ---- Types ----------------------------------------------------------------
@@ -55,7 +55,7 @@ module kronos_icache
   } icache_state_e;
 
   // ---- State registers ------------------------------------------------------
-  logic [INST_W-1:0]           data_q  [NUM_WAYS][NUM_SETS][WORDS];
+  logic [kronos_pkg::INST_W-1:0]           data_q  [NUM_WAYS][NUM_SETS][WORDS];
   logic [TAG_W-1:0]            tag_q   [NUM_SETS][NUM_WAYS];
   logic                        valid_q [NUM_SETS][NUM_WAYS];
   logic [2:0]                  plru_q  [NUM_SETS];
@@ -68,7 +68,7 @@ module kronos_icache
   logic [BEAT_CNT_W-1:0]       beat_cnt_q;    // 3 bits: 0..7
   logic                        miss_addr2_q;  // addr[2] within the critical 64-bit beat
   logic                        bypass_valid_q;
-  logic [INST_W-1:0]           bypass_data_q;
+  logic [kronos_pkg::INST_W-1:0]           bypass_data_q;
 
   // ---- Combinational signals ------------------------------------------------
   logic [SET_IDX_W-1:0]        set_idx;
@@ -80,13 +80,13 @@ module kronos_icache
   logic [$clog2(NUM_WAYS)-1:0] victim_pick;
   logic [WORD_IDX_W-1:0]       beat_base_word;
   logic [BEAT_CNT_W-1:0]       beat_idx;
-  logic [INST_W-1:0]           hit_word;
+  logic [kronos_pkg::INST_W-1:0]           hit_word;
   logic                        _unused;
 
   // ---- Address breakdown ----------------------------------------------------
   assign set_idx  = addr_i[SET_IDX_W + OFFSET_W - 1 : OFFSET_W];
   assign tag_in   = addr_i[PHYS_ADDR_W-1 : SET_IDX_W + OFFSET_W];
-  assign word_idx = addr_i[OFFSET_W-1 : $clog2(INST_W/8)];
+  assign word_idx = addr_i[OFFSET_W-1 : $clog2(kronos_pkg::INST_W/8)];
 
   // ---- Hit logic ------------------------------------------------------------
   always_comb begin
@@ -151,7 +151,7 @@ module kronos_icache
       beat_cnt_q     <= {BEAT_CNT_W{1'b0}};
       miss_addr2_q   <= 1'b0;
       bypass_valid_q <= 1'b0;
-      bypass_data_q  <= {INST_W{1'b0}};
+      bypass_data_q  <= {kronos_pkg::INST_W{1'b0}};
       for (int s = 0; s < NUM_SETS; s++) begin
         plru_q[s] <= 3'b0;
         for (int w = 0; w < NUM_WAYS; w++) begin
@@ -163,7 +163,7 @@ module kronos_icache
       for (int w = 0; w < NUM_WAYS; w++) begin
         for (int s = 0; s < NUM_SETS; s++) begin
           for (int wd = 0; wd < WORDS; wd++) begin
-            data_q[w][s][wd] <= {INST_W{1'b0}};
+            data_q[w][s][wd] <= {kronos_pkg::INST_W{1'b0}};
           end
         end
       end
@@ -199,14 +199,14 @@ module kronos_icache
             // miss_beat = miss_word_q[WORD_IDX_W-1:1] (upper bits, beat-aligned).
             // Each beat covers two 32-bit words: indices beat*2 and beat*2+1.
             // The WRAP offset is a beat index; we compute the 32-bit word addresses.
-            data_q[victim_q][miss_set_q][beat_base_word]     <= axi_rsp_i.r.data[INST_W-1:0];
-            data_q[victim_q][miss_set_q][beat_base_word + 1] <= axi_rsp_i.r.data[XLEN-1:INST_W];
+            data_q[victim_q][miss_set_q][beat_base_word]     <= axi_rsp_i.r.data[kronos_pkg::INST_W-1:0];
+            data_q[victim_q][miss_set_q][beat_base_word + 1] <= axi_rsp_i.r.data[kronos_pkg::XLEN-1:INST_W];
             beat_cnt_q <= beat_cnt_q + 1'b1;
             // CWF bypass: expose the correct 32-bit half of the first beat.
             if (beat_cnt_q == {BEAT_CNT_W{1'b0}}) begin
               bypass_valid_q <= 1'b1;
-              bypass_data_q  <= miss_addr2_q ? axi_rsp_i.r.data[XLEN-1:INST_W]
-                                             : axi_rsp_i.r.data[INST_W-1:0];
+              bypass_data_q  <= miss_addr2_q ? axi_rsp_i.r.data[kronos_pkg::XLEN-1:INST_W]
+                                             : axi_rsp_i.r.data[kronos_pkg::INST_W-1:0];
             end
             if (axi_rsp_i.r.last) begin
               tag_q[miss_set_q][victim_q]   <= miss_tag_q;
@@ -247,7 +247,7 @@ module kronos_icache
 
   // ---- Hit data path (way-select mux on data_q) ------------------------------
   always_comb begin
-    hit_word = {INST_W{1'b0}};
+    hit_word = {kronos_pkg::INST_W{1'b0}};
     for (int w = 0; w < NUM_WAYS; w++) begin
       if (hit_way_oh[w]) hit_word = data_q[w][set_idx][word_idx];
     end

--- a/rtl/stage6/kronos_lsu.sv
+++ b/rtl/stage6/kronos_lsu.sv
@@ -33,24 +33,24 @@ module kronos_lsu
   input  logic             req_i,
   input  logic             we_i,
   input  logic [31:0]      addr_i,
-  input  logic [XLEN-1:0]  wdata_i,
+  input  logic [kronos_pkg::XLEN-1:0]  wdata_i,
   input  logic [2:0]       funct3_i,
-  output logic [XLEN-1:0]  rdata_o,
+  output logic [kronos_pkg::XLEN-1:0]  rdata_o,
   output logic             valid_o,
   output logic             mem_stall_o,
 
   // FP load/store extensions (Stage 5)
   input  logic             fp_dest_req_i,    // this is a FP load/store
-  input  logic [FLEN-1:0]  fp_store_data_i,  // FP register data for FSW/FSD
+  input  logic [kronos_pkg::FLEN-1:0]  fp_store_data_i,  // FP register data for FSW/FSD
   output logic             fp_dest_rsp_o,    // load response targets FP regfile
-  output logic [FLEN-1:0]  fp_rdata_o,       // NaN-boxed FP load data
+  output logic [kronos_pkg::FLEN-1:0]  fp_rdata_o,       // NaN-boxed FP load data
 
   // A-extension
   input  logic             is_lr_i,
   input  logic             is_sc_i,
   input  logic             is_amo_i,
   input  logic [4:0]       amo_funct5_i,
-  input  logic [XLEN-1:0]  amo_src_i,
+  input  logic [kronos_pkg::XLEN-1:0]  amo_src_i,
   output logic             sc_success_o,
 
   // PMP fault input (asserted by u_pmp_data in kronos_top on a permission
@@ -74,14 +74,14 @@ module kronos_lsu
 
   // D-cache interface (replaces direct AXI master)
   output logic             dcache_req_o,
-  output logic [XLEN-1:0]  dcache_addr_o,
+  output logic [kronos_pkg::XLEN-1:0]  dcache_addr_o,
   output logic [2:0]       dcache_size_o,
   output logic             dcache_we_o,
-  output logic [XLEN-1:0]  dcache_wdata_o,
+  output logic [kronos_pkg::XLEN-1:0]  dcache_wdata_o,
   output logic             dcache_amo_req_o,
   output logic [4:0]       dcache_amo_op_o,
   input  logic             dcache_data_valid_i,
-  input  logic [XLEN-1:0]  dcache_rdata_i,
+  input  logic [kronos_pkg::XLEN-1:0]  dcache_rdata_i,
   input  logic             dcache_sc_success_i,
   input  logic             dcache_stall_i
 );
@@ -145,7 +145,7 @@ module kronos_lsu
   // request) so no cache lookup happens until the page-table walker has
   // refilled the dTLB and produced a translated PA.
   assign dcache_req_o     = req_i & ~pmp_fault_i & ~tlb_miss_i;
-  assign dcache_addr_o    = {{(XLEN-32){1'b0}}, addr_i};
+  assign dcache_addr_o    = {{(kronos_pkg::XLEN-32){1'b0}}, addr_i};
   assign dcache_we_o      = we_i;
   assign dcache_wdata_o   = fp_dest_req_i ? fp_store_data_i : wdata_i;
   assign dcache_amo_req_o = (is_lr_i | is_sc_i | is_amo_i) & ~pmp_fault_i & ~tlb_miss_i;
@@ -164,16 +164,16 @@ module kronos_lsu
     rdata_o = dcache_rdata_i;
     if (is_sc_i) begin
       // SC result: 0 = success, 1 = failure
-      rdata_o = {{(XLEN-1){1'b0}}, ~dcache_sc_success_i};
+      rdata_o = {{(kronos_pkg::XLEN-1){1'b0}}, ~dcache_sc_success_i};
     end else begin
       unique case (funct3_i)
-        3'b000: rdata_o = {{(XLEN-8){dcache_rdata_i[7]}},   dcache_rdata_i[7:0]};   // LB
-        3'b001: rdata_o = {{(XLEN-16){dcache_rdata_i[15]}}, dcache_rdata_i[15:0]};  // LH
-        3'b010: rdata_o = {{(XLEN-32){dcache_rdata_i[31]}}, dcache_rdata_i[31:0]};  // LW
+        3'b000: rdata_o = {{(kronos_pkg::XLEN-8){dcache_rdata_i[7]}},   dcache_rdata_i[7:0]};   // LB
+        3'b001: rdata_o = {{(kronos_pkg::XLEN-16){dcache_rdata_i[15]}}, dcache_rdata_i[15:0]};  // LH
+        3'b010: rdata_o = {{(kronos_pkg::XLEN-32){dcache_rdata_i[31]}}, dcache_rdata_i[31:0]};  // LW
         3'b011: rdata_o = dcache_rdata_i;                                           // LD
-        3'b100: rdata_o = {{(XLEN-8){1'b0}},   dcache_rdata_i[7:0]};                // LBU
-        3'b101: rdata_o = {{(XLEN-16){1'b0}},  dcache_rdata_i[15:0]};               // LHU
-        3'b110: rdata_o = {{(XLEN-32){1'b0}},  dcache_rdata_i[31:0]};               // LWU
+        3'b100: rdata_o = {{(kronos_pkg::XLEN-8){1'b0}},   dcache_rdata_i[7:0]};                // LBU
+        3'b101: rdata_o = {{(kronos_pkg::XLEN-16){1'b0}},  dcache_rdata_i[15:0]};               // LHU
+        3'b110: rdata_o = {{(kronos_pkg::XLEN-32){1'b0}},  dcache_rdata_i[31:0]};               // LWU
         default: rdata_o = dcache_rdata_i;
       endcase
     end
@@ -187,11 +187,11 @@ module kronos_lsu
   // pipeline routes the result to the FP register file.
   // -------------------------------------------------------------------------
   always_comb begin
-    fp_rdata_o = {FLEN{1'b0}};
+    fp_rdata_o = {kronos_pkg::FLEN{1'b0}};
     unique case (funct3_i)
-      3'b010: fp_rdata_o = {FP_NANBOX_UPPER, dcache_rdata_i[FP_S_TOTAL_W-1:0]};  // FLW: NaN-box
+      3'b010: fp_rdata_o = {kronos_pkg::FP_NANBOX_UPPER, dcache_rdata_i[kronos_pkg::FP_S_TOTAL_W-1:0]};  // FLW: NaN-box
       3'b011: fp_rdata_o = dcache_rdata_i;                                       // FLD: full 64-bit
-      default: fp_rdata_o = {FLEN{1'b0}};
+      default: fp_rdata_o = {kronos_pkg::FLEN{1'b0}};
     endcase
   end
 

--- a/rtl/stage6/kronos_muldiv.sv
+++ b/rtl/stage6/kronos_muldiv.sv
@@ -41,10 +41,10 @@ module kronos_muldiv
   input  logic            rst_ni,
   input  logic            req_i,
   input  muldiv_op_e      op_i,
-  input  logic [XLEN-1:0] a_i,
-  input  logic [XLEN-1:0] b_i,
+  input  logic [kronos_pkg::XLEN-1:0] a_i,
+  input  logic [kronos_pkg::XLEN-1:0] b_i,
   input  logic            word_op_i,
-  output logic [XLEN-1:0] result_o,
+  output logic [kronos_pkg::XLEN-1:0] result_o,
   output logic            busy_o,
   output logic            valid_o,
   output logic            idle_o
@@ -53,9 +53,9 @@ module kronos_muldiv
   // -------------------------------------------------------------------------
   // 1. Constants
   // -------------------------------------------------------------------------
-  localparam logic [XLEN-1:0] ALL_ONES_64 = 64'hFFFF_FFFF_FFFF_FFFF;
-  localparam logic [XLEN-1:0] INT_MIN_64  = 64'h8000_0000_0000_0000;
-  localparam logic [XLEN-1:0] INT_MIN_32  = 64'hFFFF_FFFF_8000_0000;
+  localparam logic [kronos_pkg::XLEN-1:0] ALL_ONES_64 = 64'hFFFF_FFFF_FFFF_FFFF;
+  localparam logic [kronos_pkg::XLEN-1:0] INT_MIN_64  = 64'h8000_0000_0000_0000;
+  localparam logic [kronos_pkg::XLEN-1:0] INT_MIN_32  = 64'hFFFF_FFFF_8000_0000;
 
   // -------------------------------------------------------------------------
   // 2. Types
@@ -73,23 +73,23 @@ module kronos_muldiv
   // 3. State registers
   // -------------------------------------------------------------------------
   muldiv_state_e         state_q;
-  logic [XLEN-1:0]       result_q;
+  logic [kronos_pkg::XLEN-1:0]       result_q;
   // Multiplier pipeline registers.
   // Partial-product width: 65 (signed a) × 33 (signed b-half) = 98 bits signed.
   // The 65×65 signed multiply is decomposed into pp_hi = a × b[64:32]_signed
   // and pp_lo = a × {1'b0, b[31:0]} (the low half treated as positive), then
   // summed as (pp_hi << 32) + pp_lo in MUL_MID.
-  logic [XLEN:0]         mul_a65_q;
-  logic [XLEN:0]         mul_b65_q;
+  logic [kronos_pkg::XLEN:0]         mul_a65_q;
+  logic [kronos_pkg::XLEN:0]         mul_b65_q;
   logic signed [97:0]    pp_lo_q;
   logic signed [97:0]    pp_hi_q;
   logic signed [129:0]   mul_product_q;
   muldiv_op_e            op_q;
   // Divider registers (restoring division)
-  logic [XLEN-1:0]       dividend_q;   // left-shifted each step; MSB feeds remainder
-  logic [XLEN:0]         remainder_q;  // 65-bit partial remainder (extra bit for borrow)
-  logic [XLEN-1:0]       quotient_q;
-  logic [XLEN-1:0]       abs_b_q;
+  logic [kronos_pkg::XLEN-1:0]       dividend_q;   // left-shifted each step; MSB feeds remainder
+  logic [kronos_pkg::XLEN:0]         remainder_q;  // 65-bit partial remainder (extra bit for borrow)
+  logic [kronos_pkg::XLEN-1:0]       quotient_q;
+  logic [kronos_pkg::XLEN-1:0]       abs_b_q;
   logic [6:0]            count_q;      // counts down from 64 (or 32 for word_op)
   logic                  div_neg_q;    // negate quotient at end (signed DIV)
   logic                  rem_neg_q;    // negate remainder at end (signed REM)
@@ -102,44 +102,44 @@ module kronos_muldiv
   // Multiplier sign-extend / word-op shaping
   logic              mul_signed_a;
   logic              mul_signed_b;
-  logic [INST_W-1:0] mul_a_low;
-  logic [INST_W-1:0] mul_b_low;
+  logic [kronos_pkg::INST_W-1:0] mul_a_low;
+  logic [kronos_pkg::INST_W-1:0] mul_b_low;
   logic              mul_a_sign_bit;
   logic              mul_b_sign_bit;
-  logic [XLEN-1:0]   mul_a_eff;
-  logic [XLEN-1:0]   mul_b_eff;
-  logic [XLEN:0]     mul_a65;
-  logic [XLEN:0]     mul_b65;
+  logic [kronos_pkg::XLEN-1:0]   mul_a_eff;
+  logic [kronos_pkg::XLEN-1:0]   mul_b_eff;
+  logic [kronos_pkg::XLEN:0]     mul_a65;
+  logic [kronos_pkg::XLEN:0]     mul_b65;
 
   // MUL_OUT half-select
-  logic [XLEN-1:0]   mul_sel;
+  logic [kronos_pkg::XLEN-1:0]   mul_sel;
 
   // IDLE → division setup combinational signals
   logic              is_signed_div;
   logic              a_sign_bit;
   logic              b_sign_bit;
-  logic [XLEN-1:0]   a_eff;
-  logic [XLEN-1:0]   b_eff;
+  logic [kronos_pkg::XLEN-1:0]   a_eff;
+  logic [kronos_pkg::XLEN-1:0]   b_eff;
   logic              neg_a;
   logic              neg_b;
-  logic [XLEN-1:0]   abs_a;
-  logic [XLEN-1:0]   abs_b;
+  logic [kronos_pkg::XLEN-1:0]   abs_a;
+  logic [kronos_pkg::XLEN-1:0]   abs_b;
   logic              b_is_zero;
   logic              ov_div;
   logic              ov_rem;
-  logic [XLEN-1:0]   int_min;
+  logic [kronos_pkg::XLEN-1:0]   int_min;
 
   // Restoring-division step
-  logic [XLEN:0]     rem_shifted;
-  logic [XLEN:0]     rem_sub;
-  logic [XLEN-1:0]   div_shifted;
+  logic [kronos_pkg::XLEN:0]     rem_shifted;
+  logic [kronos_pkg::XLEN:0]     rem_sub;
+  logic [kronos_pkg::XLEN-1:0]   div_shifted;
 
   // Final-step divider result composition
-  logic [XLEN-1:0]   final_quot;
-  logic [XLEN-1:0]   final_rem;
-  logic [XLEN-1:0]   signed_quot;
-  logic [XLEN-1:0]   signed_rem;
-  logic [XLEN-1:0]   pre_result;
+  logic [kronos_pkg::XLEN-1:0]   final_quot;
+  logic [kronos_pkg::XLEN-1:0]   final_rem;
+  logic [kronos_pkg::XLEN-1:0]   signed_quot;
+  logic [kronos_pkg::XLEN-1:0]   signed_rem;
+  logic [kronos_pkg::XLEN-1:0]   pre_result;
 
   // -------------------------------------------------------------------------
   // Multiplier operand shaping
@@ -150,30 +150,30 @@ module kronos_muldiv
   assign mul_signed_b = (op_i == MULDIV_MUL) | (op_i == MULDIV_MULH);
 
   // For word_op, the effective operands are the low 32 bits, extended to 64.
-  assign mul_a_low = a_i[INST_W-1:0];
-  assign mul_b_low = b_i[INST_W-1:0];
-  assign mul_a_sign_bit = mul_signed_a ? mul_a_low[INST_W-1] : 1'b0;
-  assign mul_b_sign_bit = mul_signed_b ? mul_b_low[INST_W-1] : 1'b0;
+  assign mul_a_low = a_i[kronos_pkg::INST_W-1:0];
+  assign mul_b_low = b_i[kronos_pkg::INST_W-1:0];
+  assign mul_a_sign_bit = mul_signed_a ? mul_a_low[kronos_pkg::INST_W-1] : 1'b0;
+  assign mul_b_sign_bit = mul_signed_b ? mul_b_low[kronos_pkg::INST_W-1] : 1'b0;
 
-  assign mul_a_eff = word_op_i ? {{INST_W{mul_a_sign_bit}}, mul_a_low} : a_i;
-  assign mul_b_eff = word_op_i ? {{INST_W{mul_b_sign_bit}}, mul_b_low} : b_i;
+  assign mul_a_eff = word_op_i ? {{kronos_pkg::INST_W{mul_a_sign_bit}}, mul_a_low} : a_i;
+  assign mul_b_eff = word_op_i ? {{kronos_pkg::INST_W{mul_b_sign_bit}}, mul_b_low} : b_i;
 
   // Extend to 65 bits for signed/unsigned product.
-  assign mul_a65 = mul_signed_a ? {mul_a_eff[XLEN-1], mul_a_eff} : {1'b0, mul_a_eff};
-  assign mul_b65 = mul_signed_b ? {mul_b_eff[XLEN-1], mul_b_eff} : {1'b0, mul_b_eff};
+  assign mul_a65 = mul_signed_a ? {mul_a_eff[kronos_pkg::XLEN-1], mul_a_eff} : {1'b0, mul_a_eff};
+  assign mul_b65 = mul_signed_b ? {mul_b_eff[kronos_pkg::XLEN-1], mul_b_eff} : {1'b0, mul_b_eff};
 
   // -------------------------------------------------------------------------
   // MUL_OUT half-select
   // -------------------------------------------------------------------------
   always_comb begin
-    mul_sel = mul_product_q[XLEN-1:0];
+    mul_sel = mul_product_q[kronos_pkg::XLEN-1:0];
     unique case (op_q)
-      MULDIV_MUL:    mul_sel = mul_product_q[XLEN-1:0];
-      MULDIV_MULH:   mul_sel = mul_product_q[2*XLEN-1:XLEN];
-      MULDIV_MULHSU: mul_sel = mul_product_q[2*XLEN-1:XLEN];
-      MULDIV_MULHU:  mul_sel = mul_product_q[2*XLEN-1:XLEN];
+      MULDIV_MUL:    mul_sel = mul_product_q[kronos_pkg::XLEN-1:0];
+      MULDIV_MULH:   mul_sel = mul_product_q[2*kronos_pkg::XLEN-1:XLEN];
+      MULDIV_MULHSU: mul_sel = mul_product_q[2*kronos_pkg::XLEN-1:XLEN];
+      MULDIV_MULHU:  mul_sel = mul_product_q[2*kronos_pkg::XLEN-1:XLEN];
       // verilator coverage_off
-      default:       mul_sel = mul_product_q[XLEN-1:0];
+      default:       mul_sel = mul_product_q[kronos_pkg::XLEN-1:0];
       // verilator coverage_on
     endcase
   end
@@ -184,17 +184,17 @@ module kronos_muldiv
   assign is_signed_div = (op_i == MULDIV_DIV) | (op_i == MULDIV_REM);
 
   // Effective operands: low 32 bits sign-extended when word_op.
-  assign a_sign_bit = is_signed_div ? a_i[INST_W-1] : 1'b0;
-  assign b_sign_bit = is_signed_div ? b_i[INST_W-1] : 1'b0;
-  assign a_eff      = word_op_i ? {{INST_W{a_sign_bit}}, a_i[INST_W-1:0]} : a_i;
-  assign b_eff      = word_op_i ? {{INST_W{b_sign_bit}}, b_i[INST_W-1:0]} : b_i;
+  assign a_sign_bit = is_signed_div ? a_i[kronos_pkg::INST_W-1] : 1'b0;
+  assign b_sign_bit = is_signed_div ? b_i[kronos_pkg::INST_W-1] : 1'b0;
+  assign a_eff      = word_op_i ? {{kronos_pkg::INST_W{a_sign_bit}}, a_i[kronos_pkg::INST_W-1:0]} : a_i;
+  assign b_eff      = word_op_i ? {{kronos_pkg::INST_W{b_sign_bit}}, b_i[kronos_pkg::INST_W-1:0]} : b_i;
 
-  assign neg_a = is_signed_div & a_eff[XLEN-1];
-  assign neg_b = is_signed_div & b_eff[XLEN-1];
-  assign abs_a = neg_a ? (~a_eff + XLEN'(1)) : a_eff;
-  assign abs_b = neg_b ? (~b_eff + XLEN'(1)) : b_eff;
+  assign neg_a = is_signed_div & a_eff[kronos_pkg::XLEN-1];
+  assign neg_b = is_signed_div & b_eff[kronos_pkg::XLEN-1];
+  assign abs_a = neg_a ? (~a_eff + kronos_pkg::XLEN'(1)) : a_eff;
+  assign abs_b = neg_b ? (~b_eff + kronos_pkg::XLEN'(1)) : b_eff;
 
-  assign b_is_zero = (b_eff == XLEN'(0));
+  assign b_is_zero = (b_eff == kronos_pkg::XLEN'(0));
 
   assign int_min = word_op_i ? INT_MIN_32 : INT_MIN_64;
   assign ov_div  = (op_i == MULDIV_DIV) & (a_eff == int_min) & (b_eff == ALL_ONES_64);
@@ -203,22 +203,22 @@ module kronos_muldiv
   // -------------------------------------------------------------------------
   // Restoring-division step
   // -------------------------------------------------------------------------
-  assign rem_shifted = {remainder_q[XLEN-1:0], dividend_q[XLEN-1]};
+  assign rem_shifted = {remainder_q[kronos_pkg::XLEN-1:0], dividend_q[kronos_pkg::XLEN-1]};
   assign rem_sub     = rem_shifted - {1'b0, abs_b_q};
-  assign div_shifted = {dividend_q[XLEN-2:0], 1'b0};
+  assign div_shifted = {dividend_q[kronos_pkg::XLEN-2:0], 1'b0};
 
   // -------------------------------------------------------------------------
   // Final-step divider result composition (used in COMPUTE last cycle)
   // -------------------------------------------------------------------------
   always_comb begin
-    final_quot  = {quotient_q[XLEN-2:0], 1'b0};
-    final_rem   = rem_shifted[XLEN-1:0];
-    if (!rem_sub[XLEN]) begin
-      final_quot = {quotient_q[XLEN-2:0], 1'b1};
-      final_rem  = rem_sub[XLEN-1:0];
+    final_quot  = {quotient_q[kronos_pkg::XLEN-2:0], 1'b0};
+    final_rem   = rem_shifted[kronos_pkg::XLEN-1:0];
+    if (!rem_sub[kronos_pkg::XLEN]) begin
+      final_quot = {quotient_q[kronos_pkg::XLEN-2:0], 1'b1};
+      final_rem  = rem_sub[kronos_pkg::XLEN-1:0];
     end
-    signed_quot = div_neg_q ? (~final_quot + XLEN'(1)) : final_quot;
-    signed_rem  = rem_neg_q ? (~final_rem  + XLEN'(1)) : final_rem;
+    signed_quot = div_neg_q ? (~final_quot + kronos_pkg::XLEN'(1)) : final_quot;
+    signed_rem  = rem_neg_q ? (~final_rem  + kronos_pkg::XLEN'(1)) : final_rem;
     pre_result  = is_rem_q  ? signed_rem : signed_quot;
   end
 
@@ -237,17 +237,17 @@ module kronos_muldiv
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       state_q       <= IDLE;
-      result_q      <= {XLEN{1'b0}};
-      mul_a65_q     <= {(XLEN+1){1'b0}};
-      mul_b65_q     <= {(XLEN+1){1'b0}};
+      result_q      <= {kronos_pkg::XLEN{1'b0}};
+      mul_a65_q     <= {(kronos_pkg::XLEN+1){1'b0}};
+      mul_b65_q     <= {(kronos_pkg::XLEN+1){1'b0}};
       pp_lo_q       <= 98'sd0;
       pp_hi_q       <= 98'sd0;
-      mul_product_q <= {(2*XLEN+2){1'b0}};
+      mul_product_q <= {(2*kronos_pkg::XLEN+2){1'b0}};
       op_q          <= MULDIV_MUL;
-      dividend_q    <= {XLEN{1'b0}};
-      remainder_q   <= {(XLEN+1){1'b0}};
-      quotient_q    <= {XLEN{1'b0}};
-      abs_b_q       <= {XLEN{1'b0}};
+      dividend_q    <= {kronos_pkg::XLEN{1'b0}};
+      remainder_q   <= {(kronos_pkg::XLEN+1){1'b0}};
+      quotient_q    <= {kronos_pkg::XLEN{1'b0}};
+      abs_b_q       <= {kronos_pkg::XLEN{1'b0}};
       count_q       <= 7'b0;
       div_neg_q     <= 1'b0;
       rem_neg_q     <= 1'b0;
@@ -279,7 +279,7 @@ module kronos_muldiv
                   // For word_op the all-ones is naturally sign-extended.
                   if ((op_i == MULDIV_REM) | (op_i == MULDIV_REMU)) begin
                     result_q <= word_op_i
-                                ? {{INST_W{a_i[INST_W-1]}}, a_i[INST_W-1:0]}
+                                ? {{kronos_pkg::INST_W{a_i[kronos_pkg::INST_W-1]}}, a_i[kronos_pkg::INST_W-1:0]}
                                 : a_i;
                   end else begin
                     result_q <= ALL_ONES_64;
@@ -291,20 +291,20 @@ module kronos_muldiv
                   state_q  <= DONE;
                 end else if (ov_rem) begin
                   // Signed overflow: INT_MIN % -1 = 0
-                  result_q <= XLEN'(0);
+                  result_q <= kronos_pkg::XLEN'(0);
                   state_q  <= DONE;
                 end else begin
                   // Normal case: iterative restoring division.
                   // For word_op, left-align the 32-bit dividend into the
                   // upper 32 bits so the MSB-first shift consumes real bits.
-                  dividend_q  <= word_op_i ? {abs_a[INST_W-1:0], {INST_W{1'b0}}} : abs_a;
-                  remainder_q <= {(XLEN+1){1'b0}};
-                  quotient_q  <= {XLEN{1'b0}};
+                  dividend_q  <= word_op_i ? {abs_a[kronos_pkg::INST_W-1:0], {kronos_pkg::INST_W{1'b0}}} : abs_a;
+                  remainder_q <= {(kronos_pkg::XLEN+1){1'b0}};
+                  quotient_q  <= {kronos_pkg::XLEN{1'b0}};
                   abs_b_q     <= abs_b;
-                  div_neg_q   <= (op_i == MULDIV_DIV) & (a_eff[XLEN-1] ^ b_eff[XLEN-1]);
-                  rem_neg_q   <= (op_i == MULDIV_REM) & a_eff[XLEN-1];
+                  div_neg_q   <= (op_i == MULDIV_DIV) & (a_eff[kronos_pkg::XLEN-1] ^ b_eff[kronos_pkg::XLEN-1]);
+                  rem_neg_q   <= (op_i == MULDIV_REM) & a_eff[kronos_pkg::XLEN-1];
                   is_rem_q    <= (op_i == MULDIV_REM) | (op_i == MULDIV_REMU);
-                  count_q     <= word_op_i ? 7'(INST_W) : 7'(XLEN);
+                  count_q     <= word_op_i ? 7'(kronos_pkg::INST_W) : 7'(kronos_pkg::XLEN);
                   state_q     <= COMPUTE;
                 end
               end
@@ -322,8 +322,8 @@ module kronos_muldiv
         // (a × {1'b0, b[31:0]}) lets each partial fit in a short DSP48E2
         // cascade, keeping the logic depth per cycle under budget.
         MUL_IN: begin
-          pp_lo_q <= $signed(mul_a65_q) * $signed({1'b0, mul_b65_q[INST_W-1:0]});
-          pp_hi_q <= $signed(mul_a65_q) * $signed(mul_b65_q[XLEN:INST_W]);
+          pp_lo_q <= $signed(mul_a65_q) * $signed({1'b0, mul_b65_q[kronos_pkg::INST_W-1:0]});
+          pp_hi_q <= $signed(mul_a65_q) * $signed(mul_b65_q[kronos_pkg::XLEN:INST_W]);
           state_q <= MUL_MID;
         end
 
@@ -333,7 +333,7 @@ module kronos_muldiv
         // MSB of pp_hi_q lands in bit 129 of mul_product_q, the sign bit of
         // the 130-bit signed result.
         MUL_MID: begin
-          mul_product_q <= 130'($signed({pp_hi_q, {INST_W{1'b0}}})
+          mul_product_q <= 130'($signed({pp_hi_q, {kronos_pkg::INST_W{1'b0}}})
                                 + $signed({{33{pp_lo_q[97]}}, pp_lo_q}));
           state_q <= MUL_OUT;
         end
@@ -342,19 +342,19 @@ module kronos_muldiv
         // Pipeline stage 4: select result half and sign-extend to 64 bits.
         // Path: product register → mux → result_q. ~1.5 ns.
         MUL_OUT: begin
-          result_q <= word_op_q ? {{INST_W{mul_sel[INST_W-1]}}, mul_sel[INST_W-1:0]} : mul_sel;
+          result_q <= word_op_q ? {{kronos_pkg::INST_W{mul_sel[kronos_pkg::INST_W-1]}}, mul_sel[kronos_pkg::INST_W-1:0]} : mul_sel;
           state_q  <= DONE;
         end
 
         // ---------------------------------------------------------------
         COMPUTE: begin
           // One restoring-division step per cycle.
-          if (!rem_sub[XLEN]) begin
-            remainder_q <= {1'b0, rem_sub[XLEN-1:0]};
-            quotient_q  <= {quotient_q[XLEN-2:0], 1'b1};
+          if (!rem_sub[kronos_pkg::XLEN]) begin
+            remainder_q <= {1'b0, rem_sub[kronos_pkg::XLEN-1:0]};
+            quotient_q  <= {quotient_q[kronos_pkg::XLEN-2:0], 1'b1};
           end else begin
-            remainder_q <= {1'b0, rem_shifted[XLEN-1:0]};
-            quotient_q  <= {quotient_q[XLEN-2:0], 1'b0};
+            remainder_q <= {1'b0, rem_shifted[kronos_pkg::XLEN-1:0]};
+            quotient_q  <= {quotient_q[kronos_pkg::XLEN-2:0], 1'b0};
           end
           dividend_q <= div_shifted;
           count_q    <= count_q - 7'd1;
@@ -362,7 +362,7 @@ module kronos_muldiv
           if (count_q == 7'd1) begin
             // For word_op, sign-extend the low 32 bits of the result.
             result_q <= word_op_q
-                        ? {{INST_W{pre_result[INST_W-1]}}, pre_result[INST_W-1:0]}
+                        ? {{kronos_pkg::INST_W{pre_result[kronos_pkg::INST_W-1]}}, pre_result[kronos_pkg::INST_W-1:0]}
                         : pre_result;
             state_q  <= DONE;
           end

--- a/rtl/stage6/kronos_ptw.sv
+++ b/rtl/stage6/kronos_ptw.sv
@@ -64,8 +64,8 @@ module kronos_ptw
 
   // 1. Constants
   localparam logic [2:0]      PTE_BYTE_OFFSET = 3'b000;
-  localparam logic [XLEN-1:0] PTE_A_MASK      = XLEN'('h40);  // bit 6
-  localparam logic [XLEN-1:0] PTE_D_MASK      = XLEN'('h80);  // bit 7
+  localparam logic [kronos_pkg::XLEN-1:0] PTE_A_MASK      = kronos_pkg::XLEN'('h40);  // bit 6
+  localparam logic [kronos_pkg::XLEN-1:0] PTE_D_MASK      = kronos_pkg::XLEN'('h80);  // bit 7
 
   // 2. Types
   typedef enum logic [3:0] {
@@ -102,14 +102,14 @@ module kronos_ptw
   logic [1:0]  start_level;
 
   // PTE field accessors
-  function automatic logic pte_v(input logic [63:0] p); return p[PTE_V_BIT]; endfunction
-  function automatic logic pte_r(input logic [63:0] p); return p[PTE_R_BIT]; endfunction
-  function automatic logic pte_w(input logic [63:0] p); return p[PTE_W_BIT]; endfunction
-  function automatic logic pte_x(input logic [63:0] p); return p[PTE_X_BIT]; endfunction
-  function automatic logic pte_u(input logic [63:0] p); return p[PTE_U_BIT]; endfunction
-  function automatic logic pte_g(input logic [63:0] p); return p[PTE_G_BIT]; endfunction
-  function automatic logic pte_a(input logic [63:0] p); return p[PTE_A_BIT]; endfunction
-  function automatic logic pte_d(input logic [63:0] p); return p[PTE_D_BIT]; endfunction
+  function automatic logic pte_v(input logic [63:0] p); return p[kronos_pkg::PTE_V_BIT]; endfunction
+  function automatic logic pte_r(input logic [63:0] p); return p[kronos_pkg::PTE_R_BIT]; endfunction
+  function automatic logic pte_w(input logic [63:0] p); return p[kronos_pkg::PTE_W_BIT]; endfunction
+  function automatic logic pte_x(input logic [63:0] p); return p[kronos_pkg::PTE_X_BIT]; endfunction
+  function automatic logic pte_u(input logic [63:0] p); return p[kronos_pkg::PTE_U_BIT]; endfunction
+  function automatic logic pte_g(input logic [63:0] p); return p[kronos_pkg::PTE_G_BIT]; endfunction
+  function automatic logic pte_a(input logic [63:0] p); return p[kronos_pkg::PTE_A_BIT]; endfunction
+  function automatic logic pte_d(input logic [63:0] p); return p[kronos_pkg::PTE_D_BIT]; endfunction
   function automatic logic [43:0] pte_ppn(input logic [63:0] p); return p[53:10]; endfunction
   function automatic logic pte_reserved_set(input logic [63:0] p); return |p[63:54]; endfunction
   function automatic logic pte_is_leaf(input logic [63:0] p);
@@ -175,14 +175,14 @@ module kronos_ptw
     end
   end
 
-  assign start_level = (satp_mode_i == SATP_MODE_SV48) ? 2'd3 : 2'd2;
+  assign start_level = (satp_mode_i == kronos_pkg::SATP_MODE_SV48) ? 2'd3 : 2'd2;
 
   always_comb begin
     state_d             = state_q;
     dcache_req_valid_o  = 1'b0;
     dcache_req_addr_o   = walk_addr_q;
     dcache_req_we_o     = 1'b0;
-    dcache_req_wdata_o  = {XLEN{1'b0}};
+    dcache_req_wdata_o  = {kronos_pkg::XLEN{1'b0}};
     dcache_req_size_o   = 3'd3;
     dcache_req_is_lr_o  = 1'b0;
     dcache_req_is_sc_o  = 1'b0;
@@ -197,7 +197,7 @@ module kronos_ptw
 
     unique case (state_q)
       S_IDLE: begin
-        if (accept_req & (satp_mode_i != SATP_MODE_BARE)) state_d = S_FETCH_REQ;
+        if (accept_req & (satp_mode_i != kronos_pkg::SATP_MODE_BARE)) state_d = S_FETCH_REQ;
       end
 
       S_FETCH_REQ: begin
@@ -247,8 +247,8 @@ module kronos_ptw
         dcache_req_is_sc_o = 1'b1;
         // Bit 6 = A, bit 7 = D
         dcache_req_wdata_o = cur_pte_q
-                              | (needs_a_q ? PTE_A_MASK : XLEN'(0))
-                              | (needs_d_q ? PTE_D_MASK : XLEN'(0));
+                              | (needs_a_q ? PTE_A_MASK : kronos_pkg::XLEN'(0))
+                              | (needs_d_q ? PTE_D_MASK : kronos_pkg::XLEN'(0));
         if (dcache_rsp_valid_i) state_d = S_AD_SC_WAIT;
       end
 
@@ -265,9 +265,9 @@ module kronos_ptw
 
       S_PAGE_FAULT: begin
         page_fault_o       = 1'b1;
-        page_fault_cause_o = (walk_which_q == TLB_FETCH) ? CAUSE_INSTR_PAGE_FAULT
-                            : (walk_which_q == TLB_LOAD)  ? CAUSE_LOAD_PAGE_FAULT
-                                                          : CAUSE_STORE_PAGE_FAULT;
+        page_fault_cause_o = (walk_which_q == TLB_FETCH) ? kronos_pkg::CAUSE_INSTR_PAGE_FAULT
+                            : (walk_which_q == TLB_LOAD)  ? kronos_pkg::CAUSE_LOAD_PAGE_FAULT
+                                                          : kronos_pkg::CAUSE_STORE_PAGE_FAULT;
         page_fault_tval_o  = walk_va_q;
         page_fault_which_o = walk_which_q;
         state_d = S_IDLE;
@@ -295,7 +295,7 @@ module kronos_ptw
       walk_va_q        <= 64'd0;
       walk_level_q     <= 2'd0;
       walk_addr_q      <= 56'd0;
-      cur_pte_q        <= {XLEN{1'b0}};
+      cur_pte_q        <= {kronos_pkg::XLEN{1'b0}};
       walk_which_q     <= TLB_NONE;
       walk_is_load_q   <= 1'b0;
       walk_is_store_q  <= 1'b0;
@@ -304,7 +304,7 @@ module kronos_ptw
     end else begin
       state_q <= state_d;
 
-      if (state_q == S_IDLE & accept_req & (satp_mode_i != SATP_MODE_BARE)) begin
+      if (state_q == S_IDLE & accept_req & (satp_mode_i != kronos_pkg::SATP_MODE_BARE)) begin
         walk_va_q       <= accepted_va;
         walk_level_q    <= start_level;
         walk_addr_q     <= {satp_ppn_i, vpn_at_level(accepted_va, start_level), PTE_BYTE_OFFSET};

--- a/rtl/stage6/kronos_tlb.sv
+++ b/rtl/stage6/kronos_tlb.sv
@@ -18,7 +18,7 @@ module kronos_tlb
 
   // Lookup port (combinational).
   input  logic              lookup_valid_i,
-  input  logic [XLEN-1:0]   lookup_va_i,
+  input  logic [kronos_pkg::XLEN-1:0]   lookup_va_i,
   input  logic [15:0]       lookup_asid_i,
   input  priv_e             lookup_priv_i,
   input  logic              is_load_i,
@@ -47,7 +47,7 @@ module kronos_tlb
   input  logic              flush_valid_i,
   input  logic              flush_va_valid_i,
   input  logic              flush_asid_valid_i,
-  input  logic [XLEN-1:0]   flush_va_i,
+  input  logic [kronos_pkg::XLEN-1:0]   flush_va_i,
   input  logic [15:0]       flush_asid_i
 );
 

--- a/rtl/stage6/kronos_top.sv
+++ b/rtl/stage6/kronos_top.sv
@@ -14,8 +14,8 @@ module kronos_top
 #(
   // PMA non-cacheable region list — exposed for SoC integrators.
   parameter int unsigned     NUM_NC_REGIONS = 1,
-  parameter logic [XLEN-1:0] NC_REGION_BASE  [NUM_NC_REGIONS] = '{MMIO_BASE},
-  parameter logic [XLEN-1:0] NC_REGION_LIMIT [NUM_NC_REGIONS] = '{64'h0000_0000_4FFF_FFFF}
+  parameter logic [kronos_pkg::XLEN-1:0] NC_REGION_BASE  [NUM_NC_REGIONS] = '{kronos_pkg::MMIO_BASE},
+  parameter logic [kronos_pkg::XLEN-1:0] NC_REGION_LIMIT [NUM_NC_REGIONS] = '{64'h0000_0000_4FFF_FFFF}
 ) (
   input  logic             clk_i,
   input  logic             rst_ni,
@@ -46,21 +46,21 @@ module kronos_top
   // Driven from mem_wb_q in the cycle it advances past WB.
   // ----------------------------------------------------------------------
   output logic            retire_valid_o,
-  output logic [XLEN-1:0] retire_pc_o,
-  output logic [INST_W-1:0] retire_instr_o,
+  output logic [kronos_pkg::XLEN-1:0] retire_pc_o,
+  output logic [kronos_pkg::INST_W-1:0] retire_instr_o,
   output logic            retire_rd_wen_o,
   output logic [4:0]      retire_rd_o,
-  output logic [XLEN-1:0] retire_rd_wdata_o,
+  output logic [kronos_pkg::XLEN-1:0] retire_rd_wdata_o,
   output logic            retire_fp_wen_o,
   output logic [4:0]      retire_fp_rd_o,
-  output logic [FLEN-1:0] retire_fp_wdata_o,
+  output logic [kronos_pkg::FLEN-1:0] retire_fp_wdata_o,
   output logic            retire_mem_wen_o,
-  output logic [XLEN-1:0] retire_mem_addr_o,
-  output logic [XLEN-1:0] retire_mem_wdata_o,
+  output logic [kronos_pkg::XLEN-1:0] retire_mem_addr_o,
+  output logic [kronos_pkg::XLEN-1:0] retire_mem_wdata_o,
   output logic [2:0]      retire_mem_funct3_o,
   output logic            retire_csr_wen_o,
   output logic [11:0]     retire_csr_addr_o,
-  output logic [XLEN-1:0] retire_csr_wdata_o,
+  output logic [kronos_pkg::XLEN-1:0] retire_csr_wdata_o,
   // Trap-taken pulse: high for one cycle on trap entry (debug/coverage only).
   output logic        retire_trap_taken_o,
   output logic [31:0] retire_trap_cause_o
@@ -90,12 +90,12 @@ module kronos_top
   // ID-stage wires
   // -------------------------------------------------------------------------
   decoded_instr_t  id_dec;
-  logic [XLEN-1:0] rs1_rdata_64, rs2_rdata_64;
-  logic [XLEN-1:0] rs1_data_id, rs2_data_id, rs3_data_id;
+  logic [kronos_pkg::XLEN-1:0] rs1_rdata_64, rs2_rdata_64;
+  logic [kronos_pkg::XLEN-1:0] rs1_data_id, rs2_data_id, rs3_data_id;
   logic            wb_writing;
 
   // FP regfile read ports
-  logic [FLEN-1:0] fp_rd1, fp_rd2, fp_rd3;
+  logic [kronos_pkg::FLEN-1:0] fp_rd1, fp_rd2, fp_rd3;
 
   // CSR frm output
   logic [2:0]     frm;
@@ -104,28 +104,28 @@ module kronos_top
   // FP paths: 2-bit one-hot selector + data mux (4-way, replaces 4-level chain).
   // Integer path: plain WB-bypass-or-regfile (EX/MEM forwarding via fwd_rs1_sel).
   logic [1:0]      fp_rs1_sel, fp_rs2_sel, fp_rs3_sel;
-  logic [FLEN-1:0] fp_rs1_data_id, fp_rs2_data_id, fp_rs3_data_id;
-  logic [XLEN-1:0] int_rs1_data_id, int_rs2_data_id;
+  logic [kronos_pkg::FLEN-1:0] fp_rs1_data_id, fp_rs2_data_id, fp_rs3_data_id;
+  logic [kronos_pkg::XLEN-1:0] int_rs1_data_id, int_rs2_data_id;
 
   // -------------------------------------------------------------------------
   // EX-stage wires (64-bit datapath)
   // -------------------------------------------------------------------------
-  logic [XLEN-1:0] fwd_rs1_data, fwd_rs2_data;
-  logic [XLEN-1:0] alu_a, alu_b, alu_result;
-  logic [XLEN-1:0] ex_result;
+  logic [kronos_pkg::XLEN-1:0] fwd_rs1_data, fwd_rs2_data;
+  logic [kronos_pkg::XLEN-1:0] alu_a, alu_b, alu_result;
+  logic [kronos_pkg::XLEN-1:0] ex_result;
   logic [31:0]     ex_pc_d                        /* verilator public_flat_rd */;
   logic            ex_redirect                        /* verilator public_flat_rd */;
   logic            branch_taken;
   logic            irq_pending;
   logic [4:0]      irq_cause;
-  logic [XLEN-1:0] csr_rdata;
-  logic [XLEN-1:0] trap_vector, mepc, sepc;
+  logic [kronos_pkg::XLEN-1:0] csr_rdata;
+  logic [kronos_pkg::XLEN-1:0] trap_vector, mepc, sepc;
   logic [31:0]     trap_cause                        /* verilator public_flat_rd */;
-  logic [XLEN-1:0] jalr_target_64;
+  logic [kronos_pkg::XLEN-1:0] jalr_target_64;
 
   // privilege state + protection wires.
   priv_e             priv_q;
-  logic [XLEN-1:0]   mstatus;
+  logic [kronos_pkg::XLEN-1:0]   mstatus;
   logic              pmp_fetch_fault;
   logic [55:0]       pmp_fetch_fault_addr;
   logic              pmp_data_fault;
@@ -166,11 +166,11 @@ module kronos_top
   logic        itlb_miss, dtlb_miss;
   logic        ptw_busy, ptw_pf;
   logic [4:0]      ptw_pf_cause;
-  logic [XLEN-1:0] ptw_pf_tval;
+  logic [kronos_pkg::XLEN-1:0] ptw_pf_tval;
   tlb_op_e         ptw_pf_which;
   logic            ptw_dc_req_valid, ptw_dc_req_we, ptw_dc_req_lr, ptw_dc_req_sc;
   logic [55:0]     ptw_dc_req_addr;
-  logic [XLEN-1:0] ptw_dc_req_wdata;
+  logic [kronos_pkg::XLEN-1:0] ptw_dc_req_wdata;
   logic [2:0]      ptw_dc_req_size;
   logic            ptw_itlb_rfv, ptw_dtlb_rfv;
   logic [1:0]      ptw_rf_size;
@@ -181,14 +181,14 @@ module kronos_top
   logic [3:0]      ptw_rf_perm;
   logic            ptw_rf_a, ptw_rf_d;
   logic            ptw_dc_rsp_valid, ptw_dc_rsp_sc_ok;
-  logic [XLEN-1:0] ptw_dc_rsp_rdata;
+  logic [kronos_pkg::XLEN-1:0] ptw_dc_rsp_rdata;
   logic [3:0]      satp_mode;
   logic [15:0]     satp_asid;
   logic [43:0]     satp_ppn;
   priv_e           eff_priv_data;
   logic            translate_data, translate_fetch;
   logic            sfence_vma, sfence_va_valid, sfence_asid_valid;
-  logic [XLEN-1:0] sfence_va;
+  logic [kronos_pkg::XLEN-1:0] sfence_va;
   logic [15:0]     sfence_asid;
   logic        wfi_priv_fail;
   logic        cross_page_fault;
@@ -201,7 +201,7 @@ module kronos_top
   logic [31:0] ex_mem_data_pa_q;
 
   // STAGE2: muldiv signals (64-bit)
-  logic [XLEN-1:0] muldiv_result;
+  logic [kronos_pkg::XLEN-1:0] muldiv_result;
   logic        muldiv_valid, muldiv_idle;
   logic        muldiv_stall;
 
@@ -218,7 +218,7 @@ module kronos_top
 
   // I-cache interface signals
   logic              icache_data_valid;
-  logic [INST_W-1:0] icache_data;
+  logic [kronos_pkg::INST_W-1:0] icache_data;
   logic              icache_stall;
   logic        icache_miss_pulse                 /* verilator public_flat_rd */;
   logic        fence_i_pulse;
@@ -232,7 +232,7 @@ module kronos_top
   logic [31:0] icache_fetch_addr;
 
   // STAGE3: C extension — alignment unit signals
-  logic [INST_W-1:0] align_instr                       /* verilator public_flat_rd */;
+  logic [kronos_pkg::INST_W-1:0] align_instr                       /* verilator public_flat_rd */;
   logic              align_instr_valid                 /* verilator public_flat_rd */;
   logic              align_is_16b;
   logic              align_stall;
@@ -256,7 +256,7 @@ module kronos_top
   // -------------------------------------------------------------------------
   // MEM-stage wires (64-bit lsu data)
   // -------------------------------------------------------------------------
-  logic [XLEN-1:0]  lsu_rdata;
+  logic [kronos_pkg::XLEN-1:0]  lsu_rdata;
   logic             lsu_valid;
   logic             mem_stall                    /* verilator public_flat_rd */;
   logic             lsu_mem_stall;
@@ -264,19 +264,19 @@ module kronos_top
   // advances.  Gates req_i so LSU does not re-issue while the pipeline is
   // frozen by instr_fetch_stall.
   logic             mem_done_q;
-  logic [XLEN-1:0]  lsu_rdata_latch;  // holds rdata across the stall gap
+  logic [kronos_pkg::XLEN-1:0]  lsu_rdata_latch;  // holds rdata across the stall gap
   logic             amo_write_latch;  // holds is_amo_write across the stall gap
 
   // D-cache interface (LSU ↔ dcache)
   logic            dcache_req;
-  logic [XLEN-1:0] dcache_addr;
+  logic [kronos_pkg::XLEN-1:0] dcache_addr;
   logic [2:0]      dcache_size;
   logic            dcache_we;
-  logic [XLEN-1:0] dcache_wdata;
+  logic [kronos_pkg::XLEN-1:0] dcache_wdata;
   logic            dcache_amo_req;
   logic [4:0]      dcache_amo_op;
   logic            dcache_data_valid;
-  logic [XLEN-1:0] dcache_rdata;
+  logic [kronos_pkg::XLEN-1:0] dcache_rdata;
   logic            dcache_sc_success;
   logic            dcache_stall                      /* verilator public_flat_rd */;
   logic            dcache_miss_pulse                 /* verilator public_flat_rd */;
@@ -289,12 +289,12 @@ module kronos_top
 
   // LSU FP response
   logic             lsu_fp_dest;
-  logic [FLEN-1:0]  lsu_fp_rdata;
+  logic [kronos_pkg::FLEN-1:0]  lsu_fp_rdata;
 
   // -------------------------------------------------------------------------
   // WB-stage wires (64-bit)
   // -------------------------------------------------------------------------
-  logic [XLEN-1:0] wb_result_64;
+  logic [kronos_pkg::XLEN-1:0] wb_result_64;
 
   // -------------------------------------------------------------------------
   // FPU wires
@@ -303,7 +303,7 @@ module kronos_top
   logic            fp_inflight_q;       // FPU is computing
   logic            fpu_dispatched_q;    // dispatch has fired for current EX instr
   logic            fpu_out_valid;
-  logic [FLEN-1:0] fpu_result;
+  logic [kronos_pkg::FLEN-1:0] fpu_result;
   logic [4:0]      fpu_fflags;
   fpu_tag_t        fpu_tag_out;
   logic            fpu_busy;
@@ -325,19 +325,19 @@ module kronos_top
   // Sdtrig (trigger module) interface
   logic            trig_hit;
   logic [31:0]     trig_hit_pc;
-  logic [XLEN-1:0] trig_csr_rdata;
+  logic [kronos_pkg::XLEN-1:0] trig_csr_rdata;
   logic            trig_csr_match;
   logic            trig_csr_we;
-  logic [XLEN-1:0] trig_csr_wdata;
+  logic [kronos_pkg::XLEN-1:0] trig_csr_wdata;
 
   // post-write CSR value piped from u_csr → mem_wb pipeline → retire
   // trace.  csr_new_val_post is the combinational output of u_csr in the EX
   // stage; ex_mem_csr_new_val_q snapshots it at the EX→MEM boundary (same
   // cycle the CSR commits its write), and mem_wb_csr_new_val_q propagates it
   // to the WB stage so retire_csr_wdata_o reflects the post-write value.
-  logic [XLEN-1:0] csr_new_val_post;
-  logic [XLEN-1:0] ex_mem_csr_new_val_q;
-  logic [XLEN-1:0] mem_wb_csr_new_val_q;
+  logic [kronos_pkg::XLEN-1:0] csr_new_val_post;
+  logic [kronos_pkg::XLEN-1:0] ex_mem_csr_new_val_q;
+  logic [kronos_pkg::XLEN-1:0] mem_wb_csr_new_val_q;
 
   // ---- Stage 5c/e performance-counter event bus ----
   logic        bpred_mispredict_pulse;
@@ -351,24 +351,24 @@ module kronos_top
   // result survives instr_fetch_stall cycles that may hold combined_stall=1
   // even after fpu_stall drops to 0.
   logic            fp_result_valid_q;
-  logic [FLEN-1:0] fp_result_q;
+  logic [kronos_pkg::FLEN-1:0] fp_result_q;
   fpu_tag_t        fp_tag_q;
 
   // Combinatorial: current FPU result (just-fired or latched)
   logic            fp_result_avail;
-  logic [FLEN-1:0] fp_result_cur;
+  logic [kronos_pkg::FLEN-1:0] fp_result_cur;
   fpu_tag_t        fp_tag_cur;
 
   // FPU operand muxes: EX forwarding for integer-source FP instructions.
   // FMV.W.X / FMV.D.X read integer rs1/rs2; use fwd_rs1/2_data so that
   // MEM-WB bypassing applies (id_ex_q.rs1_data may be stale when the
   // producer was still in MEM when the FP instruction was in ID).
-  logic [FLEN-1:0] fpu_a_i, fpu_b_i;
+  logic [kronos_pkg::FLEN-1:0] fpu_a_i, fpu_b_i;
 
   // FP regfile write port signals
   logic            fp_we;
   logic [4:0]      fp_wa;
-  logic [FLEN-1:0] fp_wd;
+  logic [kronos_pkg::FLEN-1:0] fp_wd;
 
   // -------------------------------------------------------------------------
   // PC next (combinational)
@@ -820,7 +820,7 @@ module kronos_top
                      ( (priv_q == PRIV_U) |
                        ((priv_q == PRIV_S) & mstatus[22]) );  // TSR
     satp_tvm_fail  = id_ex_q.dec.is_csr &
-                     (id_ex_q.dec.csr_addr == CSR_SATP) &
+                     (id_ex_q.dec.csr_addr == kronos_pkg::CSR_SATP) &
                      (priv_q == PRIV_S) & mstatus[20];       // TVM
   end
 
@@ -844,8 +844,8 @@ module kronos_top
   // -------------------------------------------------------------------------
   assign eff_priv_data    = (priv_q == PRIV_M & mstatus[17] /*MPRV*/)
                             ? priv_e'(mstatus[12:11]) : priv_q;
-  assign translate_data   = (satp_mode != SATP_MODE_BARE) & (eff_priv_data != PRIV_M);
-  assign translate_fetch  = (satp_mode != SATP_MODE_BARE) & (priv_q != PRIV_M);
+  assign translate_data   = (satp_mode != kronos_pkg::SATP_MODE_BARE) & (eff_priv_data != PRIV_M);
+  assign translate_fetch  = (satp_mode != kronos_pkg::SATP_MODE_BARE) & (priv_q != PRIV_M);
 
   assign sfence_vma         = id_ex_q.valid & id_ex_q.dec.is_sfence_vma & ~combined_stall;
   assign sfence_va          = fwd_rs1_data;
@@ -1194,7 +1194,7 @@ module kronos_top
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       fp_result_valid_q <= 1'b0;
-      fp_result_q       <= {FLEN{1'b0}};
+      fp_result_q       <= {kronos_pkg::FLEN{1'b0}};
       fp_tag_q          <= '{default: '0};
     end else begin
       if (fpu_out_valid & combined_stall) begin
@@ -1214,7 +1214,7 @@ module kronos_top
   always_comb begin
     fp_we = 1'b0;
     fp_wa = 5'b0;
-    fp_wd = {FLEN{1'b0}};
+    fp_wd = {kronos_pkg::FLEN{1'b0}};
 
     if (lsu_valid & ex_mem_q.valid & ex_mem_q.dec.fp_load) begin
       // FP load: write NaN-boxed data directly
@@ -1448,9 +1448,9 @@ module kronos_top
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_flush) begin
-      id_ex_q <= ID_EX_REG_ZERO;
+      id_ex_q <= kronos_pkg::ID_EX_REG_ZERO;
     end else if (id_ex_en) begin
       id_ex_q.pc          <= if_id_q.pc;
       id_ex_q.dec         <= id_dec;
@@ -1530,28 +1530,28 @@ module kronos_top
     if (trig_hit) begin
       trap_cause = 32'd3;                                   // BREAKPOINT (Sdtrig)
     end else if (instr_page_fault) begin
-      trap_cause = {27'b0, CAUSE_INSTR_PAGE_FAULT};         // 12
+      trap_cause = {27'b0, kronos_pkg::CAUSE_INSTR_PAGE_FAULT};         // 12
     end else if (pmp_fetch_fault) begin
-      trap_cause = {27'b0, CAUSE_INSTR_ACCESS_FAULT};       // 1
+      trap_cause = {27'b0, kronos_pkg::CAUSE_INSTR_ACCESS_FAULT};       // 1
     end else if (load_page_fault) begin
-      trap_cause = {27'b0, CAUSE_LOAD_PAGE_FAULT};          // 13
+      trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_PAGE_FAULT};          // 13
     end else if ((pmp_data_fault | ex_amo_nc_fault) & id_ex_q.dec.is_load) begin
       // EX-stage data access faults: id_ex_q is the offending instruction.
       // is_load covers plain LW/LD and LR (LR sets is_amo & is_load).
-      trap_cause = {27'b0, CAUSE_LOAD_ACCESS_FAULT};        // 5
+      trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};        // 5
     end else if (store_page_fault) begin
-      trap_cause = {27'b0, CAUSE_STORE_PAGE_FAULT};         // 15
+      trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_PAGE_FAULT};         // 15
     end else if ((pmp_data_fault | ex_amo_nc_fault) & id_ex_q.dec.is_store) begin
-      trap_cause = {27'b0, CAUSE_STORE_ACCESS_FAULT};       // 7
+      trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};       // 7
     end else if ((pmp_data_fault | ex_amo_nc_fault) & id_ex_q.dec.is_amo) begin
       // AMO/SC violation: report as STORE access fault (priv-spec).
-      trap_cause = {27'b0, CAUSE_STORE_ACCESS_FAULT};
+      trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
     end else if (dcache_bus_err_fault & ex_mem_q.dec.is_load) begin
       // MEM-stage bus error on a plain NC load — ex_mem_q is the offender.
-      trap_cause = {27'b0, CAUSE_LOAD_ACCESS_FAULT};        // 5
+      trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};        // 5
     end else if (dcache_bus_err_fault) begin
       // MEM-stage bus error on a plain NC store — store/AMO access fault.
-      trap_cause = {27'b0, CAUSE_STORE_ACCESS_FAULT};       // 7
+      trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};       // 7
     end else if (irq_pending) begin
       trap_cause = {1'b1, 26'b0, irq_cause};                // mcause[63]=1 (IRQ)
     end else if (id_ex_q.dec.illegal | csr_illegal |
@@ -1560,10 +1560,10 @@ module kronos_top
       trap_cause = 32'd2;                                   // ILLEGAL
     end else if (id_ex_q.dec.is_ecall) begin
       unique case (priv_q)
-        PRIV_U:  trap_cause = {27'b0, CAUSE_ECALL_U};       // 8
-        PRIV_S:  trap_cause = {27'b0, CAUSE_ECALL_S};       // 9
-        PRIV_M:  trap_cause = {27'b0, CAUSE_ECALL_M};       // 11
-        default: trap_cause = {27'b0, CAUSE_ECALL_M};
+        PRIV_U:  trap_cause = {27'b0, kronos_pkg::CAUSE_ECALL_U};       // 8
+        PRIV_S:  trap_cause = {27'b0, kronos_pkg::CAUSE_ECALL_S};       // 9
+        PRIV_M:  trap_cause = {27'b0, kronos_pkg::CAUSE_ECALL_M};       // 11
+        default: trap_cause = {27'b0, kronos_pkg::CAUSE_ECALL_M};
       endcase
     end else begin
       trap_cause = 32'd3;                                   // ebreak (default)
@@ -1667,14 +1667,14 @@ module kronos_top
   // own write commits on the same posedge (req_i is gated by ~combined_stall),
   // so this snapshot is the post-write value for the EX-stage instruction.
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)        ex_mem_csr_new_val_q <= {XLEN{1'b0}};
+    if (!rst_ni)        ex_mem_csr_new_val_q <= {kronos_pkg::XLEN{1'b0}};
     else if (ex_mem_en) ex_mem_csr_new_val_q <= csr_new_val_post;
   end
 
   // propagate the post-write CSR value MEM→WB, mirroring the
   // mem_wb_q.csr_wdata pipe.  Drives retire_csr_wdata_o.
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)        mem_wb_csr_new_val_q <= {XLEN{1'b0}};
+    if (!rst_ni)        mem_wb_csr_new_val_q <= {kronos_pkg::XLEN{1'b0}};
     else if (mem_wb_en) mem_wb_csr_new_val_q <= ex_mem_csr_new_val_q;
   end
 
@@ -1738,7 +1738,7 @@ module kronos_top
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       mem_done_q      <= 1'b0;
-      lsu_rdata_latch <= {XLEN{1'b0}};
+      lsu_rdata_latch <= {kronos_pkg::XLEN{1'b0}};
       amo_write_latch <= 1'b0;
     end else begin
       if (lsu_valid) begin
@@ -1870,18 +1870,18 @@ module kronos_top
   // mispredict=0x1E↔0x02) so the consolidated taxonomy table is contiguous.
   assign event_bus[18]    = 1'b0;
   assign event_bus[19]    = 1'b0;
-  assign event_bus[EVT_LOAD_USE_STALL]      = load_use_event;
-  assign event_bus[EVT_JALR_FWD_STALL]      = jalr_fwd_event;
-  assign event_bus[EVT_FP_RAW_STALL]        = fp_load_use_event;
-  assign event_bus[EVT_FRM_HAZARD_STALL]    = id_ex_is_frm_write & if_id_fp_dyn_rm;
-  assign event_bus[EVT_FP_INFLIGHT_STALL]   = fpu_stall;
-  assign event_bus[EVT_FENCE_I_DRAIN_STALL] = fence_i_active_q;
-  assign event_bus[EVT_MEM_BUSY_STALL]      = lsu_mem_stall | dcache_stall;
-  assign event_bus[EVT_MULDIV_STALL]        = muldiv_stall;
-  assign event_bus[EVT_FPU_STALL]           = fpu_busy_any;
-  assign event_bus[EVT_INSTR_FETCH_STALL]   = instr_fetch_stall;
-  assign event_bus[EVT_BRANCH_MISPREDICT]   = bpred_mispredict_pulse;
-  assign event_bus[EVT_EX_REDIRECT]         = ex_redirect;
+  assign event_bus[kronos_pkg::EVT_LOAD_USE_STALL]      = load_use_event;
+  assign event_bus[kronos_pkg::EVT_JALR_FWD_STALL]      = jalr_fwd_event;
+  assign event_bus[kronos_pkg::EVT_FP_RAW_STALL]        = fp_load_use_event;
+  assign event_bus[kronos_pkg::EVT_FRM_HAZARD_STALL]    = id_ex_is_frm_write & if_id_fp_dyn_rm;
+  assign event_bus[kronos_pkg::EVT_FP_INFLIGHT_STALL]   = fpu_stall;
+  assign event_bus[kronos_pkg::EVT_FENCE_I_DRAIN_STALL] = fence_i_active_q;
+  assign event_bus[kronos_pkg::EVT_MEM_BUSY_STALL]      = lsu_mem_stall | dcache_stall;
+  assign event_bus[kronos_pkg::EVT_MULDIV_STALL]        = muldiv_stall;
+  assign event_bus[kronos_pkg::EVT_FPU_STALL]           = fpu_busy_any;
+  assign event_bus[kronos_pkg::EVT_INSTR_FETCH_STALL]   = instr_fetch_stall;
+  assign event_bus[kronos_pkg::EVT_BRANCH_MISPREDICT]   = bpred_mispredict_pulse;
+  assign event_bus[kronos_pkg::EVT_EX_REDIRECT]         = ex_redirect;
 
   assign retire_valid_o      = retire_advance;
   assign retire_pc_o         = {32'b0, mem_wb_q.pc};
@@ -1898,7 +1898,7 @@ module kronos_top
   assign retire_fp_wdata_o   = mem_wb_q.dec.fp_load
                                ? (mem_wb_q.dec.mem_funct3[0]  // funct3[0]=1 → FLD (011), =0 → FLW (010)
                                   ? mem_wb_q.lsu_rdata
-                                  : {FP_NANBOX_UPPER, mem_wb_q.lsu_rdata[31:0]})
+                                  : {kronos_pkg::FP_NANBOX_UPPER, mem_wb_q.lsu_rdata[31:0]})
                                : mem_wb_q.alu_result;
 
   assign retire_mem_wen_o    = retire_advance & (mem_wb_q.dec.is_store | mem_wb_q.is_amo_write);

--- a/rtl/stage6/kronos_trigger.sv
+++ b/rtl/stage6/kronos_trigger.sv
@@ -16,8 +16,8 @@ module kronos_trigger
   input  logic            csr_req_i,
   input  logic [11:0]     csr_addr_i,
   input  logic            csr_we_i,
-  input  logic [XLEN-1:0] csr_wdata_i,
-  output logic [XLEN-1:0] csr_rdata_o,
+  input  logic [kronos_pkg::XLEN-1:0] csr_wdata_i,
+  output logic [kronos_pkg::XLEN-1:0] csr_rdata_o,
   output logic            csr_match_o,   // 1 = csr_addr_i is a trigger CSR
 
   // EX-stage probe (sample exactly when valid_i is high).
@@ -25,7 +25,7 @@ module kronos_trigger
   input  logic [31:0]     ex_pc_i,
   input  logic            ex_is_load_i,
   input  logic            ex_is_store_i,
-  input  logic [XLEN-1:0] ex_mem_addr_i,
+  input  logic [kronos_pkg::XLEN-1:0] ex_mem_addr_i,
 
   // Match output.  Combinational: hit_o pulses high for one cycle when
   // an EX-stage instruction matches an enabled trigger.
@@ -41,7 +41,7 @@ module kronos_trigger
     logic            store;    // tdata1[2]
     logic            load;     // tdata1[1]
     logic            hit;      // tdata1[10] (sticky-set on match; RW1C)
-    logic [XLEN-1:0] tdata2;
+    logic [kronos_pkg::XLEN-1:0] tdata2;
   } trigger_t;
 
   // State registers
@@ -55,9 +55,9 @@ module kronos_trigger
   logic       store_match [0:3];
 
   // Build a tdata1 view from per-trigger fields.
-  function automatic logic [XLEN-1:0] pack_tdata1(input trigger_t t);
-    logic [XLEN-1:0] v;
-    v          = {XLEN{1'b0}};
+  function automatic logic [kronos_pkg::XLEN-1:0] pack_tdata1(input trigger_t t);
+    logic [kronos_pkg::XLEN-1:0] v;
+    v          = {kronos_pkg::XLEN{1'b0}};
     v[63:60]   = 4'h6;       // type=mcontrol6
     v[59]      = 1'b0;       // dmode=0
     v[10]      = t.hit;
@@ -70,13 +70,13 @@ module kronos_trigger
 
   // CSR read mux.
   always_comb begin
-    csr_rdata_o   = {XLEN{1'b0}};
+    csr_rdata_o   = {kronos_pkg::XLEN{1'b0}};
     csr_match_o   = 1'b0;
     unique case (csr_addr_i)
-      12'h7A0: begin csr_match_o = 1'b1; csr_rdata_o = {{XLEN-2{1'b0}}, tselect_q}; end
+      12'h7A0: begin csr_match_o = 1'b1; csr_rdata_o = {{kronos_pkg::XLEN-2{1'b0}}, tselect_q}; end
       12'h7A1: begin csr_match_o = 1'b1; csr_rdata_o = pack_tdata1(triggers_q[tselect_q]); end
       12'h7A2: begin csr_match_o = 1'b1; csr_rdata_o = triggers_q[tselect_q].tdata2; end
-      12'h7A3: begin csr_match_o = 1'b1; csr_rdata_o = {XLEN{1'b0}}; end
+      12'h7A3: begin csr_match_o = 1'b1; csr_rdata_o = {kronos_pkg::XLEN{1'b0}}; end
       12'h7A4: begin csr_match_o = 1'b1; csr_rdata_o = 64'h0000_0000_0000_0040; end // bit 6 = mcontrol6
       default: ;
     endcase
@@ -92,7 +92,7 @@ module kronos_trigger
     end
     for (int i = 0; i < 4; i++) begin
       exec_match[i]  = triggers_q[i].m & triggers_q[i].execute & ex_valid_i &
-                       ({{XLEN-32{1'b0}}, ex_pc_i} == triggers_q[i].tdata2);
+                       ({{kronos_pkg::XLEN-32{1'b0}}, ex_pc_i} == triggers_q[i].tdata2);
       load_match[i]  = triggers_q[i].m & triggers_q[i].load    & ex_valid_i & ex_is_load_i  &
                        (ex_mem_addr_i == triggers_q[i].tdata2);
       store_match[i] = triggers_q[i].m & triggers_q[i].store   & ex_valid_i & ex_is_store_i &
@@ -114,7 +114,7 @@ module kronos_trigger
         triggers_q[i].store   <= 1'b0;
         triggers_q[i].load    <= 1'b0;
         triggers_q[i].hit     <= 1'b0;
-        triggers_q[i].tdata2  <= {XLEN{1'b0}};
+        triggers_q[i].tdata2  <= {kronos_pkg::XLEN{1'b0}};
       end
     end else begin
       // Sticky-hit update — set on match, regardless of CSR write.

--- a/tb/stage5/tb_fpu_fma.sv
+++ b/tb/stage5/tb_fpu_fma.sv
@@ -72,7 +72,7 @@ module tb_fpu_fma;
     int unsigned sf_r;
     byte unsigned sf_f;
     apply5(o, 1'b0, r,
-           {FP_NANBOX_UPPER, as}, {FP_NANBOX_UPPER, bs}, {FP_NANBOX_UPPER, cs});
+           {kronos_pkg::FP_NANBOX_UPPER, as}, {kronos_pkg::FP_NANBOX_UPPER, bs}, {kronos_pkg::FP_NANBOX_UPPER, cs});
     sf_a = as;
     sf_b = bs;
     sf_c = cs;
@@ -139,9 +139,9 @@ module tb_fpu_fma;
     // ------- Directed S-precision corner cases -------
     // +0 * +0 + (-0) in RNE -> +0
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h8000_0000});
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000});
     total++;
     if (result[31:0] !== 32'h0000_0000) begin
       $error("0*0+(-0) RNE: dut=%h", result[31:0]);
@@ -150,9 +150,9 @@ module tb_fpu_fma;
 
     // +0 * +0 + (-0) in RDN -> -0
     apply5(FP_FMADD, 1'b0, 3'd2,
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h8000_0000});
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000});
     total++;
     if (result[31:0] !== 32'h8000_0000) begin
       $error("0*0+(-0) RDN: dut=%h", result[31:0]);
@@ -161,22 +161,22 @@ module tb_fpu_fma;
 
     // Inf * 0 -> canonical qNaN, NV
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h7F80_0000},
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h0000_0000});
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h7F80_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000});
     total++;
-    if (result[31:0] !== FP_CANON_QNAN_S || !fflags[FP_FFLAG_NV]) begin
+    if (result[31:0] !== kronos_pkg::FP_CANON_QNAN_S || !fflags[kronos_pkg::FP_FFLAG_NV]) begin
       $error("inf*0: dut=%h flags=%b", result[31:0], fflags);
       errors++;
     end
 
     // Inf * 1 + (-Inf) -> qNaN, NV
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h7F80_0000},
-           {FP_NANBOX_UPPER, 32'h3F80_0000},
-           {FP_NANBOX_UPPER, 32'hFF80_0000});
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h7F80_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h3F80_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'hFF80_0000});
     total++;
-    if (result[31:0] !== FP_CANON_QNAN_S || !fflags[FP_FFLAG_NV]) begin
+    if (result[31:0] !== kronos_pkg::FP_CANON_QNAN_S || !fflags[kronos_pkg::FP_FFLAG_NV]) begin
       $error("inf-inf: dut=%h flags=%b", result[31:0], fflags);
       errors++;
     end
@@ -184,11 +184,11 @@ module tb_fpu_fma;
     // ── sNaN input -> canonical qNaN + NV ────────────────────────────────
     // S-precision: sNaN.S × 1.0S + 0 → qNaN.S + NV
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h7FA0_0000},   // a = sNaN.S
-           {FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
-           {FP_NANBOX_UPPER, 32'h0000_0000});  // c = +0
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h7FA0_0000},   // a = sNaN.S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000});  // c = +0
     total++;
-    if (result[31:0] !== FP_CANON_QNAN_S || !fflags[FP_FFLAG_NV]) begin
+    if (result[31:0] !== kronos_pkg::FP_CANON_QNAN_S || !fflags[kronos_pkg::FP_FFLAG_NV]) begin
       $error("sNaN.s fma: dut=%h flags=%b", result[31:0], fflags);
       errors++;
     end
@@ -198,7 +198,7 @@ module tb_fpu_fma;
            64'h3FF0_0000_0000_0000,            // b = 1.0D
            64'h0000_0000_0000_0000);           // c = +0.D
     total++;
-    if (result !== FP_CANON_QNAN_D || !fflags[FP_FFLAG_NV]) begin
+    if (result !== kronos_pkg::FP_CANON_QNAN_D || !fflags[kronos_pkg::FP_FFLAG_NV]) begin
       $error("sNaN.d fma: dut=%h flags=%b", result, fflags);
       errors++;
     end
@@ -206,9 +206,9 @@ module tb_fpu_fma;
     // ── Inf × finite (non-zero) -> ±Inf result ───────────────────────────
     // S-precision: +Inf × 1.0S + 0 → +Inf.S, no flags
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h7F80_0000},   // a = +Inf.S
-           {FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
-           {FP_NANBOX_UPPER, 32'h0000_0000});  // c = +0
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h7F80_0000},   // a = +Inf.S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000});  // c = +0
     total++;
     if (result[31:0] !== 32'h7F80_0000 || fflags !== 5'b0) begin
       $error("inf*1.s fma: dut=%h flags=%b", result[31:0], fflags);
@@ -228,9 +228,9 @@ module tb_fpu_fma;
     // ── finite × finite + Inf addend -> ±Inf result ──────────────────────
     // S-precision: 1.0S × 1.0S + (+Inf.S) → +Inf.S, no flags
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h3F80_0000},   // a = 1.0S
-           {FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
-           {FP_NANBOX_UPPER, 32'h7F80_0000});  // c = +Inf.S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h3F80_0000},   // a = 1.0S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h7F80_0000});  // c = +Inf.S
     total++;
     if (result[31:0] !== 32'h7F80_0000 || fflags !== 5'b0) begin
       $error("1*1+inf.s fma: dut=%h flags=%b", result[31:0], fflags);
@@ -251,9 +251,9 @@ module tb_fpu_fma;
     // S-precision: FMADD(-0, 1.0, -0) — product = -0, addend = -0, same-sign add
     // → result = -0 (prod_sign = 1)
     apply5(FP_FMADD, 1'b0, 3'd0,
-           {FP_NANBOX_UPPER, 32'h8000_0000},   // a = -0.S
-           {FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
-           {FP_NANBOX_UPPER, 32'h8000_0000});  // c = -0.S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000},   // a = -0.S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h3F80_0000},   // b = 1.0S
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000});  // c = -0.S
     total++;
     if (result[31:0] !== 32'h8000_0000 || fflags !== 5'b0) begin
       $error("neg-zero fma: dut=%h flags=%b", result[31:0], fflags);
@@ -305,9 +305,9 @@ module tb_fpu_fma;
     // ------- Gap 1: zero-sign edge cases for RUP and RMM -------
     // +0 * +0 + (-0) in RUP -> +0
     apply5(FP_FMADD, 1'b0, 3'd3,
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h8000_0000});
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000});
     total++;
     if (result[31:0] !== 32'h0000_0000) begin
       $error("0*0+(-0) RUP: dut=%h", result[31:0]);
@@ -316,9 +316,9 @@ module tb_fpu_fma;
 
     // +0 * +0 + (-0) in RMM -> +0
     apply5(FP_FMADD, 1'b0, 3'd4,
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h0000_0000},
-           {FP_NANBOX_UPPER, 32'h8000_0000});
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h0000_0000},
+           {kronos_pkg::FP_NANBOX_UPPER, 32'h8000_0000});
     total++;
     if (result[31:0] !== 32'h0000_0000) begin
       $error("0*0+(-0) RMM: dut=%h", result[31:0]);
@@ -378,9 +378,9 @@ module tb_fpu_fma;
             raw32 = $urandom();
             rc32  = {raw32[31], e8, raw32[22:0]};
             apply5(rand_op, 1'b0, rm_i[2:0],
-                   {FP_NANBOX_UPPER, ra32},
-                   {FP_NANBOX_UPPER, rb32},
-                   {FP_NANBOX_UPPER, rc32});
+                   {kronos_pkg::FP_NANBOX_UPPER, ra32},
+                   {kronos_pkg::FP_NANBOX_UPPER, rb32},
+                   {kronos_pkg::FP_NANBOX_UPPER, rc32});
             sf_reset();
             unique case (rand_op)
               FP_FMADD:  sf_r32 = sf_f32_mulAdd(ra32, rb32, rc32, rm_i[7:0]);

--- a/tb/stage5/tb_fpu_fmisc.sv
+++ b/tb/stage5/tb_fpu_fmisc.sv
@@ -98,7 +98,7 @@ module tb_fpu_fmisc;
 
     // FLT.S with sNaN → result 0, NV flag set
     apply(FP_FLT, 1'b0, 64'hFFFF_FFFF_7FA0_0000, 64'hFFFF_FFFF_4000_0000);
-    if (result[0] !== 1'b0 || fflags[FP_FFLAG_NV] !== 1'b1)
+    if (result[0] !== 1'b0 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b1)
       $fatal(1, "flt sNaN: r=%h f=%b", result, fflags);
 
     // FMIN.S(+0, -0) = -0 (IEEE 754 edge case)
@@ -162,7 +162,7 @@ module tb_fpu_fmisc;
     if (!out_valid || result[0] !== 1'b0 || fflags !== 5'b0) $fatal(1, "feq.d ne: %h/%b", result, fflags);
     // sNaN → result 0, NV
     apply(FP_FEQ, 1'b1, 64'h7FF4_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result[0] !== 1'b0 || fflags[FP_FFLAG_NV] !== 1'b1) $fatal(1, "feq.d sNaN: %h/%b", result, fflags);
+    if (!out_valid || result[0] !== 1'b0 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b1) $fatal(1, "feq.d sNaN: %h/%b", result, fflags);
 
     // ── FLT.D ─────────────────────────────────────────────────────────────
     // 1.0D < 2.0D → 1
@@ -173,7 +173,7 @@ module tb_fpu_fmisc;
     if (!out_valid || result[0] !== 1'b0 || fflags !== 5'b0) $fatal(1, "flt.d gt: %h/%b", result, fflags);
     // qNaN → result 0, NV
     apply(FP_FLT, 1'b1, 64'h7FF8_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result[0] !== 1'b0 || fflags[FP_FFLAG_NV] !== 1'b1) $fatal(1, "flt.d NaN: %h/%b", result, fflags);
+    if (!out_valid || result[0] !== 1'b0 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b1) $fatal(1, "flt.d NaN: %h/%b", result, fflags);
 
     // ── FLE.D ─────────────────────────────────────────────────────────────
     // 1.0D <= 1.0D → 1
@@ -184,7 +184,7 @@ module tb_fpu_fmisc;
     if (!out_valid || result[0] !== 1'b0 || fflags !== 5'b0) $fatal(1, "fle.d gt: %h/%b", result, fflags);
     // sNaN → result 0, NV
     apply(FP_FLE, 1'b1, 64'h7FF4_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result[0] !== 1'b0 || fflags[FP_FFLAG_NV] !== 1'b1) $fatal(1, "fle.d sNaN: %h/%b", result, fflags);
+    if (!out_valid || result[0] !== 1'b0 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b1) $fatal(1, "fle.d sNaN: %h/%b", result, fflags);
 
     // ── FMIN.D — all branches ─────────────────────────────────────────────
     // basic: min(1.0D, 2.0D) = 1.0D
@@ -195,7 +195,7 @@ module tb_fpu_fmisc;
     if (!out_valid || result !== 64'h8000_0000_0000_0000) $fatal(1, "fmin.d +0/-0: %h", result);
     // sNaN → non-NaN operand + NV (per RISC-V spec: "result is the non-NaN operand")
     apply(FP_FMIN, 1'b1, 64'h7FF4_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result !== 64'h3FF0_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b1)
+    if (!out_valid || result !== 64'h3FF0_0000_0000_0000 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b1)
       $fatal(1, "fmin.d sNaN: %h/%b", result, fflags);
     // qNaN a, number b → return b
     apply(FP_FMIN, 1'b1, 64'h7FF8_0000_0000_0000, 64'h3FF0_0000_0000_0000);
@@ -213,7 +213,7 @@ module tb_fpu_fmisc;
     if (!out_valid || result !== 64'h0000_0000_0000_0000) $fatal(1, "fmax.d +0/-0: %h", result);
     // sNaN → non-NaN operand + NV (per RISC-V spec: "result is the non-NaN operand")
     apply(FP_FMAX, 1'b1, 64'h7FF4_0000_0000_0000, 64'h3FF0_0000_0000_0000);
-    if (!out_valid || result !== 64'h3FF0_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b1)
+    if (!out_valid || result !== 64'h3FF0_0000_0000_0000 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b1)
       $fatal(1, "fmax.d sNaN: %h/%b", result, fflags);
     // qNaN a, number b → return b
     apply(FP_FMAX, 1'b1, 64'h7FF8_0000_0000_0000, 64'h3FF0_0000_0000_0000);
@@ -224,12 +224,12 @@ module tb_fpu_fmisc;
 
     // FMIN.D(qNaN, qNaN) → canonical qNaN, no NV  [covers both-NaN branch]
     apply(FP_FMIN, 1'b1, 64'h7FF8_0000_0000_0000, 64'h7FF8_0000_0000_0000);
-    if (!out_valid || result !== 64'h7FF8_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b0)
+    if (!out_valid || result !== 64'h7FF8_0000_0000_0000 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b0)
       $fatal(1, "fmin.d both-qNaN: r=%h f=%b", result, fflags);
 
     // FMAX.D(qNaN, qNaN) → canonical qNaN, no NV
     apply(FP_FMAX, 1'b1, 64'h7FF8_0000_0000_0000, 64'h7FF8_0000_0000_0000);
-    if (!out_valid || result !== 64'h7FF8_0000_0000_0000 || fflags[FP_FFLAG_NV] !== 1'b0)
+    if (!out_valid || result !== 64'h7FF8_0000_0000_0000 || fflags[kronos_pkg::FP_FFLAG_NV] !== 1'b0)
       $fatal(1, "fmax.d both-qNaN: r=%h f=%b", result, fflags);
 
     // FMAX.S(-0, -0) → -0  [covers the -0/-0 equal-zero branch for FMAX.S]
@@ -356,45 +356,45 @@ module tb_fpu_fmisc;
         // --- FEQ.S ---
         apply(FP_FEQ, 1'b0, {32'hFFFF_FFFF, ra32}, {32'hFFFF_FFFF, rb32});
         rand_total++;
-        if (result[0] !== ref_feq || (fflags[FP_FFLAG_NV] !== exp_nv_eq)) begin
+        if (result[0] !== ref_feq || (fflags[kronos_pkg::FP_FFLAG_NV] !== exp_nv_eq)) begin
           $error("[FEQ.S rand %0d] a=%h b=%h dut=%b/%b ref=%b nv_exp=%b",
-                 k, ra32, rb32, result[0], fflags[FP_FFLAG_NV], ref_feq, exp_nv_eq);
+                 k, ra32, rb32, result[0], fflags[kronos_pkg::FP_FFLAG_NV], ref_feq, exp_nv_eq);
           rand_errors++;
         end
 
         // --- FLT.S ---
         apply(FP_FLT, 1'b0, {32'hFFFF_FFFF, ra32}, {32'hFFFF_FFFF, rb32});
         rand_total++;
-        if (result[0] !== ref_flt || (fflags[FP_FFLAG_NV] !== exp_nv_lt)) begin
+        if (result[0] !== ref_flt || (fflags[kronos_pkg::FP_FFLAG_NV] !== exp_nv_lt)) begin
           $error("[FLT.S rand %0d] a=%h b=%h dut=%b/%b ref=%b nv_exp=%b",
-                 k, ra32, rb32, result[0], fflags[FP_FFLAG_NV], ref_flt, exp_nv_lt);
+                 k, ra32, rb32, result[0], fflags[kronos_pkg::FP_FFLAG_NV], ref_flt, exp_nv_lt);
           rand_errors++;
         end
 
         // --- FLE.S ---
         apply(FP_FLE, 1'b0, {32'hFFFF_FFFF, ra32}, {32'hFFFF_FFFF, rb32});
         rand_total++;
-        if (result[0] !== ref_fle || (fflags[FP_FFLAG_NV] !== exp_nv_le)) begin
+        if (result[0] !== ref_fle || (fflags[kronos_pkg::FP_FFLAG_NV] !== exp_nv_le)) begin
           $error("[FLE.S rand %0d] a=%h b=%h dut=%b/%b ref=%b nv_exp=%b",
-                 k, ra32, rb32, result[0], fflags[FP_FFLAG_NV], ref_fle, exp_nv_le);
+                 k, ra32, rb32, result[0], fflags[kronos_pkg::FP_FFLAG_NV], ref_fle, exp_nv_le);
           rand_errors++;
         end
 
         // --- FMIN.S --- (NaN inputs are now tested, not skipped)
         apply(FP_FMIN, 1'b0, {32'hFFFF_FFFF, ra32}, {32'hFFFF_FFFF, rb32});
         rand_total++;
-        if (result[31:0] !== ref_fmin || (fflags[FP_FFLAG_NV] !== exp_nv_min)) begin
+        if (result[31:0] !== ref_fmin || (fflags[kronos_pkg::FP_FFLAG_NV] !== exp_nv_min)) begin
           $error("[FMIN.S rand %0d] a=%h b=%h dut=%h/%b ref=%h nv_exp=%b",
-                 k, ra32, rb32, result[31:0], fflags[FP_FFLAG_NV], ref_fmin, exp_nv_min);
+                 k, ra32, rb32, result[31:0], fflags[kronos_pkg::FP_FFLAG_NV], ref_fmin, exp_nv_min);
           rand_errors++;
         end
 
         // --- FMAX.S --- (NaN inputs are now tested, not skipped)
         apply(FP_FMAX, 1'b0, {32'hFFFF_FFFF, ra32}, {32'hFFFF_FFFF, rb32});
         rand_total++;
-        if (result[31:0] !== ref_fmax || (fflags[FP_FFLAG_NV] !== exp_nv_max)) begin
+        if (result[31:0] !== ref_fmax || (fflags[kronos_pkg::FP_FFLAG_NV] !== exp_nv_max)) begin
           $error("[FMAX.S rand %0d] a=%h b=%h dut=%h/%b ref=%h nv_exp=%b",
-                 k, ra32, rb32, result[31:0], fflags[FP_FFLAG_NV], ref_fmax, exp_nv_max);
+                 k, ra32, rb32, result[31:0], fflags[kronos_pkg::FP_FFLAG_NV], ref_fmax, exp_nv_max);
           rand_errors++;
         end
       end

--- a/tb/stage5/tb_pkg_fp.sv
+++ b/tb/stage5/tb_pkg_fp.sv
@@ -18,11 +18,11 @@ module tb_pkg_fp;
     op           = FP_FADD;
     rm           = FP_RM_RNE;
     tag          = '{rd: 5'd3, fp_dest: 1'b1};
-    canon_qnan_d = FP_CANON_QNAN_D;
-    canon_qnan_s = FP_CANON_QNAN_S;
+    canon_qnan_d = kronos_pkg::FP_CANON_QNAN_D;
+    canon_qnan_s = kronos_pkg::FP_CANON_QNAN_S;
     $display("pkg_fp ok: op=%0d rm=%0d rd=%0d fp=%b qnan_s=%h qnan_d=%h",
              op, rm, tag.rd, tag.fp_dest, canon_qnan_s, canon_qnan_d);
-    if (WB_TAG_W != 5) $fatal(1, "WB_TAG_W must be 5 in Stage 5a");
+    if (kronos_pkg::WB_TAG_W != 5) $fatal(1, "kronos_pkg::WB_TAG_W must be 5 in Stage 5a");
     $finish;
   end
 endmodule

--- a/tb/stage6/tb_dcache_pma.sv
+++ b/tb/stage6/tb_dcache_pma.sv
@@ -274,9 +274,9 @@ module tb_dcache_pma
     end
   endtask
 
-  // ---- Case 1: LB at MMIO_BASE + 8 --------------------------------------
+  // ---- Case 1: LB at kronos_pkg::MMIO_BASE + 8 --------------------------------------
   task automatic test_nc_lb_at_0x4000_0008();
-    drv_load(MMIO_BASE + 64'h8, 3'd0);
+    drv_load(kronos_pkg::MMIO_BASE + 64'h8, 3'd0);
     check(last_ar_size  == 3'd0, "case 1: ar.size != 0");
     check(last_ar_len   == 8'd0, "case 1: ar.len != 0");
     check(last_ar_burst == 2'b01, "case 1: ar.burst != INCR");
@@ -284,33 +284,33 @@ module tb_dcache_pma
     check(ar_beat_count == 1,    "case 1: beat count != 1");
   endtask
 
-  // ---- Case 2: LH at MMIO_BASE + 0x10 -----------------------------------
+  // ---- Case 2: LH at kronos_pkg::MMIO_BASE + 0x10 -----------------------------------
   task automatic test_nc_lh_at_0x4000_0010();
-    drv_load(MMIO_BASE + 64'h10, 3'd1);
+    drv_load(kronos_pkg::MMIO_BASE + 64'h10, 3'd1);
     check(last_ar_size  == 3'd1, "case 2: ar.size != 1");
     check(last_ar_len   == 8'd0, "case 2: ar.len != 0");
     check(ar_beat_count == 1,    "case 2: beat count != 1");
   endtask
 
-  // ---- Case 3: LW at MMIO_BASE + 0x1_0000 -------------------------------
+  // ---- Case 3: LW at kronos_pkg::MMIO_BASE + 0x1_0000 -------------------------------
   task automatic test_nc_lw_at_0x4001_0000();
-    drv_load(MMIO_BASE + 64'h1_0000, 3'd2);
+    drv_load(kronos_pkg::MMIO_BASE + 64'h1_0000, 3'd2);
     check(last_ar_size  == 3'd2, "case 3: ar.size != 2");
     check(last_ar_len   == 8'd0, "case 3: ar.len != 0");
     check(ar_beat_count == 1,    "case 3: beat count != 1");
   endtask
 
-  // ---- Case 4: LD at MMIO_BASE + 0x20 -----------------------------------
+  // ---- Case 4: LD at kronos_pkg::MMIO_BASE + 0x20 -----------------------------------
   task automatic test_nc_ld_at_0x4000_0020();
-    drv_load(MMIO_BASE + 64'h20, 3'd3);
+    drv_load(kronos_pkg::MMIO_BASE + 64'h20, 3'd3);
     check(last_ar_size  == 3'd3, "case 4: ar.size != 3");
     check(last_ar_len   == 8'd0, "case 4: ar.len != 0");
     check(ar_beat_count == 1,    "case 4: beat count != 1");
   endtask
 
-  // ---- Case 5: SB at MMIO_BASE + 1 --------------------------------------
+  // ---- Case 5: SB at kronos_pkg::MMIO_BASE + 1 --------------------------------------
   task automatic test_nc_sb_at_0x4000_0001();
-    drv_store(MMIO_BASE + 64'h1, 3'd0, 64'h0000_0000_0000_00AB);
+    drv_store(kronos_pkg::MMIO_BASE + 64'h1, 3'd0, 64'h0000_0000_0000_00AB);
     check(last_aw_size  == 3'd0,        "case 5: aw.size != 0");
     check(last_aw_len   == 8'd0,        "case 5: aw.len != 0");
     check(last_aw_burst == 2'b01,       "case 5: aw.burst != INCR");
@@ -319,18 +319,18 @@ module tb_dcache_pma
     check(aw_beat_count == 1,           "case 5: beat count != 1");
   endtask
 
-  // ---- Case 6: SW at MMIO_BASE + 0x1_0004 -------------------------------
+  // ---- Case 6: SW at kronos_pkg::MMIO_BASE + 0x1_0004 -------------------------------
   task automatic test_nc_sw_at_0x4001_0004();
-    drv_store(MMIO_BASE + 64'h1_0004, 3'd2, 64'hDEAD_BEEF_CAFE_BABE);
+    drv_store(kronos_pkg::MMIO_BASE + 64'h1_0004, 3'd2, 64'hDEAD_BEEF_CAFE_BABE);
     check(last_aw_size  == 3'd2,        "case 6: aw.size != 2");
     check(last_aw_len   == 8'd0,        "case 6: aw.len != 0");
     check(last_w_strb   == 8'b1111_0000, "case 6: w.strb wrong");
     check(aw_beat_count == 1,           "case 6: beat count != 1");
   endtask
 
-  // ---- Case 7: SD at MMIO_BASE + 0x30 -----------------------------------
+  // ---- Case 7: SD at kronos_pkg::MMIO_BASE + 0x30 -----------------------------------
   task automatic test_nc_sd_at_0x4000_0030();
-    drv_store(MMIO_BASE + 64'h30, 3'd3, 64'h0123_4567_89AB_CDEF);
+    drv_store(kronos_pkg::MMIO_BASE + 64'h30, 3'd3, 64'h0123_4567_89AB_CDEF);
     check(last_aw_size  == 3'd3,        "case 7: aw.size != 3");
     check(last_aw_len   == 8'd0,        "case 7: aw.len != 0");
     check(last_w_strb   == 8'hFF,       "case 7: w.strb != 0xFF");
@@ -350,7 +350,7 @@ module tb_dcache_pma
     check(ar_beat_count == 8,           "case 8: refill beat count != 8");
   endtask
 
-  // ---- Case 9: LR.W at MMIO_BASE -- expect amo_nc_fault, no AXI --------
+  // ---- Case 9: LR.W at kronos_pkg::MMIO_BASE -- expect amo_nc_fault, no AXI --------
   task automatic test_lr_on_nc();
     int saw_fault = 0;
     int saw_axi   = 0;
@@ -361,13 +361,13 @@ module tb_dcache_pma
       begin
         repeat (8) begin @(posedge clk_i); if (axi_req.ar_valid) saw_axi = 1; end
       end
-      drv_amo(MMIO_BASE, 5'b00010);     // LR
+      drv_amo(kronos_pkg::MMIO_BASE, 5'b00010);     // LR
     join
     check(saw_fault == 1, "case 9: amo_nc_fault not asserted");
     check(saw_axi   == 0, "case 9: AXI AR fired on NC LR (must not)");
   endtask
 
-  // ---- Case 10: AMOSWAP.W at MMIO_BASE -- expect amo_nc_fault ----------
+  // ---- Case 10: AMOSWAP.W at kronos_pkg::MMIO_BASE -- expect amo_nc_fault ----------
   task automatic test_amoswap_on_nc();
     int saw_fault = 0;
     int saw_axi   = 0;
@@ -378,7 +378,7 @@ module tb_dcache_pma
       begin
         repeat (8) begin @(posedge clk_i); if (axi_req.ar_valid) saw_axi = 1; end
       end
-      drv_amo(MMIO_BASE, 5'b00001);     // AMOSWAP
+      drv_amo(kronos_pkg::MMIO_BASE, 5'b00001);     // AMOSWAP
     join
     check(saw_fault == 1, "case 10: amo_nc_fault not asserted");
     check(saw_axi   == 0, "case 10: AXI AR fired on NC AMOSWAP (must not)");
@@ -386,7 +386,7 @@ module tb_dcache_pma
 
   // ---- Case 11: LW at 0x4FFF_FFFC (boundary, in NC range) --------------
   task automatic test_nc_lw_at_boundary_inside();
-    drv_load(MMIO_BASE + 64'hFFF_FFFC, 3'd2);
+    drv_load(kronos_pkg::MMIO_BASE + 64'hFFF_FFFC, 3'd2);
     check(last_ar_len   == 8'd0,        "case 11: ar.len != 0 (in-range)");
     check(last_ar_burst == 2'b01,       "case 11: ar.burst != INCR");
   endtask
@@ -403,8 +403,8 @@ module tb_dcache_pma
 
   // ---- Case 13: NC store then NC load -- back-to-back ------------------
   task automatic test_nc_back_to_back();
-    drv_store(MMIO_BASE + 64'h1_0010, 3'd2, 64'h0000_0000_DEAD_BEEF);
-    drv_load (MMIO_BASE + 64'h1_0010, 3'd2);
+    drv_store(kronos_pkg::MMIO_BASE + 64'h1_0010, 3'd2, 64'h0000_0000_DEAD_BEEF);
+    drv_load (kronos_pkg::MMIO_BASE + 64'h1_0010, 3'd2);
     // The most recent transaction was the load → AR shape captured.
     check(last_ar_len   == 8'd0,        "case 13: ar.len != 0");
     check(last_ar_burst == 2'b01,       "case 13: ar.burst != INCR");
@@ -414,7 +414,7 @@ module tb_dcache_pma
 
   // ---- Case 14: NC store then cacheable load — no cross-pollination ----
   task automatic test_nc_then_cacheable();
-    drv_store(MMIO_BASE + 64'h1_0020, 3'd2, 64'hCAFE_BABE_0000_0000);
+    drv_store(kronos_pkg::MMIO_BASE + 64'h1_0020, 3'd2, 64'hCAFE_BABE_0000_0000);
     for (int b = 0; b < 8; b++) mem[29'h1000_0010 + 29'(b)] = 64'hFEED_FACE_DEAD_BEEF;
     drv_load (64'h8000_0080, 3'd2);
     // CWF fires data_valid on beat 0; wait for full refill before checking burst shape.

--- a/tb/stage6/tb_priv_csr.sv
+++ b/tb/stage6/tb_priv_csr.sv
@@ -26,9 +26,9 @@ module tb_priv_csr;
   localparam logic [11:0] CSR_CYCLE   = 12'hC00;
 
   // Mask of bits we expect to remain set after writing all-ones to mideleg.
-  localparam logic [XLEN-1:0] MIDELEG_MASK = 64'h0000_0000_0000_0222;
+  localparam logic [kronos_pkg::XLEN-1:0] MIDELEG_MASK = 64'h0000_0000_0000_0222;
   // Mask of bits expected to remain after writing all-ones to medeleg.
-  localparam logic [XLEN-1:0] MEDELEG_MASK = 64'h0000_0000_0000_B7FF;
+  localparam logic [kronos_pkg::XLEN-1:0] MEDELEG_MASK = 64'h0000_0000_0000_B7FF;
 
   // ------------------------------------------------------------------------
   // Clock / reset
@@ -44,7 +44,7 @@ module tb_priv_csr;
   logic [11:0]     addr_i;
   logic [2:0]      funct3_i;
   logic            use_imm_i;
-  logic [XLEN-1:0] rs1_data_i;
+  logic [kronos_pkg::XLEN-1:0] rs1_data_i;
   logic [4:0]      rs1_addr_i;
   logic            trap_i;
   logic [31:0]     trap_pc_i;
@@ -64,24 +64,24 @@ module tb_priv_csr;
   logic            fp_rd_we_i;
   logic            instret_retire_i;
   logic [31:0]     event_bus_i;
-  logic [XLEN-1:0] trig_csr_rdata_i;
+  logic [kronos_pkg::XLEN-1:0] trig_csr_rdata_i;
   logic            trig_csr_match_i;
 
   // ------------------------------------------------------------------------
   // DUT outputs
   // ------------------------------------------------------------------------
-  logic [XLEN-1:0]  rdata_o;
+  logic [kronos_pkg::XLEN-1:0]  rdata_o;
   logic             valid_o;
-  logic [XLEN-1:0]  trap_vector_o;
-  logic [XLEN-1:0]  mepc_o;
-  logic [XLEN-1:0]  sepc_o;
+  logic [kronos_pkg::XLEN-1:0]  trap_vector_o;
+  logic [kronos_pkg::XLEN-1:0]  mepc_o;
+  logic [kronos_pkg::XLEN-1:0]  sepc_o;
   priv_e            priv_o;
-  logic [XLEN-1:0]  mstatus_o;
+  logic [kronos_pkg::XLEN-1:0]  mstatus_o;
   logic             irq_pending_o;
   logic [4:0]       irq_cause_o;
   logic [2:0]       frm_o;
   logic             trig_csr_we_o;
-  logic [XLEN-1:0]  trig_csr_wdata_o;
+  logic [kronos_pkg::XLEN-1:0]  trig_csr_wdata_o;
   logic             csr_illegal_o;
   logic [7:0][7:0]  pmpcfg_o;
   logic [7:0][53:0] pmpaddr_o;
@@ -90,7 +90,7 @@ module tb_priv_csr;
   // Stimulus state (mid-module declarations forbidden — declared up front)
   // ------------------------------------------------------------------------
   int              fail_count;
-  logic [XLEN-1:0] v;
+  logic [kronos_pkg::XLEN-1:0] v;
   logic            illegal;
 
   // ------------------------------------------------------------------------
@@ -163,7 +163,7 @@ module tb_priv_csr;
   // Helper tasks
   // ------------------------------------------------------------------------
   // CSRRW — write `v` to CSR `a` (rs1_addr=1 so write fires).
-  task automatic csr_write(input logic [11:0] a, input logic [XLEN-1:0] v);
+  task automatic csr_write(input logic [11:0] a, input logic [kronos_pkg::XLEN-1:0] v);
     @(posedge clk);
     addr_i     = a;
     funct3_i   = 3'b001;     // CSRRW
@@ -177,7 +177,7 @@ module tb_priv_csr;
 
   // CSRRS rs1=x0 — read-only.  Returns rdata and same-cycle csr_illegal.
   task automatic csr_read(input  logic [11:0]     a,
-                          output logic [XLEN-1:0] v,
+                          output logic [kronos_pkg::XLEN-1:0] v,
                           output logic            illegal);
     @(posedge clk);
     addr_i     = a;
@@ -271,7 +271,7 @@ module tb_priv_csr;
       $display("FAIL case1: mstatus reset=%h expected 0x1800", v);
       fail_count++;
     end
-    csr_read(CSR_PMPCFG0, v, illegal);
+    csr_read(kronos_pkg::CSR_PMPCFG0, v, illegal);
     if (v !== 64'h0) begin
       $display("FAIL case1: pmpcfg0 reset=%h expected 0", v);
       fail_count++;
@@ -280,13 +280,13 @@ module tb_priv_csr;
     // ----------------------------------------------------------------------
     // Case 2: sstatus mirror — SUM (bit 18)
     // ----------------------------------------------------------------------
-    csr_write(CSR_SSTATUS, 64'h0000_0000_0004_0000);   // sstatus: bit 18
+    csr_write(kronos_pkg::CSR_SSTATUS, 64'h0000_0000_0004_0000);   // sstatus: bit 18
     csr_read (CSR_MSTATUS, v, illegal);
     if (v[18] !== 1'b1) begin
       $display("FAIL case2a: mstatus.SUM not set via sstatus write (mstatus=%h)", v);
       fail_count++;
     end
-    csr_write(CSR_SSTATUS, 64'h0);                     // clear sstatus.SUM
+    csr_write(kronos_pkg::CSR_SSTATUS, 64'h0);                     // clear sstatus.SUM
     csr_read (CSR_MSTATUS, v, illegal);
     if (v[18] !== 1'b0) begin
       $display("FAIL case2b: mstatus.SUM not cleared via sstatus (mstatus=%h)", v);
@@ -296,8 +296,8 @@ module tb_priv_csr;
     // ----------------------------------------------------------------------
     // Case 3: medeleg[11] is hardwired 0
     // ----------------------------------------------------------------------
-    csr_write(CSR_MEDELEG, 64'hFFFF_FFFF_FFFF_FFFF);
-    csr_read (CSR_MEDELEG, v, illegal);
+    csr_write(kronos_pkg::CSR_MEDELEG, 64'hFFFF_FFFF_FFFF_FFFF);
+    csr_read (kronos_pkg::CSR_MEDELEG, v, illegal);
     if (v[11] !== 1'b0) begin
       $display("FAIL case3: medeleg[11] readback=%h expected 0", v[11]);
       fail_count++;
@@ -310,8 +310,8 @@ module tb_priv_csr;
     // ----------------------------------------------------------------------
     // Case 4: mideleg WARL — only bits {1, 5, 9} writable
     // ----------------------------------------------------------------------
-    csr_write(CSR_MIDELEG, 64'hFFFF_FFFF_FFFF_FFFF);
-    csr_read (CSR_MIDELEG, v, illegal);
+    csr_write(kronos_pkg::CSR_MIDELEG, 64'hFFFF_FFFF_FFFF_FFFF);
+    csr_read (kronos_pkg::CSR_MIDELEG, v, illegal);
     if (v !== MIDELEG_MASK) begin
       $display("FAIL case4: mideleg readback=%h expected %h", v, MIDELEG_MASK);
       fail_count++;
@@ -325,15 +325,15 @@ module tb_priv_csr;
     // Case 5: pmpcfg.A=01 (TOR) collapses to A=00 (OFF); A=11 (NAPOT) preserved
     // ----------------------------------------------------------------------
     // First write NAPOT (A=11) — must be preserved.
-    csr_write(CSR_PMPCFG0, 64'h0000_0000_0000_0018);
-    csr_read (CSR_PMPCFG0, v, illegal);
+    csr_write(kronos_pkg::CSR_PMPCFG0, 64'h0000_0000_0000_0018);
+    csr_read (kronos_pkg::CSR_PMPCFG0, v, illegal);
     if (v[7:0] !== 8'h18) begin
       $display("FAIL case5a: pmpcfg0[byte0] NAPOT readback=%h expected 0x18", v[7:0]);
       fail_count++;
     end
     // Now write TOR (A=01) — must collapse to OFF (A=00 → byte=0x00).
-    csr_write(CSR_PMPCFG0, 64'h0000_0000_0000_0008);
-    csr_read (CSR_PMPCFG0, v, illegal);
+    csr_write(kronos_pkg::CSR_PMPCFG0, 64'h0000_0000_0000_0008);
+    csr_read (kronos_pkg::CSR_PMPCFG0, v, illegal);
     if (v[7:0] !== 8'h00) begin
       $display("FAIL case5b: pmpcfg0[byte0] TOR collapse readback=%h expected 0x00", v[7:0]);
       fail_count++;
@@ -342,14 +342,14 @@ module tb_priv_csr;
     // ----------------------------------------------------------------------
     // Case 6: pmpcfg lock — L=1 prevents subsequent writes to that byte
     // ----------------------------------------------------------------------
-    csr_write(CSR_PMPCFG0, 64'h0000_0000_0000_0080);   // L=1
-    csr_read (CSR_PMPCFG0, v, illegal);
+    csr_write(kronos_pkg::CSR_PMPCFG0, 64'h0000_0000_0000_0080);   // L=1
+    csr_read (kronos_pkg::CSR_PMPCFG0, v, illegal);
     if (v[7:0] !== 8'h80) begin
       $display("FAIL case6a: pmpcfg0[byte0] lock-set readback=%h expected 0x80", v[7:0]);
       fail_count++;
     end
-    csr_write(CSR_PMPCFG0, 64'h0000_0000_0000_0018);   // try NAPOT — locked!
-    csr_read (CSR_PMPCFG0, v, illegal);
+    csr_write(kronos_pkg::CSR_PMPCFG0, 64'h0000_0000_0000_0018);   // try NAPOT — locked!
+    csr_read (kronos_pkg::CSR_PMPCFG0, v, illegal);
     if (v[7:0] !== 8'h80) begin
       $display("FAIL case6b: pmpcfg0[byte0] lock-honour readback=%h expected 0x80", v[7:0]);
       fail_count++;
@@ -374,7 +374,7 @@ module tb_priv_csr;
     // Case 8: sret transition — already in S; SPP=U → priv=U
     // ----------------------------------------------------------------------
     // sstatus mask exposes SPP (bit 8); writing 0 to sstatus clears SPP.
-    csr_write(CSR_SSTATUS, 64'h0);                     // sstatus.SPP = 0
+    csr_write(kronos_pkg::CSR_SSTATUS, 64'h0);                     // sstatus.SPP = 0
     pulse_sret;
     if (priv_o !== PRIV_U) begin
       $display("FAIL case8: post-sret priv_o=%h expected PRIV_U", priv_o);
@@ -404,8 +404,8 @@ module tb_priv_csr;
     rst_n = 1'b1;
     repeat (2) @(posedge clk);
 
-    csr_write(CSR_MCOUNTEREN, 64'h0000_0000_0000_0001);   // mcounteren[0]=1
-    csr_write(CSR_SCOUNTEREN, 64'h0000_0000_0000_0001);   // scounteren[0]=1
+    csr_write(kronos_pkg::CSR_MCOUNTEREN, 64'h0000_0000_0000_0001);   // mcounteren[0]=1
+    csr_write(kronos_pkg::CSR_SCOUNTEREN, 64'h0000_0000_0000_0001);   // scounteren[0]=1
     drop_to_u;
     csr_read(CSR_CYCLE, v, illegal);
     if (illegal !== 1'b0) begin

--- a/tb/stage6/tb_ptw.sv
+++ b/tb/stage6/tb_ptw.sv
@@ -59,7 +59,7 @@ module tb_ptw;
   logic        force_sc_fail;
 
   // Memory model storage and busy flop.
-  bit [XLEN-1:0] mem [logic [55:0]];
+  bit [kronos_pkg::XLEN-1:0] mem [logic [55:0]];
   logic          dc_busy_q;  // 1 = response delivered for current req pulse
 
   // Test bookkeeping and per-test scratch (declared module-top per coding
@@ -169,7 +169,7 @@ module tb_ptw;
     miss_priv     = PRIV_S;
     sum_in        = 1'b0;
     mxr_in        = 1'b0;
-    satp_mode     = SATP_MODE_SV39;
+    satp_mode     = kronos_pkg::SATP_MODE_SV39;
     satp_asid     = 16'd1;
     satp_ppn      = 44'h0_0001_0000;  // root table at PA 0x0001_0000_0000_0000
   endtask
@@ -293,7 +293,7 @@ module tb_ptw;
     // L2 (lvl-1)  PPN = 0x0_0030_0000;
     // L3 (lvl-0)  PPN = 0x0_0040_0000.
     // ----------------------------------------------------------------------
-    satp_mode = SATP_MODE_SV48;
+    satp_mode = kronos_pkg::SATP_MODE_SV48;
 
     // root[1] (Sv48 lvl-3, VPN[3]=1) → pointer to L1 table.
     set_pte(56'h00_0000_1000_0008, mk_pointer(44'h0_0020_0000));
@@ -313,7 +313,7 @@ module tb_ptw;
     repeat (4) @(posedge clk);
 
     // Switch back to Sv39 for remaining tests.
-    satp_mode = SATP_MODE_SV39;
+    satp_mode = kronos_pkg::SATP_MODE_SV39;
 
     // ----------------------------------------------------------------------
     // Test 5 — Invalid PTE (V=0)
@@ -323,7 +323,7 @@ module tb_ptw;
     kick_load_miss(64'h0000_0000_C000_0000);  // VPN[2]=3
     wait_done(refilled, faulted);
     check("T5 invalid PTE -> page-fault", faulted & ~refilled);
-    check("T5 cause = LOAD_PAGE_FAULT",   pf_cause == CAUSE_LOAD_PAGE_FAULT);
+    check("T5 cause = LOAD_PAGE_FAULT",   pf_cause == kronos_pkg::CAUSE_LOAD_PAGE_FAULT);
     check("T5 tval = original VA",        pf_tval == 64'h0000_0000_C000_0000);
     check("T5 which = TLB_LOAD",          pf_which == TLB_LOAD);
     repeat (4) @(posedge clk);
@@ -338,7 +338,7 @@ module tb_ptw;
     kick_load_miss(64'h0000_0001_0000_0000);  // VPN[2]=4
     wait_done(refilled, faulted);
     check("T6 reserved enc -> page-fault", faulted & ~refilled);
-    check("T6 cause = LOAD_PAGE_FAULT",    pf_cause == CAUSE_LOAD_PAGE_FAULT);
+    check("T6 cause = LOAD_PAGE_FAULT",    pf_cause == kronos_pkg::CAUSE_LOAD_PAGE_FAULT);
     repeat (4) @(posedge clk);
 
     // ----------------------------------------------------------------------
@@ -353,7 +353,7 @@ module tb_ptw;
     kick_load_miss(64'h0000_0001_4000_0000);  // VPN[2]=5, VPN[1]=0
     wait_done(refilled, faulted);
     check("T7 misaligned superpage -> page-fault", faulted & ~refilled);
-    check("T7 cause = LOAD_PAGE_FAULT", pf_cause == CAUSE_LOAD_PAGE_FAULT);
+    check("T7 cause = LOAD_PAGE_FAULT", pf_cause == kronos_pkg::CAUSE_LOAD_PAGE_FAULT);
     repeat (4) @(posedge clk);
 
     // ----------------------------------------------------------------------
@@ -370,7 +370,7 @@ module tb_ptw;
     kick_load_miss(64'h0000_0001_8000_0000);  // VPN[2]=6
     wait_done(refilled, faulted);
     check("T8 U-page in S w/o SUM -> page-fault", faulted & ~refilled);
-    check("T8 cause = LOAD_PAGE_FAULT", pf_cause == CAUSE_LOAD_PAGE_FAULT);
+    check("T8 cause = LOAD_PAGE_FAULT", pf_cause == kronos_pkg::CAUSE_LOAD_PAGE_FAULT);
     repeat (4) @(posedge clk);
 
     // ----------------------------------------------------------------------
@@ -384,13 +384,13 @@ module tb_ptw;
     set_pte(leaf_addr,
             mk_leaf(44'h0_00CA_FE00, 4'b0_011, 1'b0, 1'b0, 1'b0));
     before_pte = mem[leaf_addr];
-    check("T9 leaf A=0 before walk", ((before_pte >> PTE_A_BIT) & 64'd1) == 64'd0);
+    check("T9 leaf A=0 before walk", ((before_pte >> kronos_pkg::PTE_A_BIT) & 64'd1) == 64'd0);
 
     kick_load_miss(64'h0000_0001_C000_0000);  // VPN[2]=7
     wait_done(refilled, faulted);
     check("T9 A-set walk refilled",     refilled & ~faulted);
     check("T9 A=1 in mem after SC",
-          ((mem[leaf_addr] >> PTE_A_BIT) & 64'd1) == 64'd1);
+          ((mem[leaf_addr] >> kronos_pkg::PTE_A_BIT) & 64'd1) == 64'd1);
     check("T9 PPN preserved",
           mem[leaf_addr][53:10] == 44'h0_00CA_FE00);
     check("T9 PPN refilled",            rf_ppn == 44'h0_00CA_FE00);
@@ -444,7 +444,7 @@ module tb_ptw;
     check("T10 SC-fail retry refilled", refilled & ~faulted);
     check("T10 PPN refilled",           rf_ppn == 44'h0_00DE_A000);
     check("T10 A=1 in mem",
-          ((mem[leaf_addr] >> PTE_A_BIT) & 64'd1) == 64'd1);
+          ((mem[leaf_addr] >> kronos_pkg::PTE_A_BIT) & 64'd1) == 64'd1);
     check("T10 saw an SC-fail event",   sc_seen == 1);
     repeat (4) @(posedge clk);
 

--- a/tb/stage6/tb_tlb.sv
+++ b/tb/stage6/tb_tlb.sv
@@ -13,7 +13,7 @@ module tb_tlb;
 
   // Lookup
   logic            lookup_valid;
-  logic [XLEN-1:0] lookup_va;
+  logic [kronos_pkg::XLEN-1:0] lookup_va;
   logic [15:0]     lookup_asid;
   priv_e           lookup_priv;
   logic            is_load, is_store, is_fetch;
@@ -35,7 +35,7 @@ module tb_tlb;
   // sfence
   logic            flush_valid;
   logic            flush_va_valid, flush_asid_valid;
-  logic [XLEN-1:0] flush_va;
+  logic [kronos_pkg::XLEN-1:0] flush_va;
   logic [15:0]     flush_asid;
 
   // Error counter
@@ -78,7 +78,7 @@ module tb_tlb;
 
   task automatic clear_inputs;
     lookup_valid     = 1'b0;
-    lookup_va        = {XLEN{1'b0}};
+    lookup_va        = {kronos_pkg::XLEN{1'b0}};
     lookup_asid      = 16'h0;
     lookup_priv      = PRIV_M;
     is_load          = 1'b0;
@@ -98,7 +98,7 @@ module tb_tlb;
     flush_valid      = 1'b0;
     flush_va_valid   = 1'b0;
     flush_asid_valid = 1'b0;
-    flush_va         = {XLEN{1'b0}};
+    flush_va         = {kronos_pkg::XLEN{1'b0}};
     flush_asid       = 16'h0;
   endtask
 
@@ -124,7 +124,7 @@ module tb_tlb;
     refill_valid = 1'b0;
   endtask
 
-  task automatic do_lookup(input logic [XLEN-1:0] va,
+  task automatic do_lookup(input logic [kronos_pkg::XLEN-1:0] va,
                            input logic [15:0]     aid,
                            input priv_e           p,
                            input logic            isf,
@@ -155,7 +155,7 @@ module tb_tlb;
 
   task automatic do_flush(input logic            va_v,
                           input logic            aid_v,
-                          input logic [XLEN-1:0] va,
+                          input logic [kronos_pkg::XLEN-1:0] va,
                           input logic [15:0]     aid);
     @(posedge clk);
     flush_valid      = 1'b1;


### PR DESCRIPTION
## Summary

Reference all `localparam` / `parameter` constants from `kronos_pkg` with the explicit `kronos_pkg::NAME` scope operator at every use site. Types and enum members stay bare via the existing `import kronos_pkg::*;`.

**Why:** the wildcard import hides constants' source from VSCode's SystemVerilog LSP, so hovering on `XLEN` shows nothing. Scoped names give the LSP an explicit lookup target — hover and go-to-definition resolve correctly.

**Scope split:**
- **Scoped (`kronos_pkg::NAME`):** `localparam` / `parameter` constants — `XLEN`, `FLEN`, `MMIO_BASE`, `DECODED_INSTR_ZERO`, `EVT_*`, `CSR_*`, `CAUSE_*`, `FP_*`, `PTE_*`, `SATP_MODE_*`, `WB_TAG_W`, etc.
- **Bare:** types (`decoded_instr_t`, `alu_op_e`, `id_ex_reg_t`) and enum members (`ALU_ADD`, `FWD_NONE`, `PRIV_M`, `WB_ALU`, `FP_FADD`). The enclosing type provides hover context, and scoping every `case` label would bloat decode tables.

CLAUDE.md `### Packages and Imports` is updated with the new rule plus a worked `kronos_alu` example.

## Test plan

- [x] `make build-s1` … `build-s6` — every stage builds clean under Verilator
- [x] `make sim-all` — full parallel regression PASSES (every unit testbench across every stage, stage 4 compliance, stage 5 integration)
- [x] Pure refactor — diff is exactly 1:1 lexical replacement (1632 deletions matched by 1632 of the 1654 insertions; the +22 delta is the CLAUDE.md rule + example)