### PR TITLE
refactor(decode): BOOM-style per-class sub-decoder split

### DIFF
--- a/kronos_riscv.core
+++ b/kronos_riscv.core
@@ -81,6 +81,11 @@ filesets:
       - rtl/stage3/kronos_bpred.sv
       - rtl/stage6/kronos_alu.sv
       - rtl/stage6/kronos_decode.sv
+      - rtl/stage6/kronos_decode_ctrl.sv
+      - rtl/stage6/kronos_decode_sys.sv
+      - rtl/stage6/kronos_decode_mem.sv
+      - rtl/stage6/kronos_decode_int.sv
+      - rtl/stage6/kronos_decode_fp.sv
       - rtl/stage6/kronos_regfile_fp.sv
       - rtl/stage6/kronos_icache.sv
       - rtl/stage6/kronos_csr.sv

--- a/lint/waivers.vlt
+++ b/lint/waivers.vlt
@@ -51,3 +51,22 @@ lint_off -rule BLKSEQ -file "*/tb/*"
 // (e.g. addRecFN.v). Upstream convention; cannot fix in our tree.
 // ---------------------------------------------------------------------------
 lint_off -rule DECLFILENAME -file "*/vendor/hardfloat/*"
+
+// ---------------------------------------------------------------------------
+// VARHIDDEN — per-stage decoders and decompress modules shadowed by kronos_pkg
+// opcode constants. The 20 RV64IMAFDC opcode localparams (OP, OP_IMM, BRANCH,
+// LOAD, ...) added to kronos_pkg for the stage-6 decoder split are also defined
+// module-locally in the legacy decoders (stages 0/2/4/5) and in every
+// decompress module (stages 3/4/5/6, which build expanded 32-bit encodings
+// from RVC). Values agree (they are the same RISC-V opcode encodings), so the
+// shadowing is a false alarm. Older stages are frozen; the decompress modules
+// could later be refactored to use pkg constants but are out of scope here.
+// ---------------------------------------------------------------------------
+lint_off -rule VARHIDDEN -file "*/rtl/stage0/kronos_decode.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage2/kronos_decode.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage4/kronos_decode.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage5/kronos_decode.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage3/kronos_decompress.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage4/kronos_decompress.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage5/kronos_decompress.sv"
+lint_off -rule VARHIDDEN -file "*/rtl/stage6/kronos_decompress.sv"

--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -30,6 +30,33 @@ package kronos_pkg;
   localparam int unsigned INST_W     = 32;                  // RISC-V base instruction width
 
   // -------------------------------------------------------------------------
+  // RV64IMAFDC opcode constants — referenced by kronos_decode (the wrapper)
+  // and every sub-decoder (kronos_decode_int / _ctrl / _mem / _sys / _fp).
+  // Used inside `unique case` selectors; treat like enum members at use sites
+  // (bare reference, no `kronos_pkg::` prefix needed) for ergonomics.
+  // -------------------------------------------------------------------------
+  localparam logic [6:0] OP         = 7'b011_0011;  // R-type integer ALU
+  localparam logic [6:0] OP_IMM     = 7'b001_0011;  // I-type integer ALU
+  localparam logic [6:0] OP_IMM_32  = 7'b001_1011;  // RV64 I-type ALU-W
+  localparam logic [6:0] OP_32      = 7'b011_1011;  // RV64 R-type ALU-W
+  localparam logic [6:0] LOAD       = 7'b000_0011;
+  localparam logic [6:0] STORE      = 7'b010_0011;
+  localparam logic [6:0] LOAD_FP    = 7'b000_0111;
+  localparam logic [6:0] STORE_FP   = 7'b010_0111;
+  localparam logic [6:0] OP_FP      = 7'b101_0011;
+  localparam logic [6:0] FMADD_OP   = 7'b100_0011;
+  localparam logic [6:0] FMSUB_OP   = 7'b100_0111;
+  localparam logic [6:0] FNMSUB_OP  = 7'b100_1011;
+  localparam logic [6:0] FNMADD_OP  = 7'b100_1111;
+  localparam logic [6:0] BRANCH     = 7'b110_0011;
+  localparam logic [6:0] LUI        = 7'b011_0111;
+  localparam logic [6:0] AUIPC      = 7'b001_0111;
+  localparam logic [6:0] JAL        = 7'b110_1111;
+  localparam logic [6:0] JALR       = 7'b110_0111;
+  localparam logic [6:0] SYSTEM     = 7'b111_0011;
+  localparam logic [6:0] AMO        = 7'b010_1111;
+
+  // -------------------------------------------------------------------------
   // Floating-point widths and biases (IEEE-754 binary32 / binary64)
   // -------------------------------------------------------------------------
   localparam int unsigned FLEN          = 64;
@@ -154,6 +181,18 @@ package kronos_pkg;
     // FMA
     FP_FMADD, FP_FMSUB, FP_FNMADD, FP_FNMSUB
   } fp_op_e;
