### PR TITLE
feat(stage6h): cache tag arrays + FP regfile in BRAM/LUTRAM (closes #79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Development follows a staged learning progression:
 | 6e    | PMA layer for MMIO bypass (parameterised non-cacheable regions in `kronos_dcache`) | RV64IMAFDC | AXI4 | Complete |
 | 6f    | BOOM-style frontend rewrite + icache `data_q` BRAM-back | RV64IMAFDC | AXI4 | Complete |
 | 6g    | Dcache `data_q` BRAM-back (4 × `kronos_ram`, EX-stage pre-launch) | RV64IMAFDC | AXI4 | Complete |
+| 6h    | Cache tag arrays + FP regfile in BRAM/LUTRAM (closes #79)        | RV64IMAFDC | AXI4 | Complete |
 | 7     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4 | Planned  |
 
 All five completed stages pass the full `riscv-arch-test` (ACT4) compliance

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 6e    | PMA layer for MMIO bypass (parameterised non-cacheable regions in `kronos_dcache`) | RV64IMAFDC | AXI4 | Complete |
 | 6f    | BOOM-style frontend rewrite + icache `data_q` BRAM-back              | RV64IMAFDC | AXI4    | Complete    |
 | 6g    | Dcache `data_q` BRAM-back (4 × `kronos_ram`, EX-stage pre-launch)    | RV64IMAFDC | AXI4    | Complete    |
+| 6h    | Cache tag arrays + FP regfile in BRAM/LUTRAM (closes #79)            | RV64IMAFDC | AXI4    | Complete    |
 | 7     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # kronos-riscv Architecture Reference
 
-**ISA:** RV64IMAFDC &nbsp;|&nbsp; **Microarchitecture:** 5-stage in-order pipeline &nbsp;|&nbsp; **Bus:** AXI4 &nbsp;|&nbsp; **Branch prediction:** bimodal (64-entry PHT + 16-entry BTB) &nbsp;|&nbsp; **Active stage:** Stage 6d
+**ISA:** RV64IMAFDC &nbsp;|&nbsp; **Microarchitecture:** 5-stage in-order pipeline &nbsp;|&nbsp; **Bus:** AXI4 &nbsp;|&nbsp; **Branch prediction:** bimodal (64-entry PHT + 16-entry BTB) &nbsp;|&nbsp; **Active stage:** Stage 6h
 
 kronos-riscv is a 5-stage in-order RISC-V processor implementing the RV64IMAFDC ISA. Instructions flow through Instruction Fetch (IF), Instruction Decode (ID), Execute (EX), Memory (MEM), and Writeback (WB). The IF stage includes an alignment unit that handles variable-width compressed instructions and a bimodal branch predictor that speculatively redirects fetch before branch resolution. The EX stage contains the 64-bit ALU, a multi-cycle 64-bit multiply/divide unit, branch resolution logic, and the CSR unit. The MEM stage drives an AXI4 load/store unit supporting atomic operations (LR/SC, AMO) and floating-point loads/stores. A separate FPU with six pipelined units handles the F and D extensions; the FPU uses a scoreboard rather than the integer forwarding network for hazard management. Hazard and forwarding control modules sit outside the pipeline stages and manage stalls, flushes, and operand forwarding.
 
@@ -58,7 +58,27 @@ kronos_top  (rtl/stage5/kronos_top.sv)
 
 ---
 
-## 3. IF Stage — Fetch, Alignment, Decompression, Branch Prediction
+## 3. Memory Subsystem
+
+Cache and register-file storage that maps to BRAM/LUTRAM goes through `rtl/common/kronos_ram.sv`, a parameterised SDP RAM wrapper with two backends behind the `KRONOS_RAM_FPGA` define:
+
+- **FPGA backend** — `xpm_memory_sdpram` (Xilinx Parameterized Macros). Vivado infers RAMB36/RAMB18 deterministically. Read latency is 1 cycle; same-cycle write+read collision returns the OLD value (`WRITE_MODE_B = "no_change"` — RAMB36/RAMB18 SDP only supports `"no_change"` / `"read_first"` on port B).
+- **ASIC / Verilator default** — behavioural SDP that synthesises as flops on tools without XPM. Same 1-cycle read, same byte-write semantics. Marked as a stub for vendor SRAM-compiler replacement at tape-out.
+
+Consumers handle same-cycle write→read forwarding externally:
+
+| Consumer | Wrapper instances | Per-instance geometry | Bypass strategy |
+|---|---|---|---|
+| `kronos_icache` data | 4 (one per way) | `64 sets × 16 words × 32 b` | refill→read 1-deep prev-write bypass |
+| `kronos_icache` tag  | 4 | `64 sets × 56 b` (tag zero-padded to 8 b multiple) | refill→read 1-deep prev-tag-write bypass + S1→S2 tag holdover |
+| `kronos_dcache` data | 4 | `64 sets × 8 beats × 64 b` | store-hit / last-refill-beat / load 1-deep prev-write bypass |
+| `kronos_dcache` tag  | 4 | `64 sets × 56 b` | refill→read 1-deep prev-tag-write bypass |
+
+Smaller storage stays in flops or LUTRAM — iTLB/dTLB CAMs (8 entries each), branch predictor PHT/BTB (64+16 entries), integer regfile (`rtl/stage0/kronos_regfile.sv`, LUTRAM), FP regfile (`rtl/common/kronos_regfile_fp.sv`, LUTRAM). The wrapper is not used for these because their geometry (CAMs, very small register banks) does not match BRAM SDP.
+
+---
+
+## 4. IF Stage — Fetch, Alignment, Decompression, Branch Prediction
 
 ### 3a. Fetch FSM
 
@@ -117,7 +137,7 @@ The branch predictor combines a **bimodal pattern history table (PHT)** with a *
 
 ---
 
-## 4. ID Stage — Decode and Register Read
+## 5. ID Stage — Decode and Register Read
 
 ![ID stage block diagram](diagrams/svg/id-stage.svg)
 
@@ -131,7 +151,7 @@ A WB→ID bypass mux sits between the integer register file read ports and the I
 
 ---
 
-## 5. EX Stage — Execute, Branch Resolution, Muldiv
+## 6. EX Stage — Execute, Branch Resolution, Muldiv
 
 ![EX stage block diagram](diagrams/svg/ex-stage.svg)
 
@@ -167,7 +187,7 @@ In addition to `result_o`, the ALU exposes `adder_out_o` (raw adder output, befo
 
 ---
 
-## 6. FPU
+## 7. FPU
 
 The FPU handles all F and D extension instructions. It is logically separate from the integer pipeline: FP instructions are dispatched from EX to `kronos_fpu_top`, which routes them to one of six pipelined units. Results are written directly to `kronos_regfile_fp` through the FPU's dedicated writeback interface, bypassing the integer WB mux.
 
@@ -205,7 +225,7 @@ All units implement IEEE 754-2019 rounding and exception flag generation. The re
 
 ---
 
-## 7. MEM Stage — AXI4 Load/Store Unit
+## 8. MEM Stage — AXI4 Load/Store Unit
 
 ![LSU FSM](diagrams/svg/mem-lsu-fsm.svg)
 
@@ -235,7 +255,7 @@ In STORE_SEND the FSM asserts both `awvalid` and `wvalid` simultaneously. Two fl
 
 ---
 
-## 8. WB Stage — Writeback
+## 9. WB Stage — Writeback
 
 ![Writeback mux](diagrams/svg/wb-mux.svg)
 
@@ -254,7 +274,7 @@ FP writeback is a separate path from `kronos_fpu_top` directly to `kronos_regfil
 
 ---
 
-## 9. Hazard and Forwarding Control
+## 10. Hazard and Forwarding Control
 
 ![Hazard and forwarding control plane](diagrams/svg/hazard-forward.svg)
 
@@ -285,7 +305,7 @@ FP hazards are managed entirely by the scoreboard. `kronos_forward` and `kronos_
 
 ---
 
-## 10. Timing Table
+## 11. Timing Table
 
 Cycles measured from the instruction entering EX to its result being available in WB (or to the first valid instruction after a redirect for branches and traps). FPU latencies are measured from dispatch (EX) to writeback.
 
@@ -316,7 +336,7 @@ Cycles measured from the instruction entering EX to its result being available i
 
 ---
 
-## 11. CSR Register Map
+## 12. CSR Register Map
 
 | Address | Name | Description |
 |---------|------|-------------|
@@ -343,7 +363,7 @@ Cycles measured from the instruction entering EX to its result being available i
 
 ---
 
-## 12. Performance counters (Zicntr + partial Zihpm)
+## 13. Performance counters (Zicntr + partial Zihpm)
 
 Stage 5c adds architectural performance counters so subsequent
 microarchitectural changes (caches, MMU, OOO) can be measured

--- a/rtl/common/kronos_regfile_fp.sv
+++ b/rtl/common/kronos_regfile_fp.sv
@@ -7,6 +7,11 @@
 // - Read ports are asynchronous (combinatorial), matching the integer regfile.
 //   Read-before-write: a write and read of the same address in the same cycle
 //   returns the old value; the EX-bypass network handles this case.
+// - The `ram_style` attribute directs Vivado to pack the array as LUTRAM
+//   (distributed RAM) rather than inferring per-bit flops, mirroring the
+//   integer regfile. Initial contents are X / don't-care; the FP scoreboard
+//   prevents architectural reads of un-written registers, so the lack of a
+//   reset loop is not visible.
 module kronos_regfile_fp (
   input  logic        clk_i,
   input  logic        rst_ni,
@@ -20,14 +25,14 @@ module kronos_regfile_fp (
   input  logic [63:0] wd_i,
   input  logic        we_i
 );
-  logic [63:0] rf [32];
+  (* ram_style = "distributed" *) logic [63:0] rf [32];
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      for (int i = 0; i < 32; i++) rf[i] <= {64{1'b0}};
-    end else begin
-      if (we_i) rf[wa_i] <= wd_i;
-    end
+  // rst_ni is intentionally unused (LUTRAM cannot be reset).
+  logic _unused_rst;
+  assign _unused_rst = rst_ni;
+
+  always_ff @(posedge clk_i) begin
+    if (we_i) rf[wa_i] <= wd_i;
   end
 
   assign rd1_o = rf[ra1_i];

--- a/rtl/stage6/kronos_dcache.sv
+++ b/rtl/stage6/kronos_dcache.sv
@@ -112,8 +112,9 @@ module kronos_dcache
   } dcache_state_e;
 
   // ---- State registers (driven by always_ff) -------------------------------
-  // Storage arrays (data_q is now in 4 x kronos_ram, see gen_data_ram below)
-  logic [TAG_W-1:0] tag_q   [NUM_SETS][NUM_WAYS];
+  // Storage arrays. data_q lives in 4 x kronos_ram (gen_data_ram below) and
+  // tag_q lives in 4 x kronos_ram (gen_tag_ram below); valid/dirty/PLRU stay
+  // in flops to preserve single-cycle FENCE.I and store-hit dirty updates.
   logic             valid_q [NUM_SETS][NUM_WAYS];
   logic             dirty_q [NUM_SETS][NUM_WAYS];
   logic [2:0]       plru_q  [NUM_SETS];
@@ -176,6 +177,11 @@ module kronos_dcache
   logic [SET_IDX_W-1:0]              flush_set_q;
   logic [$clog2(NUM_WAYS)-1:0]       flush_way_q;
   logic                              flush_done_q;
+  // flush_tag_settled_q: 1 iff tag_rdata_eff currently reflects flush_set_q.
+  // Cleared on every entry to DC_FLUSH_SCAN and on every flush_set_q change;
+  // set on the next cycle, after the BRAM read launched at flush_set_q has
+  // landed. Used to stall the FLUSH_SCAN body for one bubble cycle per set.
+  logic                              flush_tag_settled_q;
 
   // track which port owns the in-flight (multi-cycle) request so
   // responses produced after the request cycle (refill bypass, store_done,
@@ -284,6 +290,32 @@ module kronos_dcache
   logic                                      ram_re;
   logic [RAM_ADDR_W-1:0]                     ram_raddr;
   logic [kronos_pkg::XLEN-1:0]               ram_rdata [NUM_WAYS];
+
+  // ---- Per-way TAG-RAM interface signals (driven combinationally) ----------
+  // TAG_RAM_W is TAG_W zero-padded up to a byte multiple so kronos_ram's
+  // BYTE_WIDTH=8 byte-write geometry is satisfied.
+  localparam int unsigned TAG_RAM_W = ((TAG_W + 7) / 8) * 8;
+
+  logic [NUM_WAYS-1:0]               tag_we;
+  logic [SET_IDX_W-1:0]              tag_waddr;
+  logic [TAG_RAM_W-1:0]              tag_wdata;
+  logic                              tag_re;
+  logic [SET_IDX_W-1:0]              tag_raddr;
+  logic [TAG_RAM_W-1:0]              tag_rdata     [NUM_WAYS];
+  logic [TAG_W-1:0]                  tag_rdata_eff [NUM_WAYS];   // post-RAW-bypass
+
+  // 1-deep RAW bypass for refill-tag-write -> same-set read collision.
+  // kronos_ram port-B "no_change" mode leaves rdata stale on a same-cycle
+  // write+read at the same address; this register catches the just-written
+  // tag for one cycle so the post-refill tag-compare sees the new value.
+  logic                              prev_tag_write_q;
+  logic [SET_IDX_W-1:0]              prev_tag_set_q;
+  logic [NUM_WAYS-1:0]               prev_tag_way_oh_q;
+  logic [TAG_W-1:0]                  prev_tag_data_q;
+
+  // True for exactly one cycle on the refill-completion edge: the cycle on
+  // which the new tag/valid/dirty bookkeeping commits.
+  logic refill_complete_fire;
 
   // Refill beat-in-burst pointer (CWF wrap inside the line).
   logic [BEAT_IDX_W-1:0] refill_beat_in_burst;
@@ -459,7 +491,7 @@ module kronos_dcache
   always_comb begin
     hit_way_oh = {NUM_WAYS{1'b0}};
     for (int w = 0; w < NUM_WAYS; w++) begin
-      hit_way_oh[w] = eff_req_valid & valid_q[set_idx][w] & (tag_q[set_idx][w] == tag_in);
+      hit_way_oh[w] = eff_req_valid & valid_q[set_idx][w] & (tag_rdata_eff[w] == tag_in);
     end
     hit = |hit_way_oh;
   end
@@ -554,6 +586,93 @@ module kronos_dcache
       );
     end
   endgenerate
+
+  // ==========================================================================
+  // BRAM tag array (one kronos_ram per way)
+  // ==========================================================================
+  // Set-indexed tag store. Same WRITE_MODE_B="no_change" as the data RAM —
+  // the refill→read collision is covered by the prev_tag_*_q 1-deep bypass.
+  generate
+    for (genvar gi = 0; gi < NUM_WAYS; gi++) begin : gen_tag_ram
+      kronos_ram #(
+        .DEPTH        (NUM_SETS),
+        .WIDTH        (TAG_RAM_W),
+        .BYTE_WIDTH   (8),
+        .WRITE_MODE_B ("no_change")
+      ) u_tag_ram (
+        .clk_i   (clk_i),
+        .we_i    (tag_we[gi]),
+        .waddr_i (tag_waddr),
+        .wdata_i (tag_wdata),
+        .wmask_i ({(TAG_RAM_W/8){1'b1}}),
+        .re_i    (tag_re),
+        .raddr_i (tag_raddr),
+        .rdata_o (tag_rdata[gi])
+      );
+    end
+  endgenerate
+
+  // tag_rdata_eff: strip the zero-pad and apply the 1-deep RAW bypass for
+  // refill→same-set read collisions.
+  always_comb begin
+    for (int w = 0; w < NUM_WAYS; w++) begin
+      tag_rdata_eff[w] = tag_rdata[w][TAG_W-1:0];
+      if (prev_tag_write_q & (set_idx == prev_tag_set_q) & prev_tag_way_oh_q[w]) begin
+        tag_rdata_eff[w] = prev_tag_data_q;
+      end
+    end
+  end
+
+  // True for one cycle: the refill-bookkeeping commit (last R beat accepted).
+  // Drives the tag RAM write-enable and the prev_tag_*_q capture.
+  assign refill_complete_fire = (state_q == DC_REFILL_R)
+                              & axi_req_o.r_ready
+                              & axi_rsp_i.r_valid
+                              & axi_rsp_i.r.last;
+
+  // Tag-RAM write side. Target way is victim_q on refill complete.
+  always_comb begin
+    tag_we    = {NUM_WAYS{1'b0}};
+    tag_waddr = miss_set_q;
+    tag_wdata = {{(TAG_RAM_W - TAG_W){1'b0}}, miss_tag_q};
+
+    if (refill_complete_fire) begin
+      for (int w = 0; w < NUM_WAYS; w++) begin
+        if (w == int'(victim_q)) tag_we[w] = 1'b1;
+      end
+    end
+  end
+
+  // Tag-RAM read mux. Mirrors the data-RAM read priority chain but with
+  // set-only addressing (no beat field). Default = LSU pre-launch from
+  // EX-stage dTLB PA. Flush-walk states drive flush_set_q so the
+  // FLUSH_SCAN body can capture evict_tag_q from tag_rdata_eff[flush_way_q].
+  always_comb begin
+    tag_re    = early_req_valid_i;
+    tag_raddr = early_addr_i[OFFSET_W + SET_IDX_W - 1 : OFFSET_W];
+
+    if ((state_q == DC_REFILL_R) | (state_q == DC_REFILL_AR)
+        | (state_q == DC_AMO_RMW)) begin
+      tag_re    = 1'b1;
+      tag_raddr = eff_req_addr[OFFSET_W + SET_IDX_W - 1 : OFFSET_W];
+    end else if ((state_q == DC_IDLE) & ptw_active) begin
+      tag_re    = 1'b1;
+      tag_raddr = eff_req_addr[OFFSET_W + SET_IDX_W - 1 : OFFSET_W];
+    end else if (state_q == DC_FLUSH_SCAN) begin
+      // Drive the tag read for the flush walk's current set; the FLUSH_SCAN
+      // body captures evict_tag_q <= tag_rdata_eff[flush_way_q] one cycle
+      // after the set was last changed (gated by flush_tag_settled_q).
+      tag_re    = 1'b1;
+      tag_raddr = flush_set_q;
+    end else if ((state_q == DC_WB_AW) | (state_q == DC_WB_W)
+               | (state_q == DC_FLUSH_AW) | (state_q == DC_FLUSH_W)) begin
+      // Writeback walk: tag was already captured into evict_tag_q
+      // (in IDLE for normal miss, in FLUSH_SCAN for flush walk); the tag
+      // RAM is idle here. Keep tag_re low.
+      tag_re    = 1'b0;
+      tag_raddr = miss_set_q;
+    end
+  end
 
   // ==========================================================================
   // BRAM port-A: per-way write enables / write data / mask
@@ -734,6 +853,7 @@ module kronos_dcache
       flush_set_q          <= {SET_IDX_W{1'b0}};
       flush_way_q          <= {$clog2(NUM_WAYS){1'b0}};
       flush_done_q         <= 1'b0;
+      flush_tag_settled_q  <= 1'b0;
       in_flight_is_ptw_q   <= 1'b0;
       nc_addr_q            <= {PHYS_ADDR_W{1'b0}};
       nc_size_q            <= 3'b0;
@@ -751,16 +871,19 @@ module kronos_dcache
       prev_write_data_q    <= {kronos_pkg::XLEN{1'b0}};
       prev_write_mask_q    <= {kronos_pkg::XLEN_BYTES{1'b0}};
       prev_write_active_q  <= 1'b0;
+      prev_tag_write_q     <= 1'b0;
+      prev_tag_set_q       <= {SET_IDX_W{1'b0}};
+      prev_tag_way_oh_q    <= {NUM_WAYS{1'b0}};
+      prev_tag_data_q      <= {TAG_W{1'b0}};
       for (int s = 0; s < NUM_SETS; s++) begin
         plru_q[s] <= 3'b0;
         for (int w = 0; w < NUM_WAYS; w++) begin
           valid_q[s][w] <= 1'b0;
           dirty_q[s][w] <= 1'b0;
-          tag_q[s][w]   <= {TAG_W{1'b0}};
         end
       end
-      // No data_q reset — BRAM contents are don't-care at reset; valid_q
-      // is the source of truth for "is this address readable".
+      // No data_q / tag_q reset — BRAM contents are don't-care at reset;
+      // valid_q is the source of truth for "is this address readable".
     end else begin
       miss_pulse_q   <= miss_event;
       bypass_valid_q <= 1'b0;
@@ -777,6 +900,18 @@ module kronos_dcache
       prev_write_addr_q   <= ram_waddr;
       prev_write_data_q   <= ram_wdata;
       prev_write_mask_q   <= ram_wmask;
+      // 1-deep RAW bypass for the tag RAM: capture the tag write that fires
+      // this cycle so the next cycle's tag-compare sees the new value
+      // (xpm SDP "no_change" returns the OLD tag on a same-cycle write+read).
+      prev_tag_write_q <= refill_complete_fire;
+      if (refill_complete_fire) begin
+        prev_tag_set_q    <= miss_set_q;
+        prev_tag_way_oh_q <= {NUM_WAYS{1'b0}};
+        for (int w = 0; w < NUM_WAYS; w++) begin
+          if (w == int'(victim_q)) prev_tag_way_oh_q[w] <= 1'b1;
+        end
+        prev_tag_data_q <= miss_tag_q;
+      end
       // NC response/completion pulses — default-clear each cycle.
       nc_rsp_valid_q <= 1'b0;
       nc_b_done_q    <= 1'b0;
@@ -816,9 +951,10 @@ module kronos_dcache
           // request so we don't restart a second flush walk.
           if (flush_i & ~flush_done_q) begin
             // FENCE.I full writeback + invalidate walk.
-            flush_set_q <= {SET_IDX_W{1'b0}};
-            flush_way_q <= {$clog2(NUM_WAYS){1'b0}};
-            state_q     <= DC_FLUSH_SCAN;
+            flush_set_q         <= {SET_IDX_W{1'b0}};
+            flush_way_q         <= {$clog2(NUM_WAYS){1'b0}};
+            flush_tag_settled_q <= 1'b0;   // bubble cycle for first BRAM read
+            state_q             <= DC_FLUSH_SCAN;
           end else if (eff_req_valid & is_uncacheable) begin
             // PMA bypass — non-cacheable address; single-beat AXI.
             // Important: this arm fully owns the request when is_uncacheable
@@ -880,7 +1016,7 @@ module kronos_dcache
                                                            eff_req_wdata);
                 miss_store_strobes_q <= store_strobes(eff_req_size, eff_req_addr[2:0]);
                 miss_store_off_q     <= eff_req_addr[2:0];
-                evict_tag_q          <= tag_q[set_idx][victim_pick];
+                evict_tag_q          <= tag_rdata_eff[victim_pick];
                 wb_beat_cnt_q        <= 4'd0;
                 sc_success_q         <= 1'b1;
                 if (valid_q[set_idx][victim_pick] & dirty_q[set_idx][victim_pick]) begin
@@ -904,7 +1040,7 @@ module kronos_dcache
                 miss_beat_q    <= beat_idx;
                 victim_q       <= victim_pick;
                 beat_cnt_q     <= 4'd0;
-                evict_tag_q    <= tag_q[set_idx][victim_pick];
+                evict_tag_q    <= tag_rdata_eff[victim_pick];
                 wb_beat_cnt_q  <= 4'd0;
                 if (valid_q[set_idx][victim_pick] & dirty_q[set_idx][victim_pick]) begin
                   state_q <= DC_WB_AW;
@@ -943,7 +1079,7 @@ module kronos_dcache
                 amo_src_q      <= eff_req_wdata;
                 amo_is_word_q  <= (eff_req_size == 3'd2);
                 amo_addr_off_q <= eff_req_addr[2:0];
-                evict_tag_q    <= tag_q[set_idx][victim_pick];
+                evict_tag_q    <= tag_rdata_eff[victim_pick];
                 wb_beat_cnt_q  <= 4'd0;
                 if (valid_q[set_idx][victim_pick] & dirty_q[set_idx][victim_pick]) begin
                   state_q <= DC_WB_AW;
@@ -979,7 +1115,7 @@ module kronos_dcache
                                                          eff_req_wdata);
               miss_store_strobes_q <= store_strobes(eff_req_size, eff_req_addr[2:0]);
               miss_store_off_q     <= eff_req_addr[2:0];
-              evict_tag_q          <= tag_q[set_idx][victim_pick];
+              evict_tag_q          <= tag_rdata_eff[victim_pick];
               wb_beat_cnt_q        <= 4'd0;
               if (valid_q[set_idx][victim_pick] & dirty_q[set_idx][victim_pick]) begin
                 state_q <= DC_WB_AW;
@@ -1008,7 +1144,7 @@ module kronos_dcache
             end
             beat_cnt_q <= beat_cnt_q + 4'd1;
             if (axi_rsp_i.r.last) begin
-              tag_q[miss_set_q][victim_q]   <= miss_tag_q;
+              // tag write fires combinationally via tag_we (refill_complete_fire)
               valid_q[miss_set_q][victim_q] <= 1'b1;
               dirty_q[miss_set_q][victim_q] <= miss_was_store_q;
               plru_q[miss_set_q]            <= plru_update(plru_q[miss_set_q], victim_q);
@@ -1047,29 +1183,42 @@ module kronos_dcache
           // Walk (set, way).  Dirty → writeback path; clean → just
           // invalidate and advance.  When the walk completes, pulse
           // flush_done_q for one cycle and return to DC_IDLE.
-          if (valid_q[flush_set_q][flush_way_q] &
-              dirty_q[flush_set_q][flush_way_q]) begin
-            // Reuse the writeback registers — no other transaction is
-            // active during a flush walk.
-            miss_set_q    <= flush_set_q;
-            victim_q      <= flush_way_q;
-            evict_tag_q   <= tag_q[flush_set_q][flush_way_q];
-            wb_beat_cnt_q <= 4'd0;
-            state_q       <= DC_FLUSH_AW;
-          end else begin
-            // Clean or invalid line: just invalidate and advance.
-            valid_q[flush_set_q][flush_way_q] <= 1'b0;
-            if (flush_way_q == ($clog2(NUM_WAYS))'(NUM_WAYS - 1)) begin
-              flush_way_q <= {$clog2(NUM_WAYS){1'b0}};
-              if (flush_set_q == SET_IDX_W'(NUM_SETS - 1)) begin
-                flush_done_q <= 1'b1;
-                state_q      <= DC_IDLE;
-              end else begin
-                flush_set_q <= flush_set_q + 1'b1;
-              end
+          //
+          // Tag arrays are BRAM-back: tag_rdata_eff[flush_way_q] is only
+          // valid one cycle after flush_set_q became the tag_raddr.
+          // flush_tag_settled_q gates the body — when low, stall this cycle
+          // (do nothing else) so the BRAM read can settle. The flag is
+          // re-armed below on every flush_set_q change.
+          if (flush_tag_settled_q) begin
+            if (valid_q[flush_set_q][flush_way_q] &
+                dirty_q[flush_set_q][flush_way_q]) begin
+              // Dirty line: capture the tag (from BRAM via tag_rdata_eff)
+              // and start the writeback. Reuse the WB registers — no
+              // other transaction is active during a flush walk.
+              miss_set_q    <= flush_set_q;
+              victim_q      <= flush_way_q;
+              evict_tag_q   <= tag_rdata_eff[flush_way_q];
+              wb_beat_cnt_q <= 4'd0;
+              state_q       <= DC_FLUSH_AW;
             end else begin
-              flush_way_q <= flush_way_q + 1'b1;
+              // Clean or invalid line: just invalidate and advance.
+              valid_q[flush_set_q][flush_way_q] <= 1'b0;
+              if (flush_way_q == ($clog2(NUM_WAYS))'(NUM_WAYS - 1)) begin
+                flush_way_q <= {$clog2(NUM_WAYS){1'b0}};
+                if (flush_set_q == SET_IDX_W'(NUM_SETS - 1)) begin
+                  flush_done_q <= 1'b1;
+                  state_q      <= DC_IDLE;
+                end else begin
+                  flush_set_q         <= flush_set_q + 1'b1;
+                  flush_tag_settled_q <= 1'b0;
+                end
+              end else begin
+                flush_way_q <= flush_way_q + 1'b1;
+              end
             end
+          end else begin
+            // Bubble cycle: BRAM read in flight, latch settled for next.
+            flush_tag_settled_q <= 1'b1;
           end
         end
         DC_FLUSH_AW: begin
@@ -1089,8 +1238,9 @@ module kronos_dcache
                   flush_done_q <= 1'b1;
                   state_q      <= DC_IDLE;
                 end else begin
-                  flush_set_q <= flush_set_q + 1'b1;
-                  state_q     <= DC_FLUSH_SCAN;
+                  flush_set_q         <= flush_set_q + 1'b1;
+                  flush_tag_settled_q <= 1'b0;   // new set: need a bubble
+                  state_q             <= DC_FLUSH_SCAN;
                 end
               end else begin
                 flush_way_q <= flush_way_q + 1'b1;
@@ -1167,6 +1317,11 @@ module kronos_dcache
     // Write channel: dirty-eviction AW/W/B (line-aligned address)
     // TAG_W + SET_IDX_W + OFFSET_W == PHYS_ADDR_W by construction, so no
     // upper-pad concat is needed (Synth 8-693 zero-replication).
+    //
+    // evict_tag_q is captured in DC_IDLE for normal misses (from
+    // tag_rdata_eff[victim_pick]) and in DC_FLUSH_SCAN for the flush walk
+    // (from tag_rdata_eff[flush_way_q]); in both cases the tag is read
+    // from BRAM and held in evict_tag_q across the multi-cycle WB burst.
     axi_req_o.aw.addr  = {evict_tag_q, miss_set_q, {OFFSET_W{1'b0}}};
     axi_req_o.aw.size  = 3'b011;
     axi_req_o.aw.len   = 8'd7;

--- a/rtl/stage6/kronos_icache.sv
+++ b/rtl/stage6/kronos_icache.sv
@@ -102,8 +102,10 @@ module kronos_icache
     ICACHE_REFILL_R   = 2'b10
   } icache_state_e;
 
-  // ---- Tag / valid / PLRU arrays (FF — same as v2) -------------------------
-  logic [TAG_W-1:0]              tag_q   [NUM_SETS][NUM_WAYS];
+  // ---- Tag / valid / PLRU arrays -------------------------------------------
+  // Tag arrays are wrapped in per-way kronos_ram instances (see gen_tag_ram
+  // below).  valid_q stays in flops to preserve the single-cycle FENCE.I
+  // flash-clear; PLRU stays in flops because it is rewritten every hit.
   logic                          valid_q [NUM_SETS][NUM_WAYS];
   logic [2:0]                    plru_q  [NUM_SETS];
 
@@ -208,6 +210,31 @@ module kronos_icache
   logic [kronos_pkg::INST_W-1:0] ram_wdata;
   logic [kronos_pkg::INST_W-1:0] ram_rdata [NUM_WAYS];
 
+  // ---- Per-way TAG-RAM interface signals (driven combinationally) ----------
+  // TAG_W = 52, padded to a multiple of BYTE_WIDTH (8) so xpm_memory_sdpram
+  // accepts the byte-write geometry.  The 4 unused MSBs are tied to zero on
+  // write and stripped on read.
+  localparam int unsigned TAG_RAM_W = ((TAG_W + 7) / 8) * 8;   // 56
+
+  logic [NUM_WAYS-1:0]           tag_we;
+  logic [SET_IDX_W-1:0]          tag_waddr;
+  logic [TAG_RAM_W-1:0]          tag_wdata;
+  logic                          tag_re;
+  logic [SET_IDX_W-1:0]          tag_raddr;
+  logic [TAG_RAM_W-1:0]          tag_rdata        [NUM_WAYS];
+  logic [TAG_W-1:0]              tag_rdata_eff_s1 [NUM_WAYS];   // S1, post-bypass
+  logic [TAG_W-1:0]              s2_tag_data_q    [NUM_WAYS];   // S2 holdover
+
+  // 1-deep RAW bypass for refill→read collision (BRAM port-B is "no_change",
+  // so a load reading the just-written tag would otherwise see stale data).
+  logic                          prev_tag_write_q;
+  logic [SET_IDX_W-1:0]          prev_tag_set_q;
+  logic [NUM_WAYS-1:0]           prev_tag_way_oh_q;
+  logic [TAG_W-1:0]              prev_tag_data_q;
+
+  // One-cycle pulse: refill commit cycle (replaces the in-FSM tag_q write).
+  logic                          refill_tag_write_fire;
+
   // Lint suppression
   logic                          _unused;
 
@@ -246,7 +273,7 @@ module kronos_icache
     hit_way_oh_s1 = {NUM_WAYS{1'b0}};
     for (int w = 0; w < NUM_WAYS; w++) begin
       hit_way_oh_s1[w] = s1_valid_q & valid_q[s1_set_idx][w] &
-                         (tag_q[s1_set_idx][w] == s1_tag);
+                         (tag_rdata_eff_s1[w] == s1_tag);
     end
     hit_s1 = |hit_way_oh_s1;
   end
@@ -265,7 +292,7 @@ module kronos_icache
     hit_way_s2    = {$clog2(NUM_WAYS){1'b0}};
     for (int w = 0; w < NUM_WAYS; w++) begin
       hit_way_oh_s2[w] = s2_valid_q & valid_q[s2_set_idx][w] &
-                         (tag_q[s2_set_idx][w] == s2_tag);
+                         (s2_tag_data_q[w] == s2_tag);
     end
     for (int w = 0; w < NUM_WAYS; w++) begin
       if (hit_way_oh_s2[w]) hit_way_s2 = w[$clog2(NUM_WAYS)-1:0];
@@ -421,7 +448,6 @@ module kronos_icache
         plru_q[s] <= 3'b0;
         for (int w = 0; w < NUM_WAYS; w++) begin
           valid_q[s][w] <= 1'b0;
-          tag_q[s][w]   <= {TAG_W{1'b0}};
         end
       end
     end else begin
@@ -471,7 +497,7 @@ module kronos_icache
             refill_phase_q <= 1'b0;
             beat_cnt_q     <= beat_cnt_q + BEAT_CNT_W'(1);
             if (refill_last_done) begin
-              tag_q[miss_set_q][victim_q]   <= miss_tag_q;
+              // Tag write is handled by refill_tag_write_fire → tag RAM port.
               valid_q[miss_set_q][victim_q] <= 1'b1;
               plru_q[miss_set_q]            <= plru_update(plru_q[miss_set_q], victim_q);
               refill_squashed_q             <= 1'b0;
@@ -548,6 +574,105 @@ module kronos_icache
       );
     end
   endgenerate
+
+  // ==========================================================================
+  // Tag RAM — one kronos_ram per way (port-A write, port-B read).
+  // Per-way DEPTH=NUM_SETS, WIDTH=TAG_RAM_W (TAG_W zero-padded to 8b multiple).
+  // WRITE_MODE_B="no_change" matches the data RAM; refill→read same-set
+  // collision handled by the 1-deep prev_tag_*_q bypass.
+  // ==========================================================================
+  generate
+    for (genvar gi = 0; gi < NUM_WAYS; gi++) begin : gen_tag_ram
+      kronos_ram #(
+        .DEPTH        (NUM_SETS),
+        .WIDTH        (TAG_RAM_W),
+        .BYTE_WIDTH   (8),
+        .WRITE_MODE_B ("no_change")
+      ) u_tag_ram (
+        .clk_i   (clk_i),
+        .we_i    (tag_we[gi]),
+        .waddr_i (tag_waddr),
+        .wdata_i (tag_wdata),
+        .wmask_i ({(TAG_RAM_W/8){1'b1}}),
+        .re_i    (tag_re),
+        .raddr_i (tag_raddr),
+        .rdata_o (tag_rdata[gi])
+      );
+    end
+  endgenerate
+
+  // ---- Tag RAM read mux ----------------------------------------------------
+  // Tag read launches at S0 alongside the data-RAM read; output lands at S1
+  // for the hit comparator.  Holds across S1 stalls because s0_ready_o gates
+  // s0_accept (no new launch ⇒ BRAM port-B holds the previous output).
+  always_comb begin
+    tag_re    = s0_accept;
+    tag_raddr = s0_set_idx;
+  end
+
+  // ---- Tag RAM write side --------------------------------------------------
+  // Write fires for exactly one cycle on the refill-complete edge — same
+  // predicate that previously drove `tag_q[miss_set_q][victim_q] <= miss_tag_q`
+  // inside the FSM.
+  assign refill_tag_write_fire = (state_q == ICACHE_REFILL_R) & refill_last_done;
+
+  always_comb begin
+    tag_we    = {NUM_WAYS{1'b0}};
+    tag_waddr = miss_set_q;
+    tag_wdata = {{(TAG_RAM_W - TAG_W){1'b0}}, miss_tag_q};
+
+    if (refill_tag_write_fire) begin
+      for (int w = 0; w < NUM_WAYS; w++) begin
+        if (w == int'(victim_q)) tag_we[w] = 1'b1;
+      end
+    end
+  end
+
+  // ---- 1-deep RAW-bypass register ------------------------------------------
+  // After a refill writes the tag at cycle N, an S0 read launched at cycle N
+  // (same set) would see the OLD tag at S1 because port-B is "no_change".
+  // The bypass tracks the most recent tag write and overrides the per-way
+  // S1 tag compare.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      prev_tag_write_q  <= 1'b0;
+      prev_tag_set_q    <= {SET_IDX_W{1'b0}};
+      prev_tag_way_oh_q <= {NUM_WAYS{1'b0}};
+      prev_tag_data_q   <= {TAG_W{1'b0}};
+    end else begin
+      prev_tag_write_q <= refill_tag_write_fire;
+      if (refill_tag_write_fire) begin
+        prev_tag_set_q    <= miss_set_q;
+        prev_tag_way_oh_q <= {NUM_WAYS{1'b0}};
+        for (int w = 0; w < NUM_WAYS; w++) begin
+          if (w == int'(victim_q)) prev_tag_way_oh_q[w] <= 1'b1;
+        end
+        prev_tag_data_q <= miss_tag_q;
+      end
+    end
+  end
+
+  // ---- S1 effective tag (post-RAW-bypass) ----------------------------------
+  always_comb begin
+    for (int w = 0; w < NUM_WAYS; w++) begin
+      tag_rdata_eff_s1[w] = tag_rdata[w][TAG_W-1:0];
+      if (prev_tag_write_q & (s1_set_idx == prev_tag_set_q) &
+          prev_tag_way_oh_q[w]) begin
+        tag_rdata_eff_s1[w] = prev_tag_data_q;
+      end
+    end
+  end
+
+  // ---- S1 → S2 tag holdover register ---------------------------------------
+  // S2 hit detection runs against the registered tag.  Latched on s1_advance
+  // (the same predicate that promotes the rest of the S1 entry into S2).
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      for (int w = 0; w < NUM_WAYS; w++) s2_tag_data_q[w] <= {TAG_W{1'b0}};
+    end else if (s1_advance) begin
+      for (int w = 0; w < NUM_WAYS; w++) s2_tag_data_q[w] <= tag_rdata_eff_s1[w];
+    end
+  end
 
   // ---- Bypass holding register ---------------------------------------------
   // bypass_drive presents the bypass tuple to the FB whenever a fresh


### PR DESCRIPTION
## Summary

- iCache + dCache tag arrays wrapped in `kronos_ram` (xpm SDP / ASIC stub) with 1-deep refill→read RAW bypass. iCache adds a 208-FF S1→S2 tag holdover register; dCache reuses the EX-stage `early_addr_i` pre-launch hook from 6g and captures `evict_tag_q` from BRAM with a 1-cycle settle bubble on the flush walk to keep the AW-address path flop-bounded.
- FP register file moved to LUTRAM via `(* ram_style = "distributed" *)`, reset loop removed.
- `valid` + `dirty` arrays kept in flops on purpose: preserves single-cycle FENCE.I on icache and single-cycle store-hit dirty update on dcache.
- New `Memory Subsystem` section in `docs/architecture.md`; README + CLAUDE.md stage tables ticked.

## FF/resource impact (post-OOC-synth, xck26-sfvc784-2LV-c, Vivado 2025.2)

| Metric | Post-6g | Post-6h |
|---|---:|---:|
| Total FFs | 44,828 | **15,762** (−29,066, −65 %) |
| RAMB36E2 cells | 8 | 16 (+8 — 4 per cache for new tag arrays) |
| LUTRAM (RAM32M16) cells | — | 25 |

Lands well under the ≤ 20 K total-FF acceptance criterion in #79.

## Test plan

- [x] `make sim-all` — all unit + integration testbenches PASS
- [x] `make sim-arch-test-s6` — 305/305
- [x] `make sim-arch-test-s6-priv` — 305/305
- [x] `make sim-crv-smoke` — all CRV groups PASS
- [x] `make gls-funcsim-s6` — 6/6 PASS
- [x] Pre-commit `python3 scripts/check_rtl_rules.py --staged` clean on every staged delta
- [x] OOC synth on xck26 (numbers above)

Closes #79.
Closes #64.

Spec: `docs/superpowers/specs/2026-05-03-stage6h-cache-tag-bram-design.md`
Plan: `docs/superpowers/plans/2026-05-03-stage6h-cache-tag-bram.md`