+
+  // FP rm-field helpers — used by kronos_decode_fp.
+  // resolve_rm: substitute FRM (FCSR.frm) when the instruction-encoded rm
+  // field is DYN (3'b111). rm_is_illegal: true for the two reserved encodings.
+  function automatic logic [2:0] resolve_rm(input logic [2:0] rm_in,
+                                            input logic [2:0] frm);
+    return (rm_in == 3'b111) ? frm : rm_in;
+  endfunction
+
+  function automatic logic rm_is_illegal(input logic [2:0] rm);
+    return (rm == 3'b101) || (rm == 3'b110);
+  endfunction
 
   // Decoded instruction — output of kronos_decode
   typedef struct packed {

--- a/rtl/stage6/kronos_decode.sv
+++ b/rtl/stage6/kronos_decode.sv
@@ -2,595 +2,97 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// kronos_decode.sv (stage5) — RV64IMAFDC instruction decoder.
-// Extends the stage4 RV64IMAC decoder with:
-//   - LOAD-FP  (0x07): FLW, FLD
-//   - STORE-FP (0x27): FSW, FSD
-//   - OP-FP    (0x53): FADD/FSUB/FMUL, FSGNJ*, FMIN/FMAX, FEQ/FLT/FLE,
-//                      FCVT.*, FMV.*, FCLASS
-//   - FMADD/FMSUB/FNMSUB/FNMADD (0x43/0x47/0x4B/0x4F)
-//   - rm field resolution (dynamic FRM) + illegal-rm trap
-// illegal_insn_o is asserted for any instruction that cannot be executed;
-// the illegal flag is also mirrored into decoded_o.illegal for pipeline use.
+// kronos_decode.sv (stage6) — RV64IMAFDC instruction-decode dispatch wrapper.
+// Instantiates five per-class sub-decoders and dispatches by opcode[6:0].
+// Each sub-decoder owns its class's funct3/funct7-level decoding + per-class
+// illegal-encoding checks. The wrapper owns the "no class matched" illegal.
+
 module kronos_decode
   import kronos_pkg::*;
 (
   input  logic [kronos_pkg::INST_W-1:0] instr_i,
-  input  logic [2:0]        frm_i,        // current FRM from FCSR (for dynamic rm)
-  output decoded_instr_t    decoded_o,
-  output logic              illegal_insn_o
+  input  logic [2:0]                    frm_i,
+  output decoded_instr_t                decoded_o,
+  output logic                          illegal_insn_o
 );
 
-  // 1. Constants — opcode encodings
-  localparam logic [6:0] OP         = 7'b011_0011; // R-type
-  localparam logic [6:0] OP_IMM     = 7'b001_0011; // I-type ALU
-  localparam logic [6:0] OP_IMM_32  = 7'b001_1011; // RV64 I-type ALU-W
-  localparam logic [6:0] OP_32      = 7'b011_1011; // RV64 R-type ALU-W
-  localparam logic [6:0] LOAD       = 7'b000_0011;
-  localparam logic [6:0] STORE      = 7'b010_0011;
-  localparam logic [6:0] LOAD_FP    = 7'b000_0111;
-  localparam logic [6:0] STORE_FP   = 7'b010_0111;
-  localparam logic [6:0] OP_FP      = 7'b101_0011;
-  localparam logic [6:0] FMADD_OP   = 7'b100_0011;
-  localparam logic [6:0] FMSUB_OP   = 7'b100_0111;
-  localparam logic [6:0] FNMSUB_OP  = 7'b100_1011;
-  localparam logic [6:0] FNMADD_OP  = 7'b100_1111;
-  localparam logic [6:0] BRANCH     = 7'b110_0011;
-  localparam logic [6:0] LUI        = 7'b011_0111;
-  localparam logic [6:0] AUIPC      = 7'b001_0111;
-  localparam logic [6:0] JAL        = 7'b110_1111;
-  localparam logic [6:0] JALR       = 7'b110_0111;
-  localparam logic [6:0] SYSTEM     = 7'b111_0011;
-  localparam logic [6:0] AMO        = 7'b010_1111;
-
-  // 4. Combinational signals — instruction fields
-  logic [6:0] opcode;
-  logic [4:0] rd;
-  logic [2:0] funct3;
-  logic [4:0] rs1;
-  logic [4:0] rs2;
-  logic [6:0] funct7;
-  logic       illegal;
-
-  // Resolves the FP rounding mode field, substituting frm when rm_in=DYN (111).
-  function automatic logic [2:0] resolve_rm(input logic [2:0] rm_in, input logic [2:0] frm);
-    return (rm_in == 3'b111) ? frm : rm_in;
-  endfunction
-  function automatic logic rm_is_illegal(input logic [2:0] rm);
-    return (rm == 3'b101) || (rm == 3'b110);
-  endfunction
+  logic [6:0]      opcode;
+  decoded_instr_t  int_decoded;
+  decoded_instr_t  ctrl_decoded;
+  decoded_instr_t  mem_decoded;
+  decoded_instr_t  sys_decoded;
+  decoded_instr_t  fp_decoded;
+  logic            int_illegal;
+  logic            ctrl_illegal;
+  logic            mem_illegal;
+  logic            sys_illegal;
+  logic            fp_illegal;
 
   assign opcode = instr_i[6:0];
-  assign rd     = instr_i[11:7];
-  assign funct3 = instr_i[14:12];
-  assign rs1    = instr_i[19:15];
-  assign rs2    = instr_i[24:20];
-  assign funct7 = instr_i[31:25];
+
+  kronos_decode_int  u_int  (
+    .instr_i   (instr_i),
+    .decoded_o (int_decoded),
+    .illegal_o (int_illegal)
+  );
+
+  kronos_decode_ctrl u_ctrl (
+    .instr_i   (instr_i),
+    .decoded_o (ctrl_decoded),
+    .illegal_o (ctrl_illegal)
+  );
+
+  kronos_decode_mem  u_mem  (
+    .instr_i   (instr_i),
+    .decoded_o (mem_decoded),
+    .illegal_o (mem_illegal)
+  );
+
+  kronos_decode_sys  u_sys  (
+    .instr_i   (instr_i),
+    .decoded_o (sys_decoded),
+    .illegal_o (sys_illegal)
+  );
+
+  kronos_decode_fp   u_fp   (
+    .instr_i   (instr_i),
+    .frm_i     (frm_i),
+    .decoded_o (fp_decoded),
+    .illegal_o (fp_illegal)
+  );
 
   always_comb begin
-    decoded_o          = kronos_pkg::DECODED_INSTR_ZERO;
-    decoded_o.rs1      = rs1;
-    decoded_o.rs2      = rs2;
-    decoded_o.rd       = rd;
-    illegal            = 1'b0;
+    decoded_o              = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1          = instr_i[19:15];
+    decoded_o.rs2          = instr_i[24:20];
+    decoded_o.rd           = instr_i[11:7];
+    illegal_insn_o         = 1'b1;
 
     unique case (opcode)
-      OP: begin  // R-type: ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND + M-ext
-        decoded_o.rs1_used = 1'b1;
-        decoded_o.rs2_used = 1'b1;
-        decoded_o.rd_wen   = 1'b1;
-        decoded_o.wb_sel   = WB_ALU;
-
-        if (funct7 == 7'b000_0001) begin
-          // M extension: MUL/MULH/MULHSU/MULHU/DIV/DIVU/REM/REMU
-          decoded_o.is_muldiv = 1'b1;
-          decoded_o.muldiv_op = muldiv_op_e'(funct3);
-          decoded_o.use_imm   = 1'b0;
-          decoded_o.alu_op    = ALU_ADD; // don't-care; ALU result is discarded
-        end else begin
-          decoded_o.use_imm = 1'b0;
-          unique case ({funct7, funct3})
-            {7'b000_0000, 3'b000}: decoded_o.alu_op = ALU_ADD;
-            {7'b010_0000, 3'b000}: decoded_o.alu_op = ALU_SUB;
-            {7'b000_0000, 3'b001}: decoded_o.alu_op = ALU_SLL;
-            {7'b000_0000, 3'b010}: decoded_o.alu_op = ALU_SLT;
-            {7'b000_0000, 3'b011}: decoded_o.alu_op = ALU_SLTU;
-            {7'b000_0000, 3'b100}: decoded_o.alu_op = ALU_XOR;
-            {7'b000_0000, 3'b101}: decoded_o.alu_op = ALU_SRL;
-            {7'b010_0000, 3'b101}: decoded_o.alu_op = ALU_SRA;
-            {7'b000_0000, 3'b110}: decoded_o.alu_op = ALU_OR;
-            {7'b000_0000, 3'b111}: decoded_o.alu_op = ALU_AND;
-            default:               illegal = 1'b1;
-          endcase
-        end
+      OP, OP_IMM, OP_IMM_32, OP_32, LUI, AUIPC: begin
+        decoded_o      = int_decoded;
+        illegal_insn_o = int_illegal;
       end
-
-      OP_IMM: begin  // I-type ALU: ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI
-        decoded_o.rs1_used = 1'b1;
-        decoded_o.rd_wen   = 1'b1;
-        decoded_o.use_imm  = 1'b1;
-        decoded_o.wb_sel   = WB_ALU;
-        decoded_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
-        unique case (funct3)
-          3'b000: decoded_o.alu_op = ALU_ADD;   // ADDI
-          3'b010: decoded_o.alu_op = ALU_SLT;   // SLTI
-          3'b011: decoded_o.alu_op = ALU_SLTU;  // SLTIU
-          3'b100: decoded_o.alu_op = ALU_XOR;   // XORI
-          3'b110: decoded_o.alu_op = ALU_OR;    // ORI
-          3'b111: decoded_o.alu_op = ALU_AND;   // ANDI
-          3'b001: begin  // SLLI (6-bit shamt in RV64)
-            decoded_o.alu_op = ALU_SLL;
-            decoded_o.imm    = {26'b0, instr_i[25:20]};
-            if (funct7[6:1] != 6'b000_000) illegal = 1'b1;
-          end
-          3'b101: begin  // SRLI / SRAI (6-bit shamt in RV64)
-            decoded_o.imm = {26'b0, instr_i[25:20]};
-            if      (funct7[6:1] == 6'b000_000) decoded_o.alu_op = ALU_SRL;
-            else if (funct7[6:1] == 6'b010_000) decoded_o.alu_op = ALU_SRA;
-            else                                illegal = 1'b1;
-          end
-          // verilator coverage_off
-          default: illegal = 1'b1;
-          // verilator coverage_on
-        endcase
+      JAL, JALR, BRANCH: begin
+        decoded_o      = ctrl_decoded;
+        illegal_insn_o = ctrl_illegal;
       end
-
-      OP_IMM_32: begin  // ADDIW / SLLIW / SRLIW / SRAIW
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.rd_wen     = 1'b1;
-        decoded_o.use_imm    = 1'b1;
-        decoded_o.wb_sel     = WB_ALU;
-        decoded_o.is_word_op = 1'b1;
-        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
-        unique case (funct3)
-          3'b000: decoded_o.alu_op = ALU_ADD;
-          3'b001: begin  // SLLIW
-            decoded_o.alu_op = ALU_SLL;
-            decoded_o.imm    = {27'b0, instr_i[24:20]};
-            if (funct7 != 7'b000_0000) illegal = 1'b1;
-          end
-          3'b101: begin  // SRLIW / SRAIW
-            decoded_o.imm = {27'b0, instr_i[24:20]};
-            if      (funct7 == 7'b000_0000) decoded_o.alu_op = ALU_SRL;
-            else if (funct7 == 7'b010_0000) decoded_o.alu_op = ALU_SRA;
-            else                            illegal = 1'b1;
-          end
-          default: illegal = 1'b1;
-        endcase
+      LOAD, STORE, LOAD_FP, STORE_FP, AMO: begin
+        decoded_o      = mem_decoded;
+        illegal_insn_o = mem_illegal;
       end
-
-      OP_32: begin  // ADDW / SUBW / SLLW / SRLW / SRAW + MULW/DIVW/DIVUW/REMW/REMUW
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.rs2_used   = 1'b1;
-        decoded_o.rd_wen     = 1'b1;
-        decoded_o.wb_sel     = WB_ALU;
-        decoded_o.is_word_op = 1'b1;
-
-        if (funct7 == 7'b000_0001) begin
-          decoded_o.is_muldiv = 1'b1;
-          decoded_o.muldiv_op = muldiv_op_e'(funct3);
-          decoded_o.use_imm   = 1'b0;
-          decoded_o.alu_op    = ALU_ADD;
-          if (funct3 > 3'b000 && funct3 < 3'b100) illegal = 1'b1;
-        end else begin
-          decoded_o.use_imm = 1'b0;
-          unique case ({funct7, funct3})
-            {7'b000_0000, 3'b000}: decoded_o.alu_op = ALU_ADD;
-            {7'b010_0000, 3'b000}: decoded_o.alu_op = ALU_SUB;
-            {7'b000_0000, 3'b001}: decoded_o.alu_op = ALU_SLL;
-            {7'b000_0000, 3'b101}: decoded_o.alu_op = ALU_SRL;
-            {7'b010_0000, 3'b101}: decoded_o.alu_op = ALU_SRA;
-            default:               illegal = 1'b1;
-          endcase
-        end
-      end
-
-      LUI: begin
-        decoded_o.rd_wen  = 1'b1;
-        decoded_o.use_imm = 1'b1;
-        decoded_o.alu_op  = ALU_PASSB;
-        decoded_o.imm     = {instr_i[31:12], 12'b0};
-        decoded_o.wb_sel  = WB_ALU;
-      end
-
-      AUIPC: begin
-        decoded_o.rd_wen  = 1'b1;
-        decoded_o.use_imm = 1'b1;
-        decoded_o.use_pc  = 1'b1;
-        decoded_o.alu_op  = ALU_ADD;
-        decoded_o.imm     = {instr_i[31:12], 12'b0};
-        decoded_o.wb_sel  = WB_ALU;
-      end
-
-      JAL: begin
-        decoded_o.rd_wen = 1'b1;
-        decoded_o.is_jal = 1'b1;
-        // J-type immediate: imm[20|10:1|11|19:12], bit 0 always 0
-        decoded_o.imm    = {{11{instr_i[31]}}, instr_i[31], instr_i[19:12],
-                            instr_i[20], instr_i[30:21], 1'b0};
-        decoded_o.wb_sel = WB_PC4;
-      end
-
-      JALR: begin
-        decoded_o.rs1_used = 1'b1;
-        decoded_o.rd_wen   = 1'b1;
-        decoded_o.is_jalr  = 1'b1;
-        decoded_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
-        decoded_o.wb_sel   = WB_PC4;
-        if (funct3 != 3'b000) illegal = 1'b1;
-      end
-
-      BRANCH: begin  // BEQ, BNE, BLT, BGE, BLTU, BGEU
-        decoded_o.rs1_used      = 1'b1;
-        decoded_o.rs2_used      = 1'b1;
-        decoded_o.is_branch     = 1'b1;
-        decoded_o.branch_funct3 = funct3;
-        // B-type immediate: imm[12|10:5|4:1|11], bit 0 always 0
-        decoded_o.imm = {{19{instr_i[31]}}, instr_i[31], instr_i[7],
-                         instr_i[30:25], instr_i[11:8], 1'b0};
-        // Drive the ALU's comparator with the right signedness so kronos_top
-        // can consume cmp_lt_o for BLT/BGE/BLTU/BGEU. BEQ/BNE consume eq_o,
-        // which is valid for any subtract-style alu_op.
-        unique case (funct3)
-          3'b100, 3'b101: decoded_o.alu_op = ALU_SLT;   // BLT, BGE
-          3'b110, 3'b111: decoded_o.alu_op = ALU_SLTU;  // BLTU, BGEU
-          default:        decoded_o.alu_op = ALU_SLTU;  // BEQ, BNE — any sub-style op
-        endcase
-        if (funct3 == 3'b010 || funct3 == 3'b011) illegal = 1'b1;
-      end
-
-      LOAD: begin  // LB, LH, LW, LBU, LHU + RV64 LD, LWU
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.rd_wen     = 1'b1;
-        decoded_o.use_imm    = 1'b1;
-        decoded_o.alu_op     = ALU_ADD;
-        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
-        decoded_o.is_load    = 1'b1;
-        decoded_o.mem_funct3 = funct3;
-        decoded_o.wb_sel     = WB_MEM;
-        if (funct3 == 3'b111) illegal = 1'b1; // reserved in RV64
-      end
-
-      STORE: begin  // SB, SH, SW + RV64 SD
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.rs2_used   = 1'b1;
-        decoded_o.use_imm    = 1'b1;
-        decoded_o.alu_op     = ALU_ADD;
-        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
-        decoded_o.is_store   = 1'b1;
-        decoded_o.mem_funct3 = funct3;
-        decoded_o.wb_sel     = WB_ALU;
-        decoded_o.rd_wen     = 1'b0;
-        if (funct3 > 3'b011) illegal = 1'b1; // only SB/SH/SW/SD
-      end
-
-      AMO: begin  // LR.W/D, SC.W/D, AMO*.W/D
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.rd_wen     = 1'b1;
-        decoded_o.wb_sel     = WB_MEM;
-        decoded_o.mem_funct3 = funct3;
-        decoded_o.use_imm    = 1'b1;
-        decoded_o.alu_op     = ALU_ADD;
-        decoded_o.imm        = 32'd0;
-
-        unique case (funct7[6:2])
-          5'b00010: begin
-            decoded_o.is_load = 1'b1;
-            decoded_o.is_lr   = 1'b1;
-          end
-          5'b00011: begin
-            decoded_o.is_store = 1'b1;
-            decoded_o.is_sc    = 1'b1;
-            decoded_o.rs2_used = 1'b1;
-          end
-          default: begin
-            decoded_o.is_amo     = 1'b1;
-            decoded_o.amo_funct5 = funct7[6:2];
-            decoded_o.rs2_used   = 1'b1;
-          end
-        endcase
-
-        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
-      end
-
       SYSTEM: begin
-        unique case (funct3)
-          3'b000: begin  // ECALL, EBREAK, MRET, SRET, SFENCE.VMA, WFI
-            // SFENCE.VMA — funct7 = 0x09 (Stage 6b: real op)
-            if (instr_i[31:25] == 7'b000_1001) begin
-              decoded_o.is_sfence_vma = 1'b1;
-              illegal                 = 1'b0;
-            end else begin
-              unique case (instr_i[31:20])
-                12'h000: decoded_o.is_ecall  = 1'b1;
-                12'h001: decoded_o.is_ebreak = 1'b1;
-                12'h302: decoded_o.is_mret   = 1'b1;
-                12'h102: decoded_o.is_sret   = 1'b1;  // Stage 6a
-                12'h105: decoded_o.is_wfi    = 1'b1;  // Stage 6b
-                default: illegal             = 1'b1;
-              endcase
-            end
-          end
-          default: begin  // CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI
-            decoded_o.is_csr      = 1'b1;
-            decoded_o.rd_wen      = 1'b1;
-            decoded_o.rs1_used    = ~funct3[2]; // funct3[2]=1 means zimm form
-            decoded_o.csr_addr    = instr_i[31:20];
-            decoded_o.csr_funct3  = funct3;
-            decoded_o.csr_use_imm = funct3[2];
-            decoded_o.wb_sel      = WB_CSR;
-          end
-        endcase
+        decoded_o      = sys_decoded;
+        illegal_insn_o = sys_illegal;
       end
-
-      // -----------------------------------------------------------------------
-      // Floating-point instructions
-      // -----------------------------------------------------------------------
-
-      LOAD_FP: begin  // FLW (funct3=010) / FLD (funct3=011)
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.rd_wen     = 1'b1;
-        decoded_o.use_imm    = 1'b1;
-        decoded_o.alu_op     = ALU_ADD;
-        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
-        decoded_o.is_load    = 1'b1;
-        decoded_o.mem_funct3 = funct3;
-        decoded_o.wb_sel     = WB_MEM;
-        decoded_o.is_fp      = 1'b1;
-        decoded_o.fp_load    = 1'b1;
-        decoded_o.rd_fp      = 1'b1;
-        decoded_o.fmt_d      = (funct3 == 3'b011);
-        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      OP_FP, FMADD_OP, FMSUB_OP, FNMSUB_OP, FNMADD_OP: begin
+        decoded_o      = fp_decoded;
+        illegal_insn_o = fp_illegal;
       end
-
-      STORE_FP: begin  // FSW (funct3=010) / FSD (funct3=011)
-        decoded_o.rs1_used   = 1'b1;
-        decoded_o.use_imm    = 1'b1;
-        decoded_o.alu_op     = ALU_ADD;
-        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
-        decoded_o.is_store   = 1'b1;
-        decoded_o.mem_funct3 = funct3;
-        decoded_o.wb_sel     = WB_ALU;
-        decoded_o.rd_wen     = 1'b0;
-        decoded_o.is_fp      = 1'b1;
-        decoded_o.fp_store   = 1'b1;
-        decoded_o.rs2_fp     = 1'b1;
-        decoded_o.fmt_d      = (funct3 == 3'b011);
-        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
-      end
-
-      OP_FP: begin  // FP arithmetic, compare, convert, move
-        decoded_o.is_fp = 1'b1;
-        decoded_o.fmt_d = instr_i[25]; // bit 25: 0=single, 1=double
-
-        unique case (funct7[6:2])
-          5'b00000: begin  // FADD.S/D
-            decoded_o.rs1_fp     = 1'b1;
-            decoded_o.rs2_fp     = 1'b1;
-            decoded_o.rd_fp      = 1'b1;
-            decoded_o.fp_op      = FP_FADD;
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b00001: begin  // FSUB.S/D
-            decoded_o.rs1_fp     = 1'b1;
-            decoded_o.rs2_fp     = 1'b1;
-            decoded_o.rd_fp      = 1'b1;
-            decoded_o.fp_op      = FP_FSUB;
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b00010: begin  // FMUL.S/D
-            decoded_o.rs1_fp     = 1'b1;
-            decoded_o.rs2_fp     = 1'b1;
-            decoded_o.rd_fp      = 1'b1;
-            decoded_o.fp_op      = FP_FMUL;
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b00011: begin  // FDIV.S/D
-            decoded_o.rs1_fp     = 1'b1;
-            decoded_o.rs2_fp     = 1'b1;
-            decoded_o.rd_fp      = 1'b1;
-            decoded_o.fp_op      = FP_FDIV;
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b00100: begin  // FSGNJ.S/D, FSGNJN.S/D, FSGNJX.S/D
-            decoded_o.rs1_fp = 1'b1;
-            decoded_o.rs2_fp = 1'b1;
-            decoded_o.rd_fp  = 1'b1;
-            unique case (funct3)
-              3'b000:  decoded_o.fp_op = FP_FSGNJ;
-              3'b001:  decoded_o.fp_op = FP_FSGNJN;
-              3'b010:  decoded_o.fp_op = FP_FSGNJX;
-              default: illegal = 1'b1;
-            endcase
-          end
-          5'b00101: begin  // FMIN.S/D, FMAX.S/D
-            decoded_o.rs1_fp = 1'b1;
-            decoded_o.rs2_fp = 1'b1;
-            decoded_o.rd_fp  = 1'b1;
-            unique case (funct3)
-              3'b000:  decoded_o.fp_op = FP_FMIN;
-              3'b001:  decoded_o.fp_op = FP_FMAX;
-              default: illegal = 1'b1;
-            endcase
-          end
-          5'b01000: begin  // FCVT.S.D / FCVT.D.S (inter-format conversion)
-            decoded_o.rs1_fp = 1'b1;
-            decoded_o.rd_fp  = 1'b1;
-            unique case (funct7[1:0])
-              2'b01: decoded_o.fp_op = FP_FCVT_D_S;  // FCVT.D.S (S→D): funct7=0x21
-              2'b00: decoded_o.fp_op = FP_FCVT_S_D;  // FCVT.S.D (D→S): funct7=0x20
-              default: illegal = 1'b1;
-            endcase
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b01011: begin  // FSQRT.S/D
-            decoded_o.rs1_fp     = 1'b1;
-            decoded_o.rd_fp      = 1'b1;
-            decoded_o.fp_op      = FP_FSQRT;
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-            // rs2 must be 00000 for FSQRT
-            if (instr_i[24:20] != 5'b00000) illegal = 1'b1;
-          end
-          5'b10100: begin  // FEQ/FLT/FLE (result to integer rd)
-            decoded_o.rs1_fp = 1'b1;
-            decoded_o.rs2_fp = 1'b1;
-            decoded_o.rd_wen = 1'b1;
-            decoded_o.wb_sel = WB_ALU;
-            unique case (funct3)
-              3'b010:  decoded_o.fp_op = FP_FEQ;
-              3'b001:  decoded_o.fp_op = FP_FLT;
-              3'b000:  decoded_o.fp_op = FP_FLE;
-              default: illegal = 1'b1;
-            endcase
-          end
-          5'b11000: begin  // FCVT.W/WU/L/LU.F (FP→int)
-            decoded_o.rs1_fp = 1'b1;
-            decoded_o.rd_wen = 1'b1;
-            decoded_o.wb_sel = WB_ALU;
-            unique case (instr_i[24:20])
-              5'b00000: decoded_o.fp_op = FP_FCVT_W_F;
-              5'b00001: decoded_o.fp_op = FP_FCVT_WU_F;
-              5'b00010: decoded_o.fp_op = FP_FCVT_L_F;
-              5'b00011: decoded_o.fp_op = FP_FCVT_LU_F;
-              default:  illegal = 1'b1;
-            endcase
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b11010: begin  // FCVT.F.W/WU/L/LU (int→FP)
-            decoded_o.rd_fp  = 1'b1;
-            unique case (instr_i[24:20])
-              5'b00000: decoded_o.fp_op = FP_FCVT_F_W;
-              5'b00001: decoded_o.fp_op = FP_FCVT_F_WU;
-              5'b00010: decoded_o.fp_op = FP_FCVT_F_L;
-              5'b00011: decoded_o.fp_op = FP_FCVT_F_LU;
-              default:  illegal = 1'b1;
-            endcase
-            decoded_o.rs1_used = 1'b1;
-            begin
-              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-            end
-          end
-          5'b11100: begin  // FMV.X.W / FMV.X.D / FCLASS.S / FCLASS.D
-            decoded_o.rs1_fp = 1'b1;
-            decoded_o.rd_wen = 1'b1;
-            decoded_o.wb_sel = WB_ALU;
-            if (instr_i[25] == 1'b0) begin
-              // Single-precision: FMV.X.W or FCLASS.S
-              unique case (funct3)
-                3'b000:  decoded_o.fp_op = FP_FMV_X_W;
-                3'b001:  decoded_o.fp_op = FP_FCLASS;
-                default: illegal = 1'b1;
-              endcase
-            end else begin
-              // Double-precision: FMV.X.D or FCLASS.D
-              unique case (funct3)
-                3'b000:  decoded_o.fp_op = FP_FMV_X_D;
-                3'b001:  decoded_o.fp_op = FP_FCLASS;
-                default: illegal = 1'b1;
-              endcase
-            end
-          end
-          5'b11110: begin  // FMV.W.X / FMV.D.X (integer→FP register)
-            decoded_o.rs1_used = 1'b1;
-            decoded_o.rd_fp    = 1'b1;
-            if (instr_i[25] == 1'b0) begin
-              decoded_o.fp_op = FP_FMV_W_X;
-            end else begin
-              decoded_o.fp_op = FP_FMV_D_X;
-            end
-          end
-          default: illegal = 1'b1;
-        endcase
-      end
-
-      // FMA variants: FMADD/FMSUB/FNMSUB/FNMADD
-      FMADD_OP: begin
-        decoded_o.is_fp   = 1'b1;
-        decoded_o.rs1_fp  = 1'b1;
-        decoded_o.rs2_fp  = 1'b1;
-        decoded_o.rs3_fp  = 1'b1;
-        decoded_o.rd_fp   = 1'b1;
-        decoded_o.rs3     = instr_i[31:27];
-        decoded_o.fmt_d   = instr_i[25];
-        decoded_o.fp_op   = FP_FMADD;
-        begin
-          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-        end
-      end
-
-      FMSUB_OP: begin
-        decoded_o.is_fp   = 1'b1;
-        decoded_o.rs1_fp  = 1'b1;
-        decoded_o.rs2_fp  = 1'b1;
-        decoded_o.rs3_fp  = 1'b1;
-        decoded_o.rd_fp   = 1'b1;
-        decoded_o.rs3     = instr_i[31:27];
-        decoded_o.fmt_d   = instr_i[25];
-        decoded_o.fp_op   = FP_FMSUB;
-        begin
-          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-        end
-      end
-
-      FNMSUB_OP: begin
-        decoded_o.is_fp   = 1'b1;
-        decoded_o.rs1_fp  = 1'b1;
-        decoded_o.rs2_fp  = 1'b1;
-        decoded_o.rs3_fp  = 1'b1;
-        decoded_o.rd_fp   = 1'b1;
-        decoded_o.rs3     = instr_i[31:27];
-        decoded_o.fmt_d   = instr_i[25];
-        decoded_o.fp_op   = FP_FNMSUB;
-        begin
-          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-        end
-      end
-
-      FNMADD_OP: begin
-        decoded_o.is_fp   = 1'b1;
-        decoded_o.rs1_fp  = 1'b1;
-        decoded_o.rs2_fp  = 1'b1;
-        decoded_o.rs3_fp  = 1'b1;
-        decoded_o.rd_fp   = 1'b1;
-        decoded_o.rs3     = instr_i[31:27];
-        decoded_o.fmt_d   = instr_i[25];
-        decoded_o.fp_op   = FP_FNMADD;
-        begin
-          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
-          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
-        end
-      end
-
-      default: illegal = 1'b1;
+      default: illegal_insn_o = 1'b1;
     endcase
 
-    decoded_o.illegal = illegal;
-    illegal_insn_o    = illegal;
+    decoded_o.illegal = illegal_insn_o;
   end
 
 endmodule

--- a/rtl/stage6/kronos_decode_ctrl.sv
+++ b/rtl/stage6/kronos_decode_ctrl.sv
@@ -1,0 +1,78 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode_ctrl.sv — CTRL-class sub-decoder (JAL, JALR, BRANCH).
+// One of five per-class sub-decoders dispatched by kronos_decode.
+
+module kronos_decode_ctrl
+  import kronos_pkg::*;
+(
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
+  output decoded_instr_t                decoded_o,
+  output logic                          illegal_o
+);
+
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [2:0] funct3;
+  logic       illegal;
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct3 = instr_i[14:12];
+
+  always_comb begin
+    decoded_o     = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1 = rs1;
+    decoded_o.rs2 = rs2;
+    decoded_o.rd  = rd;
+    illegal       = 1'b0;
+
+    unique case (opcode)
+      JAL: begin
+        decoded_o.rd_wen = 1'b1;
+        decoded_o.is_jal = 1'b1;
+        decoded_o.imm    = {{11{instr_i[31]}}, instr_i[31], instr_i[19:12],
+                            instr_i[20], instr_i[30:21], 1'b0};
+        decoded_o.wb_sel = WB_PC4;
+      end
+
+      JALR: begin
+        decoded_o.rs1_used = 1'b1;
+        decoded_o.rd_wen   = 1'b1;
+        decoded_o.is_jalr  = 1'b1;
+        decoded_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
+        decoded_o.wb_sel   = WB_PC4;
+        if (funct3 != 3'b000) illegal = 1'b1;
+      end
+
+      BRANCH: begin
+        decoded_o.rs1_used      = 1'b1;
+        decoded_o.rs2_used      = 1'b1;
+        decoded_o.is_branch     = 1'b1;
+        decoded_o.branch_funct3 = funct3;
+        decoded_o.imm = {{19{instr_i[31]}}, instr_i[31], instr_i[7],
+                         instr_i[30:25], instr_i[11:8], 1'b0};
+        unique case (funct3)
+          3'b100, 3'b101: decoded_o.alu_op = ALU_SLT;
+          3'b110, 3'b111: decoded_o.alu_op = ALU_SLTU;
+          default:        decoded_o.alu_op = ALU_SLTU;
+        endcase
+        if (funct3 == 3'b010 || funct3 == 3'b011) illegal = 1'b1;
+      end
+
+      default: begin
+        decoded_o = kronos_pkg::DECODED_INSTR_ZERO;
+        illegal   = 1'b0;
+      end
+    endcase
+
+    illegal_o = illegal;
+  end
+
+endmodule

--- a/rtl/stage6/kronos_decode_fp.sv
+++ b/rtl/stage6/kronos_decode_fp.sv
@@ -1,0 +1,246 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode_fp.sv — FP sub-decoder.
+// Owns OP_FP (funct7[6:2] dispatch table) and the four FMA opcodes
+// (FMADD/FMSUB/FNMSUB/FNMADD). The only sub-decoder that consumes frm_i.
+
+module kronos_decode_fp
+  import kronos_pkg::*;
+(
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
+  input  logic [2:0]                    frm_i,
+  output decoded_instr_t                decoded_o,
+  output logic                          illegal_o
+);
+
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [2:0] funct3;
+  logic [6:0] funct7;
+  logic       illegal;
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct3 = instr_i[14:12];
+  assign funct7 = instr_i[31:25];
+
+  always_comb begin
+    decoded_o     = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1 = rs1;
+    decoded_o.rs2 = rs2;
+    decoded_o.rd  = rd;
+    illegal       = 1'b0;
+
+    unique case (opcode)
+      OP_FP: begin
+        decoded_o.is_fp = 1'b1;
+        decoded_o.fmt_d = instr_i[25];
+
+        unique case (funct7[6:2])
+          5'b00000: begin  // FADD.S/D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            decoded_o.fp_op  = FP_FADD;
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b00001: begin  // FSUB.S/D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            decoded_o.fp_op  = FP_FSUB;
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b00010: begin  // FMUL.S/D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            decoded_o.fp_op  = FP_FMUL;
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b00011: begin  // FDIV.S/D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            decoded_o.fp_op  = FP_FDIV;
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b00100: begin  // FSGNJ / FSGNJN / FSGNJX
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            unique case (funct3)
+              3'b000:  decoded_o.fp_op = FP_FSGNJ;
+              3'b001:  decoded_o.fp_op = FP_FSGNJN;
+              3'b010:  decoded_o.fp_op = FP_FSGNJX;
+              default: illegal = 1'b1;
+            endcase
+          end
+          5'b00101: begin  // FMIN / FMAX
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            unique case (funct3)
+              3'b000:  decoded_o.fp_op = FP_FMIN;
+              3'b001:  decoded_o.fp_op = FP_FMAX;
+              default: illegal = 1'b1;
+            endcase
+          end
+          5'b01000: begin  // FCVT.S.D / FCVT.D.S
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            unique case (funct7[1:0])
+              2'b01:   decoded_o.fp_op = FP_FCVT_D_S;
+              2'b00:   decoded_o.fp_op = FP_FCVT_S_D;
+              default: illegal = 1'b1;
+            endcase
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b01011: begin  // FSQRT
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            decoded_o.fp_op  = FP_FSQRT;
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            if (instr_i[24:20] != 5'b00000) illegal = 1'b1;
+          end
+          5'b10100: begin  // FEQ / FLT / FLE
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_wen = 1'b1;
+            decoded_o.wb_sel = WB_ALU;
+            unique case (funct3)
+              3'b010:  decoded_o.fp_op = FP_FEQ;
+              3'b001:  decoded_o.fp_op = FP_FLT;
+              3'b000:  decoded_o.fp_op = FP_FLE;
+              default: illegal = 1'b1;
+            endcase
+          end
+          5'b11000: begin  // FCVT.W/WU/L/LU.F (FP→int)
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_wen = 1'b1;
+            decoded_o.wb_sel = WB_ALU;
+            unique case (instr_i[24:20])
+              5'b00000: decoded_o.fp_op = FP_FCVT_W_F;
+              5'b00001: decoded_o.fp_op = FP_FCVT_WU_F;
+              5'b00010: decoded_o.fp_op = FP_FCVT_L_F;
+              5'b00011: decoded_o.fp_op = FP_FCVT_LU_F;
+              default:  illegal = 1'b1;
+            endcase
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b11010: begin  // FCVT.F.W/WU/L/LU (int→FP)
+            decoded_o.rd_fp = 1'b1;
+            unique case (instr_i[24:20])
+              5'b00000: decoded_o.fp_op = FP_FCVT_F_W;
+              5'b00001: decoded_o.fp_op = FP_FCVT_F_WU;
+              5'b00010: decoded_o.fp_op = FP_FCVT_F_L;
+              5'b00011: decoded_o.fp_op = FP_FCVT_F_LU;
+              default:  illegal = 1'b1;
+            endcase
+            decoded_o.rs1_used = 1'b1;
+            decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+            if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+          end
+          5'b11100: begin  // FMV.X.W / FMV.X.D / FCLASS
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_wen = 1'b1;
+            decoded_o.wb_sel = WB_ALU;
+            if (instr_i[25] == 1'b0) begin
+              unique case (funct3)
+                3'b000:  decoded_o.fp_op = FP_FMV_X_W;
+                3'b001:  decoded_o.fp_op = FP_FCLASS;
+                default: illegal = 1'b1;
+              endcase
+            end else begin
+              unique case (funct3)
+                3'b000:  decoded_o.fp_op = FP_FMV_X_D;
+                3'b001:  decoded_o.fp_op = FP_FCLASS;
+                default: illegal = 1'b1;
+              endcase
+            end
+          end
+          5'b11110: begin  // FMV.W.X / FMV.D.X
+            decoded_o.rs1_used = 1'b1;
+            decoded_o.rd_fp    = 1'b1;
+            if (instr_i[25] == 1'b0) decoded_o.fp_op = FP_FMV_W_X;
+            else                     decoded_o.fp_op = FP_FMV_D_X;
+          end
+          default: illegal = 1'b1;
+        endcase
+      end
+
+      FMADD_OP: begin
+        decoded_o.is_fp  = 1'b1;
+        decoded_o.rs1_fp = 1'b1;
+        decoded_o.rs2_fp = 1'b1;
+        decoded_o.rs3_fp = 1'b1;
+        decoded_o.rd_fp  = 1'b1;
+        decoded_o.rs3    = instr_i[31:27];
+        decoded_o.fmt_d  = instr_i[25];
+        decoded_o.fp_op  = FP_FMADD;
+        decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+        if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+      end
+
+      FMSUB_OP: begin
+        decoded_o.is_fp  = 1'b1;
+        decoded_o.rs1_fp = 1'b1;
+        decoded_o.rs2_fp = 1'b1;
+        decoded_o.rs3_fp = 1'b1;
+        decoded_o.rd_fp  = 1'b1;
+        decoded_o.rs3    = instr_i[31:27];
+        decoded_o.fmt_d  = instr_i[25];
+        decoded_o.fp_op  = FP_FMSUB;
+        decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+        if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+      end
+
+      FNMSUB_OP: begin
+        decoded_o.is_fp  = 1'b1;
+        decoded_o.rs1_fp = 1'b1;
+        decoded_o.rs2_fp = 1'b1;
+        decoded_o.rs3_fp = 1'b1;
+        decoded_o.rd_fp  = 1'b1;
+        decoded_o.rs3    = instr_i[31:27];
+        decoded_o.fmt_d  = instr_i[25];
+        decoded_o.fp_op  = FP_FNMSUB;
+        decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+        if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+      end
+
+      FNMADD_OP: begin
+        decoded_o.is_fp  = 1'b1;
+        decoded_o.rs1_fp = 1'b1;
+        decoded_o.rs2_fp = 1'b1;
+        decoded_o.rs3_fp = 1'b1;
+        decoded_o.rd_fp  = 1'b1;
+        decoded_o.rs3    = instr_i[31:27];
+        decoded_o.fmt_d  = instr_i[25];
+        decoded_o.fp_op  = FP_FNMADD;
+        decoded_o.rm_resolved = kronos_pkg::resolve_rm(instr_i[14:12], frm_i);
+        if (kronos_pkg::rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+      end
+
+      default: begin
+        decoded_o = kronos_pkg::DECODED_INSTR_ZERO;
+        illegal   = 1'b0;
+      end
+    endcase
+
+    illegal_o = illegal;
+  end
+
+endmodule

--- a/rtl/stage6/kronos_decode_int.sv
+++ b/rtl/stage6/kronos_decode_int.sv
@@ -1,0 +1,174 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode_int.sv — INT sub-decoder.
+// Owns OP, OP_IMM, OP_IMM_32, OP_32 (incl. M-ext on funct7=0x01), LUI, AUIPC.
+
+module kronos_decode_int
+  import kronos_pkg::*;
+(
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
+  output decoded_instr_t                decoded_o,
+  output logic                          illegal_o
+);
+
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [2:0] funct3;
+  logic [6:0] funct7;
+  logic       illegal;
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct3 = instr_i[14:12];
+  assign funct7 = instr_i[31:25];
+
+  always_comb begin
+    decoded_o     = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1 = rs1;
+    decoded_o.rs2 = rs2;
+    decoded_o.rd  = rd;
+    illegal       = 1'b0;
+
+    unique case (opcode)
+      OP: begin
+        decoded_o.rs1_used = 1'b1;
+        decoded_o.rs2_used = 1'b1;
+        decoded_o.rd_wen   = 1'b1;
+        decoded_o.wb_sel   = WB_ALU;
+
+        if (funct7 == 7'b000_0001) begin
+          decoded_o.is_muldiv = 1'b1;
+          decoded_o.muldiv_op = muldiv_op_e'(funct3);
+          decoded_o.use_imm   = 1'b0;
+          decoded_o.alu_op    = ALU_ADD;
+        end else begin
+          decoded_o.use_imm = 1'b0;
+          unique case ({funct7, funct3})
+            {7'b000_0000, 3'b000}: decoded_o.alu_op = ALU_ADD;
+            {7'b010_0000, 3'b000}: decoded_o.alu_op = ALU_SUB;
+            {7'b000_0000, 3'b001}: decoded_o.alu_op = ALU_SLL;
+            {7'b000_0000, 3'b010}: decoded_o.alu_op = ALU_SLT;
+            {7'b000_0000, 3'b011}: decoded_o.alu_op = ALU_SLTU;
+            {7'b000_0000, 3'b100}: decoded_o.alu_op = ALU_XOR;
+            {7'b000_0000, 3'b101}: decoded_o.alu_op = ALU_SRL;
+            {7'b010_0000, 3'b101}: decoded_o.alu_op = ALU_SRA;
+            {7'b000_0000, 3'b110}: decoded_o.alu_op = ALU_OR;
+            {7'b000_0000, 3'b111}: decoded_o.alu_op = ALU_AND;
+            default:               illegal = 1'b1;
+          endcase
+        end
+      end
+
+      OP_IMM: begin
+        decoded_o.rs1_used = 1'b1;
+        decoded_o.rd_wen   = 1'b1;
+        decoded_o.use_imm  = 1'b1;
+        decoded_o.wb_sel   = WB_ALU;
+        decoded_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
+        unique case (funct3)
+          3'b000: decoded_o.alu_op = ALU_ADD;
+          3'b010: decoded_o.alu_op = ALU_SLT;
+          3'b011: decoded_o.alu_op = ALU_SLTU;
+          3'b100: decoded_o.alu_op = ALU_XOR;
+          3'b110: decoded_o.alu_op = ALU_OR;
+          3'b111: decoded_o.alu_op = ALU_AND;
+          3'b001: begin
+            decoded_o.alu_op = ALU_SLL;
+            decoded_o.imm    = {26'b0, instr_i[25:20]};
+            if (funct7[6:1] != 6'b000_000) illegal = 1'b1;
+          end
+          3'b101: begin
+            decoded_o.imm = {26'b0, instr_i[25:20]};
+            if      (funct7[6:1] == 6'b000_000) decoded_o.alu_op = ALU_SRL;
+            else if (funct7[6:1] == 6'b010_000) decoded_o.alu_op = ALU_SRA;
+            else                                illegal = 1'b1;
+          end
+          // verilator coverage_off
+          default: illegal = 1'b1;
+          // verilator coverage_on
+        endcase
+      end
+
+      OP_IMM_32: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.is_word_op = 1'b1;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        unique case (funct3)
+          3'b000: decoded_o.alu_op = ALU_ADD;
+          3'b001: begin
+            decoded_o.alu_op = ALU_SLL;
+            decoded_o.imm    = {27'b0, instr_i[24:20]};
+            if (funct7 != 7'b000_0000) illegal = 1'b1;
+          end
+          3'b101: begin
+            decoded_o.imm = {27'b0, instr_i[24:20]};
+            if      (funct7 == 7'b000_0000) decoded_o.alu_op = ALU_SRL;
+            else if (funct7 == 7'b010_0000) decoded_o.alu_op = ALU_SRA;
+            else                            illegal = 1'b1;
+          end
+          default: illegal = 1'b1;
+        endcase
+      end
+
+      OP_32: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rs2_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.is_word_op = 1'b1;
+
+        if (funct7 == 7'b000_0001) begin
+          decoded_o.is_muldiv = 1'b1;
+          decoded_o.muldiv_op = muldiv_op_e'(funct3);
+          decoded_o.use_imm   = 1'b0;
+          decoded_o.alu_op    = ALU_ADD;
+          if (funct3 > 3'b000 && funct3 < 3'b100) illegal = 1'b1;
+        end else begin
+          decoded_o.use_imm = 1'b0;
+          unique case ({funct7, funct3})
+            {7'b000_0000, 3'b000}: decoded_o.alu_op = ALU_ADD;
+            {7'b010_0000, 3'b000}: decoded_o.alu_op = ALU_SUB;
+            {7'b000_0000, 3'b001}: decoded_o.alu_op = ALU_SLL;
+            {7'b000_0000, 3'b101}: decoded_o.alu_op = ALU_SRL;
+            {7'b010_0000, 3'b101}: decoded_o.alu_op = ALU_SRA;
+            default:               illegal = 1'b1;
+          endcase
+        end
+      end
+
+      LUI: begin
+        decoded_o.rd_wen  = 1'b1;
+        decoded_o.use_imm = 1'b1;
+        decoded_o.alu_op  = ALU_PASSB;
+        decoded_o.imm     = {instr_i[31:12], 12'b0};
+        decoded_o.wb_sel  = WB_ALU;
+      end
+
+      AUIPC: begin
+        decoded_o.rd_wen  = 1'b1;
+        decoded_o.use_imm = 1'b1;
+        decoded_o.use_pc  = 1'b1;
+        decoded_o.alu_op  = ALU_ADD;
+        decoded_o.imm     = {instr_i[31:12], 12'b0};
+        decoded_o.wb_sel  = WB_ALU;
+      end
+
+      default: begin
+        decoded_o = kronos_pkg::DECODED_INSTR_ZERO;
+        illegal   = 1'b0;
+      end
+    endcase
+
+    illegal_o = illegal;
+  end
+
+endmodule

--- a/rtl/stage6/kronos_decode_mem.sv
+++ b/rtl/stage6/kronos_decode_mem.sv
@@ -1,0 +1,135 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode_mem.sv — MEM sub-decoder.
+// Owns LOAD, STORE, LOAD_FP, STORE_FP, AMO. All produce a rs1+imm address
+// adder via alu_op = ALU_ADD; FP variants additionally tag is_fp/fp_load/etc.
+
+module kronos_decode_mem
+  import kronos_pkg::*;
+(
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
+  output decoded_instr_t                decoded_o,
+  output logic                          illegal_o
+);
+
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [2:0] funct3;
+  logic [6:0] funct7;
+  logic       illegal;
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct3 = instr_i[14:12];
+  assign funct7 = instr_i[31:25];
+
+  always_comb begin
+    decoded_o     = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1 = rs1;
+    decoded_o.rs2 = rs2;
+    decoded_o.rd  = rd;
+    illegal       = 1'b0;
+
+    unique case (opcode)
+      LOAD: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        decoded_o.is_load    = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_MEM;
+        if (funct3 == 3'b111) illegal = 1'b1;
+      end
+
+      STORE: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rs2_used   = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
+        decoded_o.is_store   = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.rd_wen     = 1'b0;
+        if (funct3 > 3'b011) illegal = 1'b1;
+      end
+
+      LOAD_FP: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        decoded_o.is_load    = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_MEM;
+        decoded_o.is_fp      = 1'b1;
+        decoded_o.fp_load    = 1'b1;
+        decoded_o.rd_fp      = 1'b1;
+        decoded_o.fmt_d      = (funct3 == 3'b011);
+        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      end
+
+      STORE_FP: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
+        decoded_o.is_store   = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.rd_wen     = 1'b0;
+        decoded_o.is_fp      = 1'b1;
+        decoded_o.fp_store   = 1'b1;
+        decoded_o.rs2_fp     = 1'b1;
+        decoded_o.fmt_d      = (funct3 == 3'b011);
+        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      end
+
+      AMO: begin
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.wb_sel     = WB_MEM;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = 32'd0;
+
+        unique case (funct7[6:2])
+          5'b00010: begin
+            decoded_o.is_load = 1'b1;
+            decoded_o.is_lr   = 1'b1;
+          end
+          5'b00011: begin
+            decoded_o.is_store = 1'b1;
+            decoded_o.is_sc    = 1'b1;
+            decoded_o.rs2_used = 1'b1;
+          end
+          default: begin
+            decoded_o.is_amo     = 1'b1;
+            decoded_o.amo_funct5 = funct7[6:2];
+            decoded_o.rs2_used   = 1'b1;
+          end
+        endcase
+
+        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      end
+
+      default: begin
+        decoded_o = kronos_pkg::DECODED_INSTR_ZERO;
+        illegal   = 1'b0;
+      end
+    endcase
+
+    illegal_o = illegal;
+  end
+
+endmodule

--- a/rtl/stage6/kronos_decode_sys.sv
+++ b/rtl/stage6/kronos_decode_sys.sv
@@ -1,0 +1,77 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode_sys.sv — SYSTEM sub-decoder.
+// Owns funct3=0 priv/sfence cluster and CSR* variants.
+
+module kronos_decode_sys
+  import kronos_pkg::*;
+(
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
+  output decoded_instr_t                decoded_o,
+  output logic                          illegal_o
+);
+
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [2:0] funct3;
+  logic       illegal;
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct3 = instr_i[14:12];
+
+  always_comb begin
+    decoded_o     = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1 = rs1;
+    decoded_o.rs2 = rs2;
+    decoded_o.rd  = rd;
+    illegal       = 1'b0;
+
+    unique case (opcode)
+      SYSTEM: begin
+        unique case (funct3)
+          3'b000: begin
+            // SFENCE.VMA (funct7 = 0x09)
+            if (instr_i[31:25] == 7'b000_1001) begin
+              decoded_o.is_sfence_vma = 1'b1;
+              illegal                 = 1'b0;
+            end else begin
+              unique case (instr_i[31:20])
+                12'h000: decoded_o.is_ecall  = 1'b1;
+                12'h001: decoded_o.is_ebreak = 1'b1;
+                12'h302: decoded_o.is_mret   = 1'b1;
+                12'h102: decoded_o.is_sret   = 1'b1;
+                12'h105: decoded_o.is_wfi    = 1'b1;
+                default: illegal             = 1'b1;
+              endcase
+            end
+          end
+          default: begin
+            // CSRRW/RS/RC and immediate variants
+            decoded_o.is_csr      = 1'b1;
+            decoded_o.rd_wen      = 1'b1;
+            decoded_o.rs1_used    = ~funct3[2];
+            decoded_o.csr_addr    = instr_i[31:20];
+            decoded_o.csr_funct3  = funct3;
+            decoded_o.csr_use_imm = funct3[2];
+            decoded_o.wb_sel      = WB_CSR;
+          end
+        endcase
+      end
+
+      default: begin
+        decoded_o = kronos_pkg::DECODED_INSTR_ZERO;
+        illegal   = 1'b0;
+      end
+    endcase
+
+    illegal_o = illegal;
+  end
+
+endmodule

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1015,6 +1015,11 @@ SV_FILES_S6 := $(AXI_PKG_SV) \
                $(RTL_DIR_COMMON)/kronos_ram.sv \
                $(RTL_DIR_S6)/kronos_alu.sv \
                $(RTL_DIR_S6)/kronos_decode.sv \
+               $(RTL_DIR_S6)/kronos_decode_int.sv \
+               $(RTL_DIR_S6)/kronos_decode_ctrl.sv \
+               $(RTL_DIR_S6)/kronos_decode_mem.sv \
+               $(RTL_DIR_S6)/kronos_decode_sys.sv \
+               $(RTL_DIR_S6)/kronos_decode_fp.sv \
                $(RTL_DIR)/stage0/kronos_regfile.sv \
                $(RTL_DIR_S6)/kronos_icache.sv \
                $(RTL_DIR_S6)/kronos_csr.sv \
@@ -1258,6 +1263,24 @@ sim-alu-s6:
 	  --top-module tb_alu_s6 $(TB_ALU_S6_FILES) \
 	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_alu_s6
 	$(OBJ_DIR)/tb_alu_s6/Vtb_alu_s6
+
+# ── Stage 6 decode unit TB (equivalence vs frozen legacy snapshot) ─────────
+TB_DECODE_S6_FILES := $(AXI_PKG_SV) \
+                      $(RTL_DIR)/kronos_pkg.sv \
+                      $(RTL_DIR)/stage6/kronos_decode_ctrl.sv \
+                      $(RTL_DIR)/stage6/kronos_decode_sys.sv \
+                      $(RTL_DIR)/stage6/kronos_decode_mem.sv \
+                      $(RTL_DIR)/stage6/kronos_decode_int.sv \
+                      $(RTL_DIR)/stage6/kronos_decode_fp.sv \
+                      $(RTL_DIR)/stage6/kronos_decode.sv \
+                      $(TB_DIR)/stage6/kronos_decode_legacy.sv \
+                      $(TB_DIR)/stage6/tb_decode_s6.sv
+sim-decode-s6-tb:
+	$(VERILATOR) $(WAIVER) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
+	  --Wno-VARHIDDEN \
+	  --top-module tb_decode_s6 $(TB_DECODE_S6_FILES) \
+	  $(PULP_AXI_INC) -Mdir $(OBJ_DIR)/tb_decode_s6
+	$(OBJ_DIR)/tb_decode_s6/Vtb_decode_s6
 
 TB_TLB_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
                  $(RTL_DIR)/stage6/kronos_tlb.sv \

--- a/tb/stage6/kronos_decode_legacy.sv
+++ b/tb/stage6/kronos_decode_legacy.sv
@@ -1,0 +1,588 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// kronos_decode_legacy.sv — frozen pre-refactor copy of kronos_decode for
+// equivalence verification. Removed at stage-6 close.
+module kronos_decode_legacy
+  import kronos_pkg::*;
+(
+  input  logic [kronos_pkg::INST_W-1:0] instr_i,
+  input  logic [2:0]        frm_i,        // current FRM from FCSR (for dynamic rm)
+  output decoded_instr_t    decoded_o,
+  output logic              illegal_insn_o
+);
+
+  // 1. Constants — opcode encodings
+  localparam logic [6:0] OP         = 7'b011_0011; // R-type
+  localparam logic [6:0] OP_IMM     = 7'b001_0011; // I-type ALU
+  localparam logic [6:0] OP_IMM_32  = 7'b001_1011; // RV64 I-type ALU-W
+  localparam logic [6:0] OP_32      = 7'b011_1011; // RV64 R-type ALU-W
+  localparam logic [6:0] LOAD       = 7'b000_0011;
+  localparam logic [6:0] STORE      = 7'b010_0011;
+  localparam logic [6:0] LOAD_FP    = 7'b000_0111;
+  localparam logic [6:0] STORE_FP   = 7'b010_0111;
+  localparam logic [6:0] OP_FP      = 7'b101_0011;
+  localparam logic [6:0] FMADD_OP   = 7'b100_0011;
+  localparam logic [6:0] FMSUB_OP   = 7'b100_0111;
+  localparam logic [6:0] FNMSUB_OP  = 7'b100_1011;
+  localparam logic [6:0] FNMADD_OP  = 7'b100_1111;
+  localparam logic [6:0] BRANCH     = 7'b110_0011;
+  localparam logic [6:0] LUI        = 7'b011_0111;
+  localparam logic [6:0] AUIPC      = 7'b001_0111;
+  localparam logic [6:0] JAL        = 7'b110_1111;
+  localparam logic [6:0] JALR       = 7'b110_0111;
+  localparam logic [6:0] SYSTEM     = 7'b111_0011;
+  localparam logic [6:0] AMO        = 7'b010_1111;
+
+  // 4. Combinational signals — instruction fields
+  logic [6:0] opcode;
+  logic [4:0] rd;
+  logic [2:0] funct3;
+  logic [4:0] rs1;
+  logic [4:0] rs2;
+  logic [6:0] funct7;
+  logic       illegal;
+
+  // Resolves the FP rounding mode field, substituting frm when rm_in=DYN (111).
+  function automatic logic [2:0] resolve_rm(input logic [2:0] rm_in, input logic [2:0] frm);
+    return (rm_in == 3'b111) ? frm : rm_in;
+  endfunction
+  function automatic logic rm_is_illegal(input logic [2:0] rm);
+    return (rm == 3'b101) || (rm == 3'b110);
+  endfunction
+
+  assign opcode = instr_i[6:0];
+  assign rd     = instr_i[11:7];
+  assign funct3 = instr_i[14:12];
+  assign rs1    = instr_i[19:15];
+  assign rs2    = instr_i[24:20];
+  assign funct7 = instr_i[31:25];
+
+  always_comb begin
+    decoded_o          = kronos_pkg::DECODED_INSTR_ZERO;
+    decoded_o.rs1      = rs1;
+    decoded_o.rs2      = rs2;
+    decoded_o.rd       = rd;
+    illegal            = 1'b0;
+
+    unique case (opcode)
+      OP: begin  // R-type: ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND + M-ext
+        decoded_o.rs1_used = 1'b1;
+        decoded_o.rs2_used = 1'b1;
+        decoded_o.rd_wen   = 1'b1;
+        decoded_o.wb_sel   = WB_ALU;
+
+        if (funct7 == 7'b000_0001) begin
+          // M extension: MUL/MULH/MULHSU/MULHU/DIV/DIVU/REM/REMU
+          decoded_o.is_muldiv = 1'b1;
+          decoded_o.muldiv_op = muldiv_op_e'(funct3);
+          decoded_o.use_imm   = 1'b0;
+          decoded_o.alu_op    = ALU_ADD; // don't-care; ALU result is discarded
+        end else begin
+          decoded_o.use_imm = 1'b0;
+          unique case ({funct7, funct3})
+            {7'b000_0000, 3'b000}: decoded_o.alu_op = ALU_ADD;
+            {7'b010_0000, 3'b000}: decoded_o.alu_op = ALU_SUB;
+            {7'b000_0000, 3'b001}: decoded_o.alu_op = ALU_SLL;
+            {7'b000_0000, 3'b010}: decoded_o.alu_op = ALU_SLT;
+            {7'b000_0000, 3'b011}: decoded_o.alu_op = ALU_SLTU;
+            {7'b000_0000, 3'b100}: decoded_o.alu_op = ALU_XOR;
+            {7'b000_0000, 3'b101}: decoded_o.alu_op = ALU_SRL;
+            {7'b010_0000, 3'b101}: decoded_o.alu_op = ALU_SRA;
+            {7'b000_0000, 3'b110}: decoded_o.alu_op = ALU_OR;
+            {7'b000_0000, 3'b111}: decoded_o.alu_op = ALU_AND;
+            default:               illegal = 1'b1;
+          endcase
+        end
+      end
+
+      OP_IMM: begin  // I-type ALU: ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI
+        decoded_o.rs1_used = 1'b1;
+        decoded_o.rd_wen   = 1'b1;
+        decoded_o.use_imm  = 1'b1;
+        decoded_o.wb_sel   = WB_ALU;
+        decoded_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
+        unique case (funct3)
+          3'b000: decoded_o.alu_op = ALU_ADD;   // ADDI
+          3'b010: decoded_o.alu_op = ALU_SLT;   // SLTI
+          3'b011: decoded_o.alu_op = ALU_SLTU;  // SLTIU
+          3'b100: decoded_o.alu_op = ALU_XOR;   // XORI
+          3'b110: decoded_o.alu_op = ALU_OR;    // ORI
+          3'b111: decoded_o.alu_op = ALU_AND;   // ANDI
+          3'b001: begin  // SLLI (6-bit shamt in RV64)
+            decoded_o.alu_op = ALU_SLL;
+            decoded_o.imm    = {26'b0, instr_i[25:20]};
+            if (funct7[6:1] != 6'b000_000) illegal = 1'b1;
+          end
+          3'b101: begin  // SRLI / SRAI (6-bit shamt in RV64)
+            decoded_o.imm = {26'b0, instr_i[25:20]};
+            if      (funct7[6:1] == 6'b000_000) decoded_o.alu_op = ALU_SRL;
+            else if (funct7[6:1] == 6'b010_000) decoded_o.alu_op = ALU_SRA;
+            else                                illegal = 1'b1;
+          end
+          // verilator coverage_off
+          default: illegal = 1'b1;
+          // verilator coverage_on
+        endcase
+      end
+
+      OP_IMM_32: begin  // ADDIW / SLLIW / SRLIW / SRAIW
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.is_word_op = 1'b1;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        unique case (funct3)
+          3'b000: decoded_o.alu_op = ALU_ADD;
+          3'b001: begin  // SLLIW
+            decoded_o.alu_op = ALU_SLL;
+            decoded_o.imm    = {27'b0, instr_i[24:20]};
+            if (funct7 != 7'b000_0000) illegal = 1'b1;
+          end
+          3'b101: begin  // SRLIW / SRAIW
+            decoded_o.imm = {27'b0, instr_i[24:20]};
+            if      (funct7 == 7'b000_0000) decoded_o.alu_op = ALU_SRL;
+            else if (funct7 == 7'b010_0000) decoded_o.alu_op = ALU_SRA;
+            else                            illegal = 1'b1;
+          end
+          default: illegal = 1'b1;
+        endcase
+      end
+
+      OP_32: begin  // ADDW / SUBW / SLLW / SRLW / SRAW + MULW/DIVW/DIVUW/REMW/REMUW
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rs2_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.is_word_op = 1'b1;
+
+        if (funct7 == 7'b000_0001) begin
+          decoded_o.is_muldiv = 1'b1;
+          decoded_o.muldiv_op = muldiv_op_e'(funct3);
+          decoded_o.use_imm   = 1'b0;
+          decoded_o.alu_op    = ALU_ADD;
+          if (funct3 > 3'b000 && funct3 < 3'b100) illegal = 1'b1;
+        end else begin
+          decoded_o.use_imm = 1'b0;
+          unique case ({funct7, funct3})
+            {7'b000_0000, 3'b000}: decoded_o.alu_op = ALU_ADD;
+            {7'b010_0000, 3'b000}: decoded_o.alu_op = ALU_SUB;
+            {7'b000_0000, 3'b001}: decoded_o.alu_op = ALU_SLL;
+            {7'b000_0000, 3'b101}: decoded_o.alu_op = ALU_SRL;
+            {7'b010_0000, 3'b101}: decoded_o.alu_op = ALU_SRA;
+            default:               illegal = 1'b1;
+          endcase
+        end
+      end
+
+      LUI: begin
+        decoded_o.rd_wen  = 1'b1;
+        decoded_o.use_imm = 1'b1;
+        decoded_o.alu_op  = ALU_PASSB;
+        decoded_o.imm     = {instr_i[31:12], 12'b0};
+        decoded_o.wb_sel  = WB_ALU;
+      end
+
+      AUIPC: begin
+        decoded_o.rd_wen  = 1'b1;
+        decoded_o.use_imm = 1'b1;
+        decoded_o.use_pc  = 1'b1;
+        decoded_o.alu_op  = ALU_ADD;
+        decoded_o.imm     = {instr_i[31:12], 12'b0};
+        decoded_o.wb_sel  = WB_ALU;
+      end
+
+      JAL: begin
+        decoded_o.rd_wen = 1'b1;
+        decoded_o.is_jal = 1'b1;
+        // J-type immediate: imm[20|10:1|11|19:12], bit 0 always 0
+        decoded_o.imm    = {{11{instr_i[31]}}, instr_i[31], instr_i[19:12],
+                            instr_i[20], instr_i[30:21], 1'b0};
+        decoded_o.wb_sel = WB_PC4;
+      end
+
+      JALR: begin
+        decoded_o.rs1_used = 1'b1;
+        decoded_o.rd_wen   = 1'b1;
+        decoded_o.is_jalr  = 1'b1;
+        decoded_o.imm      = {{20{instr_i[31]}}, instr_i[31:20]};
+        decoded_o.wb_sel   = WB_PC4;
+        if (funct3 != 3'b000) illegal = 1'b1;
+      end
+
+      BRANCH: begin  // BEQ, BNE, BLT, BGE, BLTU, BGEU
+        decoded_o.rs1_used      = 1'b1;
+        decoded_o.rs2_used      = 1'b1;
+        decoded_o.is_branch     = 1'b1;
+        decoded_o.branch_funct3 = funct3;
+        // B-type immediate: imm[12|10:5|4:1|11], bit 0 always 0
+        decoded_o.imm = {{19{instr_i[31]}}, instr_i[31], instr_i[7],
+                         instr_i[30:25], instr_i[11:8], 1'b0};
+        // Drive the ALU's comparator with the right signedness so kronos_top
+        // can consume cmp_lt_o for BLT/BGE/BLTU/BGEU. BEQ/BNE consume eq_o,
+        // which is valid for any subtract-style alu_op.
+        unique case (funct3)
+          3'b100, 3'b101: decoded_o.alu_op = ALU_SLT;   // BLT, BGE
+          3'b110, 3'b111: decoded_o.alu_op = ALU_SLTU;  // BLTU, BGEU
+          default:        decoded_o.alu_op = ALU_SLTU;  // BEQ, BNE — any sub-style op
+        endcase
+        if (funct3 == 3'b010 || funct3 == 3'b011) illegal = 1'b1;
+      end
+
+      LOAD: begin  // LB, LH, LW, LBU, LHU + RV64 LD, LWU
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        decoded_o.is_load    = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_MEM;
+        if (funct3 == 3'b111) illegal = 1'b1; // reserved in RV64
+      end
+
+      STORE: begin  // SB, SH, SW + RV64 SD
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rs2_used   = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
+        decoded_o.is_store   = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.rd_wen     = 1'b0;
+        if (funct3 > 3'b011) illegal = 1'b1; // only SB/SH/SW/SD
+      end
+
+      AMO: begin  // LR.W/D, SC.W/D, AMO*.W/D
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.wb_sel     = WB_MEM;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = 32'd0;
+
+        unique case (funct7[6:2])
+          5'b00010: begin
+            decoded_o.is_load = 1'b1;
+            decoded_o.is_lr   = 1'b1;
+          end
+          5'b00011: begin
+            decoded_o.is_store = 1'b1;
+            decoded_o.is_sc    = 1'b1;
+            decoded_o.rs2_used = 1'b1;
+          end
+          default: begin
+            decoded_o.is_amo     = 1'b1;
+            decoded_o.amo_funct5 = funct7[6:2];
+            decoded_o.rs2_used   = 1'b1;
+          end
+        endcase
+
+        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      end
+
+      SYSTEM: begin
+        unique case (funct3)
+          3'b000: begin  // ECALL, EBREAK, MRET, SRET, SFENCE.VMA, WFI
+            // SFENCE.VMA — funct7 = 0x09 (Stage 6b: real op)
+            if (instr_i[31:25] == 7'b000_1001) begin
+              decoded_o.is_sfence_vma = 1'b1;
+              illegal                 = 1'b0;
+            end else begin
+              unique case (instr_i[31:20])
+                12'h000: decoded_o.is_ecall  = 1'b1;
+                12'h001: decoded_o.is_ebreak = 1'b1;
+                12'h302: decoded_o.is_mret   = 1'b1;
+                12'h102: decoded_o.is_sret   = 1'b1;  // Stage 6a
+                12'h105: decoded_o.is_wfi    = 1'b1;  // Stage 6b
+                default: illegal             = 1'b1;
+              endcase
+            end
+          end
+          default: begin  // CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI
+            decoded_o.is_csr      = 1'b1;
+            decoded_o.rd_wen      = 1'b1;
+            decoded_o.rs1_used    = ~funct3[2]; // funct3[2]=1 means zimm form
+            decoded_o.csr_addr    = instr_i[31:20];
+            decoded_o.csr_funct3  = funct3;
+            decoded_o.csr_use_imm = funct3[2];
+            decoded_o.wb_sel      = WB_CSR;
+          end
+        endcase
+      end
+
+      // -----------------------------------------------------------------------
+      // Floating-point instructions
+      // -----------------------------------------------------------------------
+
+      LOAD_FP: begin  // FLW (funct3=010) / FLD (funct3=011)
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.rd_wen     = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:20]};
+        decoded_o.is_load    = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_MEM;
+        decoded_o.is_fp      = 1'b1;
+        decoded_o.fp_load    = 1'b1;
+        decoded_o.rd_fp      = 1'b1;
+        decoded_o.fmt_d      = (funct3 == 3'b011);
+        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      end
+
+      STORE_FP: begin  // FSW (funct3=010) / FSD (funct3=011)
+        decoded_o.rs1_used   = 1'b1;
+        decoded_o.use_imm    = 1'b1;
+        decoded_o.alu_op     = ALU_ADD;
+        decoded_o.imm        = {{20{instr_i[31]}}, instr_i[31:25], instr_i[11:7]};
+        decoded_o.is_store   = 1'b1;
+        decoded_o.mem_funct3 = funct3;
+        decoded_o.wb_sel     = WB_ALU;
+        decoded_o.rd_wen     = 1'b0;
+        decoded_o.is_fp      = 1'b1;
+        decoded_o.fp_store   = 1'b1;
+        decoded_o.rs2_fp     = 1'b1;
+        decoded_o.fmt_d      = (funct3 == 3'b011);
+        if (funct3 != 3'b010 && funct3 != 3'b011) illegal = 1'b1;
+      end
+
+      OP_FP: begin  // FP arithmetic, compare, convert, move
+        decoded_o.is_fp = 1'b1;
+        decoded_o.fmt_d = instr_i[25]; // bit 25: 0=single, 1=double
+
+        unique case (funct7[6:2])
+          5'b00000: begin  // FADD.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rs2_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FADD;
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b00001: begin  // FSUB.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rs2_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FSUB;
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b00010: begin  // FMUL.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rs2_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FMUL;
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b00011: begin  // FDIV.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rs2_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FDIV;
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b00100: begin  // FSGNJ.S/D, FSGNJN.S/D, FSGNJX.S/D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            unique case (funct3)
+              3'b000:  decoded_o.fp_op = FP_FSGNJ;
+              3'b001:  decoded_o.fp_op = FP_FSGNJN;
+              3'b010:  decoded_o.fp_op = FP_FSGNJX;
+              default: illegal = 1'b1;
+            endcase
+          end
+          5'b00101: begin  // FMIN.S/D, FMAX.S/D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            unique case (funct3)
+              3'b000:  decoded_o.fp_op = FP_FMIN;
+              3'b001:  decoded_o.fp_op = FP_FMAX;
+              default: illegal = 1'b1;
+            endcase
+          end
+          5'b01000: begin  // FCVT.S.D / FCVT.D.S (inter-format conversion)
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_fp  = 1'b1;
+            unique case (funct7[1:0])
+              2'b01: decoded_o.fp_op = FP_FCVT_D_S;  // FCVT.D.S (S→D): funct7=0x21
+              2'b00: decoded_o.fp_op = FP_FCVT_S_D;  // FCVT.S.D (D→S): funct7=0x20
+              default: illegal = 1'b1;
+            endcase
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b01011: begin  // FSQRT.S/D
+            decoded_o.rs1_fp     = 1'b1;
+            decoded_o.rd_fp      = 1'b1;
+            decoded_o.fp_op      = FP_FSQRT;
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+            // rs2 must be 00000 for FSQRT
+            if (instr_i[24:20] != 5'b00000) illegal = 1'b1;
+          end
+          5'b10100: begin  // FEQ/FLT/FLE (result to integer rd)
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rs2_fp = 1'b1;
+            decoded_o.rd_wen = 1'b1;
+            decoded_o.wb_sel = WB_ALU;
+            unique case (funct3)
+              3'b010:  decoded_o.fp_op = FP_FEQ;
+              3'b001:  decoded_o.fp_op = FP_FLT;
+              3'b000:  decoded_o.fp_op = FP_FLE;
+              default: illegal = 1'b1;
+            endcase
+          end
+          5'b11000: begin  // FCVT.W/WU/L/LU.F (FP→int)
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_wen = 1'b1;
+            decoded_o.wb_sel = WB_ALU;
+            unique case (instr_i[24:20])
+              5'b00000: decoded_o.fp_op = FP_FCVT_W_F;
+              5'b00001: decoded_o.fp_op = FP_FCVT_WU_F;
+              5'b00010: decoded_o.fp_op = FP_FCVT_L_F;
+              5'b00011: decoded_o.fp_op = FP_FCVT_LU_F;
+              default:  illegal = 1'b1;
+            endcase
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b11010: begin  // FCVT.F.W/WU/L/LU (int→FP)
+            decoded_o.rd_fp  = 1'b1;
+            unique case (instr_i[24:20])
+              5'b00000: decoded_o.fp_op = FP_FCVT_F_W;
+              5'b00001: decoded_o.fp_op = FP_FCVT_F_WU;
+              5'b00010: decoded_o.fp_op = FP_FCVT_F_L;
+              5'b00011: decoded_o.fp_op = FP_FCVT_F_LU;
+              default:  illegal = 1'b1;
+            endcase
+            decoded_o.rs1_used = 1'b1;
+            begin
+              decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+              if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+            end
+          end
+          5'b11100: begin  // FMV.X.W / FMV.X.D / FCLASS.S / FCLASS.D
+            decoded_o.rs1_fp = 1'b1;
+            decoded_o.rd_wen = 1'b1;
+            decoded_o.wb_sel = WB_ALU;
+            if (instr_i[25] == 1'b0) begin
+              // Single-precision: FMV.X.W or FCLASS.S
+              unique case (funct3)
+                3'b000:  decoded_o.fp_op = FP_FMV_X_W;
+                3'b001:  decoded_o.fp_op = FP_FCLASS;
+                default: illegal = 1'b1;
+              endcase
+            end else begin
+              // Double-precision: FMV.X.D or FCLASS.D
+              unique case (funct3)
+                3'b000:  decoded_o.fp_op = FP_FMV_X_D;
+                3'b001:  decoded_o.fp_op = FP_FCLASS;
+                default: illegal = 1'b1;
+              endcase
+            end
+          end
+          5'b11110: begin  // FMV.W.X / FMV.D.X (integer→FP register)
+            decoded_o.rs1_used = 1'b1;
+            decoded_o.rd_fp    = 1'b1;
+            if (instr_i[25] == 1'b0) begin
+              decoded_o.fp_op = FP_FMV_W_X;
+            end else begin
+              decoded_o.fp_op = FP_FMV_D_X;
+            end
+          end
+          default: illegal = 1'b1;
+        endcase
+      end
+
+      // FMA variants: FMADD/FMSUB/FNMSUB/FNMADD
+      FMADD_OP: begin
+        decoded_o.is_fp   = 1'b1;
+        decoded_o.rs1_fp  = 1'b1;
+        decoded_o.rs2_fp  = 1'b1;
+        decoded_o.rs3_fp  = 1'b1;
+        decoded_o.rd_fp   = 1'b1;
+        decoded_o.rs3     = instr_i[31:27];
+        decoded_o.fmt_d   = instr_i[25];
+        decoded_o.fp_op   = FP_FMADD;
+        begin
+          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+        end
+      end
+
+      FMSUB_OP: begin
+        decoded_o.is_fp   = 1'b1;
+        decoded_o.rs1_fp  = 1'b1;
+        decoded_o.rs2_fp  = 1'b1;
+        decoded_o.rs3_fp  = 1'b1;
+        decoded_o.rd_fp   = 1'b1;
+        decoded_o.rs3     = instr_i[31:27];
+        decoded_o.fmt_d   = instr_i[25];
+        decoded_o.fp_op   = FP_FMSUB;
+        begin
+          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+        end
+      end
+
+      FNMSUB_OP: begin
+        decoded_o.is_fp   = 1'b1;
+        decoded_o.rs1_fp  = 1'b1;
+        decoded_o.rs2_fp  = 1'b1;
+        decoded_o.rs3_fp  = 1'b1;
+        decoded_o.rd_fp   = 1'b1;
+        decoded_o.rs3     = instr_i[31:27];
+        decoded_o.fmt_d   = instr_i[25];
+        decoded_o.fp_op   = FP_FNMSUB;
+        begin
+          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+        end
+      end
+
+      FNMADD_OP: begin
+        decoded_o.is_fp   = 1'b1;
+        decoded_o.rs1_fp  = 1'b1;
+        decoded_o.rs2_fp  = 1'b1;
+        decoded_o.rs3_fp  = 1'b1;
+        decoded_o.rd_fp   = 1'b1;
+        decoded_o.rs3     = instr_i[31:27];
+        decoded_o.fmt_d   = instr_i[25];
+        decoded_o.fp_op   = FP_FNMADD;
+        begin
+          decoded_o.rm_resolved = resolve_rm(instr_i[14:12], frm_i);
+          if (rm_is_illegal(decoded_o.rm_resolved)) illegal = 1'b1;
+        end
+      end
+
+      default: illegal = 1'b1;
+    endcase
+
+    decoded_o.illegal = illegal;
+    illegal_insn_o    = illegal;
+  end
+
+endmodule

--- a/tb/stage6/tb_decode_s6.sv
+++ b/tb/stage6/tb_decode_s6.sv
@@ -1,0 +1,263 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// tb_decode_s6.sv — equivalence harness for kronos_decode vs kronos_decode_legacy.
+// Compares the (eventually refactored) decoder against a frozen pre-refactor
+// snapshot over directed + parametric + random stimulus. Any mismatch in
+// decoded_o or illegal_insn_o fails the TB.
+
+`timescale 1ns/1ps
+
+module tb_decode_s6;
+  import kronos_pkg::*;
+
+  // Stimulus
+  logic [INST_W-1:0] instr;
+  logic [2:0]        frm;
+
+  // DUT outputs
+  decoded_instr_t    new_decoded;
+  decoded_instr_t    old_decoded;
+  logic              new_illegal;
+  logic              old_illegal;
+
+  // Counters
+  int                check_count;
+  int                err_count;
+
+  // ----------------------------------------------------------------
+  // DUT instances
+  // ----------------------------------------------------------------
+  kronos_decode u_new (
+    .instr_i        (instr),
+    .frm_i          (frm),
+    .decoded_o      (new_decoded),
+    .illegal_insn_o (new_illegal)
+  );
+
+  kronos_decode_legacy u_old (
+    .instr_i        (instr),
+    .frm_i          (frm),
+    .decoded_o      (old_decoded),
+    .illegal_insn_o (old_illegal)
+  );
+
+  // ----------------------------------------------------------------
+  // Compare task — call after each stimulus update
+  // ----------------------------------------------------------------
+  task automatic check(input string label);
+    #1;
+    check_count++;
+    if (new_decoded !== old_decoded || new_illegal !== old_illegal) begin
+      err_count++;
+      $display("FAIL [%s]: instr=%08h frm=%b", label, instr, frm);
+      $display("  new_illegal=%b old_illegal=%b", new_illegal, old_illegal);
+      if (err_count >= 20) begin
+        $display("Aborting after 20 mismatches.");
+        $finish;
+      end
+    end
+  endtask
+
+  // ----------------------------------------------------------------
+  // Directed phase — every legal opcode + every Section-4 illegal case
+  // ----------------------------------------------------------------
+  task automatic directed_phase();
+    frm = 3'b000;
+
+    // INT — R-type
+    instr = 32'h0000_0033; check("ADD");
+    instr = 32'h4000_8033; check("SUB");
+    instr = 32'h0000_9033; check("SLL");
+    instr = 32'h0000_A033; check("SLT");
+    instr = 32'h0000_B033; check("SLTU");
+    instr = 32'h0000_C033; check("XOR");
+    instr = 32'h0000_D033; check("SRL");
+    instr = 32'h4000_D033; check("SRA");
+    instr = 32'h0000_E033; check("OR");
+    instr = 32'h0000_F033; check("AND");
+    instr = 32'h0220_8033; check("MUL");
+    instr = 32'h0220_F033; check("REMU");
+
+    // INT — I-type
+    instr = 32'h0050_0013; check("ADDI x0,x0,5");
+    instr = 32'h0050_2013; check("SLTI x0,x0,5");
+    instr = 32'h7FF0_2013; check("SLTI x0,x0,2047");
+    instr = 32'h0030_1013; check("SLLI x0,x0,3");
+    instr = 32'h0050_5013; check("SRLI x0,x0,5");
+    instr = 32'h4050_5013; check("SRAI x0,x0,5");
+
+    // INT — word ops
+    instr = 32'h0000_003B; check("ADDW");
+    instr = 32'h4000_803B; check("SUBW");
+    instr = 32'h0220_803B; check("MULW");
+    instr = 32'h0050_001B; check("ADDIW");
+
+    // INT — LUI / AUIPC
+    instr = 32'hDEAD_C037; check("LUI");
+    instr = 32'h1234_5017; check("AUIPC");
+
+    // CTRL — JAL / JALR / BRANCH
+    instr = 32'h0080_00EF; check("JAL");
+    instr = 32'h0080_00E7; check("JALR");
+    instr = 32'h0080_0063; check("BEQ");
+    instr = 32'h0080_1063; check("BNE");
+    instr = 32'h0080_4063; check("BLT");
+    instr = 32'h0080_5063; check("BGE");
+    instr = 32'h0080_6063; check("BLTU");
+    instr = 32'h0080_7063; check("BGEU");
+    instr = 32'h0080_2063; check("BRANCH funct3=010 illegal");
+    instr = 32'h0080_3063; check("BRANCH funct3=011 illegal");
+    instr = 32'h0080_10E7; check("JALR funct3!=0 illegal");
+
+    // MEM — LOAD / STORE / FP-LOAD / FP-STORE / AMO
+    instr = 32'h0000_0003; check("LB");
+    instr = 32'h0000_2003; check("LW");
+    instr = 32'h0000_3003; check("LD");
+    instr = 32'h0000_7003; check("LOAD funct3=111 illegal");
+    instr = 32'h0000_0023; check("SB");
+    instr = 32'h0000_3023; check("SD");
+    instr = 32'h0000_4023; check("STORE funct3=100 illegal");
+    instr = 32'h0000_2007; check("FLW");
+    instr = 32'h0000_3007; check("FLD");
+    instr = 32'h0000_2027; check("FSW");
+    instr = 32'h0000_3027; check("FSD");
+    instr = 32'h1000_802F; check("LR.W");
+    instr = 32'h0810_802F; check("AMOSWAP.W");
+
+    // SYS — privileged + CSR
+    instr = 32'h0000_0073; check("ECALL");
+    instr = 32'h0010_0073; check("EBREAK");
+    instr = 32'h3020_0073; check("MRET");
+    instr = 32'h1020_0073; check("SRET");
+    instr = 32'h1050_0073; check("WFI");
+    instr = 32'h1230_0073; check("SFENCE.VMA");
+    instr = 32'hC000_2073; check("CSRRS rdcycle");
+    instr = 32'hF000_50F3; check("CSRRWI x1, mtval, 0");
+
+    // FP — OP_FP arithmetic + compare + classify + move
+    instr = 32'h0010_0053; check("FADD.S placeholder");
+    instr = 32'h0810_0053; check("FSUB.D placeholder");
+    instr = 32'h2000_0053; check("FSGNJ.S placeholder");
+    instr = 32'hA000_0053; check("FLE.S placeholder");
+    instr = 32'hC000_0053; check("FCVT.W.S placeholder");
+    instr = 32'hE000_0053; check("FMV.X.W placeholder");
+
+    // FMA opcodes
+    instr = 32'h0000_0043; check("FMADD.S placeholder");
+    instr = 32'h0000_0047; check("FMSUB.S placeholder");
+    instr = 32'h0000_004B; check("FNMSUB.S placeholder");
+    instr = 32'h0000_004F; check("FNMADD.S placeholder");
+
+    // Fully reserved opcode → wrapper default illegal
+    instr = 32'h0000_007F; check("opcode 0x7F reserved");
+    instr = 32'h0000_001F; check("opcode 0x1F reserved");
+  endtask
+
+  // ----------------------------------------------------------------
+  // Parametric phase — exhaustive funct3/funct7 sweeps per class
+  // ----------------------------------------------------------------
+  task automatic parametric_phase();
+    logic [6:0] op_field;
+    frm = 3'b000;
+
+    // OP (R-type) — full funct3 × funct7 sweep with rs1=x1, rs2=x2, rd=x3
+    for (int f7 = 0; f7 < 128; f7++) begin
+      for (int f3 = 0; f3 < 8; f3++) begin
+        instr = {f7[6:0], 5'd2, 5'd1, f3[2:0], 5'd3, 7'b011_0011};
+        check($sformatf("OP f7=%0d f3=%0d", f7, f3));
+      end
+    end
+
+    // OP_IMM — funct3 sweep with imm=0x123
+    for (int f3 = 0; f3 < 8; f3++) begin
+      instr = {12'h123, 5'd1, f3[2:0], 5'd3, 7'b001_0011};
+      check($sformatf("OP_IMM f3=%0d", f3));
+    end
+
+    // OP_32 — funct3 × funct7
+    for (int f7 = 0; f7 < 128; f7++) begin
+      for (int f3 = 0; f3 < 8; f3++) begin
+        instr = {f7[6:0], 5'd2, 5'd1, f3[2:0], 5'd3, 7'b011_1011};
+        check($sformatf("OP_32 f7=%0d f3=%0d", f7, f3));
+      end
+    end
+
+    // BRANCH — funct3 sweep
+    for (int f3 = 0; f3 < 8; f3++) begin
+      instr = {7'h00, 5'd2, 5'd1, f3[2:0], 5'h00, 7'b110_0011};
+      check($sformatf("BRANCH f3=%0d", f3));
+    end
+
+    // LOAD — funct3 sweep
+    for (int f3 = 0; f3 < 8; f3++) begin
+      instr = {12'h000, 5'd1, f3[2:0], 5'd3, 7'b000_0011};
+      check($sformatf("LOAD f3=%0d", f3));
+    end
+
+    // STORE — funct3 sweep
+    for (int f3 = 0; f3 < 8; f3++) begin
+      instr = {7'h00, 5'd2, 5'd1, f3[2:0], 5'h00, 7'b010_0011};
+      check($sformatf("STORE f3=%0d", f3));
+    end
+
+    // SYSTEM funct3 sweep
+    for (int f3 = 0; f3 < 8; f3++) begin
+      instr = {12'h000, 5'd1, f3[2:0], 5'd3, 7'b111_0011};
+      check($sformatf("SYSTEM f3=%0d", f3));
+    end
+
+    // OP_FP — funct7[6:2] × funct3 × rm_field sweep
+    for (int f7h = 0; f7h < 32; f7h++) begin
+      for (int f3 = 0; f3 < 8; f3++) begin
+        for (int rm = 0; rm < 8; rm++) begin
+          frm   = 3'b000;
+          instr = {f7h[4:0], 2'b00, 5'd2, 5'd1, rm[2:0], 5'd3, 7'b101_0011};
+          check($sformatf("OP_FP f7h=%0d rm_field=%0d", f7h, rm));
+        end
+      end
+    end
+    frm = 3'b000;
+
+    // FMADD/FMSUB/FNMSUB/FNMADD — rm sweep
+    for (int op = 0; op < 4; op++) begin
+      for (int rm = 0; rm < 8; rm++) begin
+        op_field = {3'b100, op[1:0], 2'b11};
+        instr    = {5'd0, 2'b00, 5'd2, 5'd1, rm[2:0], 5'd3, op_field};
+        check($sformatf("FMA opcode=%0h rm=%0d", op_field, rm));
+      end
+    end
+  endtask
+
+  // ----------------------------------------------------------------
+  // Random phase — 100k uniform-random instruction words
+  // ----------------------------------------------------------------
+  task automatic random_phase();
+    for (int i = 0; i < 100_000; i++) begin
+      instr = $urandom();
+      frm   = 3'($urandom_range(0, 7));
+      check("random");
+    end
+  endtask
+
+  // ----------------------------------------------------------------
+  // Main
+  // ----------------------------------------------------------------
+  initial begin
+    instr       = 32'h0;
+    frm         = 3'b000;
+    check_count = 0;
+    err_count   = 0;
+
+    directed_phase();
+    parametric_phase();
+    random_phase();
+
+    $display("=== tb_decode_s6: %0d checks, %0d errors ===",
+             check_count, err_count);
+    if (err_count == 0) $display("PASS");
+    else                $display("FAIL");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

- Splits the 596-line monolithic `kronos_decode` into a thin dispatch wrapper (~98 lines) plus five per-class sub-decoders (`kronos_decode_int`, `_ctrl`, `_mem`, `_sys`, `_fp`).
- Hoists `resolve_rm`, `rm_is_illegal`, and the 20 RV64IMAFDC opcode `localparam`s into `kronos_pkg`.
- External interface and behaviour are bit-equivalent to the pre-refactor decoder; `kronos_top.sv` is byte-identical.
- Verified by a new equivalence harness (`tb_decode_s6.sv`) over directed + parametric + 100k random stimulus (104,236 checks, 0 errors).

## Notes

- This PR sits on top of #72 (ALU redesign). It will be rebased onto `main` once #72 merges; until then the diff includes the ALU commit.
- `tb/stage6/kronos_decode_legacy.sv` is a frozen pre-refactor snapshot used only as the equivalence-harness oracle. It is committed for stage 6 and removed at stage-6 close.
- Lint waivers added for VARHIDDEN false alarms in legacy stage decoders (stages 0/2/4/5) and decompress modules (stages 3/4/5/6) whose module-local opcode `localparam`s shadow the new pkg constants. Values agree (same RISC-V encodings); older stages are frozen historical snapshots.

## Test plan

- [x] `fusesoc --cores-root=. run --target=lint opensoc:ip:kronos_riscv` — clean (post-waiver baseline preserved)
- [x] `cd sim && make sim-all` — every TB green, including stage-4 compliance regression
- [x] `cd sim && make sim-decode-s6-tb` — 104,236 equivalence checks, 0 errors
- [x] `git diff origin/main -- rtl/stage6/kronos_top.sv` — empty (zero downstream impact)
- [x] `cd sim && make sim-arch-test-s6` — verilator build succeeds; full 307-test ACT4 run gates in CI