### PR TITLE
feat(stage6i): verification overhaul (dcache RAW regression + CRV-s6 + cosim fuzzer)

### DIFF
--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -80,6 +80,208 @@ jobs:
               labels: ['ci-failure', 'crv'],
             });
 
+  dcache-stress-deep-s6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run dcache-stress-deep-s6
+        id: dcache
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim sim-dcache-s6-stress-deep PULP_AXI_ROOT=/tmp/pulp_axi
+
+      - name: Open tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[dcache-stress-deep nightly] failure ${date} (run ${context.runId})`,
+              body: [
+                `Nightly dcache constrained-random stressor (100 seeds × 10k ops) failed.`,
+                ``,
+                `**Run:** https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                ``,
+                `Reproduce locally:`,
+                '```',
+                `  cd ~/kronos-riscv`,
+                `  make -C sim sim-dcache-s6-stress DCACHE_SEED=<failing_seed>`,
+                '```',
+              ].join('\n'),
+              labels: ['ci-failure', 'dcache'],
+            });
+
+  crv-deep-s6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Install Sail
+        run: |
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/riscv/sail-riscv/releases/download/0.10/sail-riscv-$(uname)-$(arch).tar.gz \
+            | sudo tar xz --directory=/usr/local --strip-components=1
+          sudo tee /usr/local/bin/sail_riscv_sim_timeout > /dev/null <<'EOF'
+          #!/usr/bin/env bash
+          exec timeout 60 sail_riscv_sim "$@"
+          EOF
+          sudo chmod +x /usr/local/bin/sail_riscv_sim_timeout
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run crv-deep-s6
+        id: crv_s6
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim sim-crv-deep-s6 PULP_AXI_ROOT=/tmp/pulp_axi \
+            CRV_SEED_BASE=$(date +%Y%m%d)000
+
+      - name: Upload CRV artefacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crv-deep-s6-${{ github.run_id }}
+          path: sim/obj_dir/crv/
+          if-no-files-found: ignore
+
+      - name: Open tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[crv-deep-s6 nightly] failure ${date} (run ${context.runId})`,
+              body: [
+                `Nightly Stage-6 CRV-deep regression (8 scenarios × 50 seeds) failed.`,
+                ``,
+                `**Run:** https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `**Artefacts:** \`crv-deep-s6-${context.runId}\` attached to the run`,
+                ``,
+                `Reproduce locally:`,
+                '```',
+                `  cd ~/kronos-riscv`,
+                `  make -C sim sim-crv-s6-<scenario> CRV_SEED=<failing_seed>`,
+                '```',
+                ``,
+                `Look at the artefact's \`<scenario>_<seed>/\` directory for the .S, traces, and diff.txt.`,
+              ].join('\n'),
+              labels: ['ci-failure', 'crv'],
+            });
+
+  cosim-deep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Sail config lives under riscv-arch-test/ (submodule). Without it,
+          # Sail crashes silently and trace_diff sees an empty Sail trace.
+          submodules: recursive
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V GCC toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Install Sail
+        run: |
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/riscv/sail-riscv/releases/download/0.10/sail-riscv-$(uname)-$(arch).tar.gz \
+            | sudo tar xz --directory=/usr/local --strip-components=1
+          sudo tee /usr/local/bin/sail_riscv_sim_timeout > /dev/null <<'EOF'
+          #!/usr/bin/env bash
+          exec timeout 60 sail_riscv_sim "$@"
+          EOF
+          sudo chmod +x /usr/local/bin/sail_riscv_sim_timeout
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run cosim-deep
+        id: cosim
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim sim-cosim-deep PULP_AXI_ROOT=/tmp/pulp_axi
+
+      - name: Upload cosim artefacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosim-deep-${{ github.run_id }}
+          path: sim/obj_dir/cosim_fuzz/
+          if-no-files-found: ignore
+
+      - name: Open tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[cosim-deep nightly] failure ${date} (run ${context.runId})`,
+              body: [
+                `Nightly cosim fuzzer (13 programs × 50 mutations) failed.`,
+                ``,
+                `**Run:** https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `**Artefacts:** \`cosim-deep-${context.runId}\` attached to the run`,
+                ``,
+                `Find the failing program/seed in the log (look for \`[cosim_fuzz] FAIL\`),`,
+                `then reproduce that single case:`,
+                '```',
+                `  cd ~/kronos-riscv`,
+                `  PYTHONPATH=. python3 -m tools.cosim_fuzz.runner \\`,
+                `    --program sw/cosim/<failing_prog>.c --seed <failing_seed> \\`,
+                `    --out-dir sim/obj_dir/cosim_fuzz \\`,
+                `    --kronos-bin sim/obj_dir/s6/Vsim_top \\`,
+                `    --sail-trace-script tools/sail_trace.sh \\`,
+                `    --diff-script tools/trace_diff.py`,
+                '```',
+              ].join('\n'),
+              labels: ['ci-failure', 'cosim'],
+            });
+
   compliance-s6-priv:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -257,6 +257,104 @@ jobs:
       - name: Run perf-baseline-s6
         run: make -C sim sim-perf-baseline-s6 PULP_AXI_ROOT=/tmp/pulp_axi
 
+  dcache-stress-s6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: dcache-stress-s6
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V GCC toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run dcache-stress-s6
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim sim-dcache-s6-stress PULP_AXI_ROOT=/tmp/pulp_axi
+
+  crv-smoke-s6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: crv-smoke-s6
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Install Sail
+        run: |
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/riscv/sail-riscv/releases/download/0.10/sail-riscv-$(uname)-$(arch).tar.gz \
+            | sudo tar xz --directory=/usr/local --strip-components=1
+          sudo tee /usr/local/bin/sail_riscv_sim_timeout > /dev/null <<'EOF'
+          #!/usr/bin/env bash
+          exec timeout 60 sail_riscv_sim "$@"
+          EOF
+          sudo chmod +x /usr/local/bin/sail_riscv_sim_timeout
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run crv-smoke-s6
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim sim-crv-smoke-s6 PULP_AXI_ROOT=/tmp/pulp_axi
+
+  cosim-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: cosim-smoke
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Sail config lives under riscv-arch-test/config/kronos/... — same
+          # reason crv-smoke-s6 needs the submodule. Without it, Sail crashes
+          # silently and trace_diff sees an empty Sail trace.
+          submodules: recursive
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V GCC toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Install Sail
+        run: |
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/riscv/sail-riscv/releases/download/0.10/sail-riscv-$(uname)-$(arch).tar.gz \
+            | sudo tar xz --directory=/usr/local --strip-components=1
+          sudo tee /usr/local/bin/sail_riscv_sim_timeout > /dev/null <<'EOF'
+          #!/usr/bin/env bash
+          exec timeout 60 sail_riscv_sim "$@"
+          EOF
+          sudo chmod +x /usr/local/bin/sail_riscv_sim_timeout
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Run cosim-smoke
+        run: |
+          mkdir -p sim/obj_dir
+          make -C sim sim-cosim-smoke PULP_AXI_ROOT=/tmp/pulp_axi
+
   sim-diff-traced:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,60 @@ After completing each implementation step:
 
 Both files should always reflect the current state of the code, not the original plan.
 
+## CI gates
+
+### Branch protection — repository setting
+
+`main` should have a branch protection rule that **requires all PR-blocking CI
+checks to pass before merge can be enabled.** Configure once under `Settings ->
+Branches -> Add rule for main -> Require status checks to pass before merging`,
+and tick every job in `.github/workflows/sim.yml` (compliance-s1..s6,
+sim-s5-asm, sim-s6-asm, sim-s6b-asm, sim-fp-top, sim-fp-unit, sim-diff-s5,
+sim-diff-s5-traced, sim-crv-smoke, dcache-stress-s6, crv-smoke-s6,
+cosim-smoke, perf-baseline-s6, sim-s1s2, sim-s3s4, sim-s5-int, sim-s6-int,
+pytest, sim-all). With this enabled, the GitHub merge button is disabled
+whenever any of those checks is failing — the human reviewer cannot merge
+red.
+
+### Local CI verification — `make ci-local`
+
+Before pushing a PR branch, run `make ci-local` from `sim/`. It runs the full
+PR-gating set against the **same toolchain CI uses** (apt
+`gcc-riscv64-unknown-elf 13.2.x` at `/usr/bin/`, not the user's local
+toolchain) so any failure that would be exposed in CI surfaces locally first.
+Push only when this is clean.
+
+### Hard rule — never bypass a failing CI gate
+
+**HARD RULE — never bypass a failing CI gate to enable a PR merge.** This applies
+to every agent and every contributor:
+
+- Do **not** add `continue-on-error: true`, `if: false`, or any equivalent gate
+  bypass to a CI job that has been deliberately failing because it found a bug.
+- Do **not** add a "skip list" / "exclude list" / `KNOWN_FAILURES` mechanism
+  whose purpose is to remove failing tests from a gating job. Tests that are
+  failing for a real reason must stay in the gate so the PR stays red until the
+  underlying bug is fixed.
+- Do **not** rename a failing job to `*-informational`, push it to `nightly`,
+  or otherwise hide its red signal so the PR-blocking gate goes green.
+- Do **not** mark a real failure as `xfail` / "expected to fail" without an
+  explicit, documented platform / config exception (e.g. `if-only` matrix gating
+  for a known-broken host). The bar for adding such exceptions is high and they
+  must reference a tracking issue.
+
+The verification stack exists to catch bugs. A green gate that hides a real
+failure is worse than a red gate that exposes it: it tells maintainers the
+codebase is healthy when it isn't, and it lets the bug ship.
+
+The correct response to a failing gate is one of:
+1. **Fix the underlying bug** so the test passes naturally.
+2. **Repair the test** if the test itself is wrong (reproducer is incorrect,
+   harness is brittle, etc.).
+3. **Wait** — leave the gate red and the PR un-mergeable until 1 or 2 happens.
+
+Filing a tracking issue is necessary but not sufficient. The gate must stay
+red until the fix lands.
+
 ## SW Tests
 
 When creating a new test under `sw/stage<N>/`, add it to the stage's `Makefile` TESTS list.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 6f    | BOOM-style frontend rewrite + icache `data_q` BRAM-back              | RV64IMAFDC | AXI4    | Complete    |
 | 6g    | Dcache `data_q` BRAM-back (4 × `kronos_ram`, EX-stage pre-launch)    | RV64IMAFDC | AXI4    | Complete    |
 | 6h    | Cache tag arrays + FP regfile in BRAM/LUTRAM (closes #79)            | RV64IMAFDC | AXI4    | Complete    |
+| 6i    | Verification overhaul: dcache RAW regression + CRV-s6 + cosim fuzzer | RV64IMAFDC | AXI4    | Complete    |
 | 7     | Out-of-order execution (BOOM style)             | RV64IMAFDС       | AXI4    | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same

--- a/rtl/stage5/kronos_top.sv
+++ b/rtl/stage5/kronos_top.sv
@@ -799,7 +799,13 @@ module kronos_top
     end else begin
       pred_taken_q  <= pred_taken & align_instr_valid & if_id_en &
                        ~ex_redirect & ~mem_redirect;
-      pred_target_q <= pred_target;
+      // Hold pred_target_q during a redirect cycle.  Otherwise the
+      // wrong-path predecode emit during a redirect-flush cycle can
+      // overwrite pred_target_q with the wrong-path branch's target,
+      // chaining a misdirect.  See stage 6 kronos_top for the full repro.
+      if (~pred_taken_q & ~ex_redirect & ~mem_redirect) begin
+        pred_target_q <= pred_target;
+      end
     end
   end
 
@@ -954,14 +960,27 @@ module kronos_top
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       if_id_q <= '{default: '0};
-    end else if (if_id_flush | pred_taken_q) begin
-      // pred_taken_q fires the cycle AFTER the branch was captured into
-      // if_id_q.  The wrong-path fall-through that predecode is presenting
-      // this cycle must not propagate to ID — clear the IF/ID register so
-      // ID sees a bubble while the IFU resyncs to pred_target_q.  The branch
-      // itself was already captured the prior cycle and is now safely at
-      // if_id_q's output, so id_ex_en will still latch it into ID/EX.
+    end else if (if_id_flush) begin
+      // ex_redirect / mem_redirect / load-use bubble — the branch (or the
+      // load itself in the load-use case) is wrong-path, so always clear.
       if_id_q <= '{default: '0};
+    end else if (pred_taken_q) begin
+      // pred_taken_q fires the cycle AFTER the branch was captured into
+      // if_id_q.  The branch is at if_id_q's output and we want id_ex to
+      // latch it; the wrong-path fall-through that predecode would emit
+      // this cycle must NOT enter if_id_q.  Two cases:
+      //   (a) id_ex_en = 1: id_ex latches the branch this cycle, so we
+      //       can safely clear if_id_q to bubble the wrong-path fetch.
+      //   (b) id_ex_en = 0 (muldiv/mem stall): id_ex cannot accept the
+      //       branch yet.  Clearing if_id_q here would lose the branch
+      //       — closes #86 (mulw → addiw → bne tight-loop wedge).
+      //       Hold if_id_q so id_ex picks up the branch when the stall
+      //       releases.  The wrong-path predecode emit is naturally
+      //       suppressed: `if_id_en` is also 0 under any stall that drops
+      //       id_ex_en, so we don't fall into the latch branch below.
+      if (id_ex_en) begin
+        if_id_q <= '{default: '0};
+      end
     end else if (if_id_en) begin
       if_id_q.pc          <= predecode_instr_pc;
       if_id_q.instr       <= align_instr;

--- a/rtl/stage6/kronos_top.sv
+++ b/rtl/stage6/kronos_top.sv
@@ -1380,7 +1380,20 @@ module kronos_top
     end else begin
       pred_taken_q  <= pred_taken & align_instr_valid & if_id_en &
                        ~ex_redirect & ~mem_redirect;
-      pred_target_q <= pred_target;
+      // Hold pred_target_q during a cycle that is already issuing a redirect
+      // (pred_taken_q high, ex/mem_redirect high).  Otherwise: cycle K
+      // fires pred_taken_q for branch B (target T1); cycle K's FB and
+      // predecode are mid-flush; predecode at K still emits the next
+      // wrong-path instruction; the BPU lookup of that wrong-path PC writes
+      // pred_target_q with the wrong-path target T_w; if pred_taken_q
+      // latches 1 again at K+1 (chained), the redirect uses T_w instead of
+      // T1 — a livelock.  Holding pred_target_q across the redirect cycle
+      // preserves T1; even if the chain fires, the redirect goes to T1
+      // (effectively a no-op redirect since the IF is already loading T1).
+      // Less invasive than gating pred_taken_q itself, which broke dhrystone.
+      if (~pred_taken_q & ~ex_redirect & ~mem_redirect) begin
+        pred_target_q <= pred_target;
+      end
     end
   end
 
@@ -1545,14 +1558,27 @@ module kronos_top
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       if_id_q <= '{default: '0};
-    end else if (if_id_flush | pred_taken_q) begin
-      // pred_taken_q fires the cycle AFTER the branch was captured into
-      // if_id_q.  The wrong-path fall-through that predecode is presenting
-      // this cycle must not propagate to ID — clear the IF/ID register so
-      // ID sees a bubble while the IFU resyncs to pred_target_q.  The branch
-      // itself was already captured the prior cycle and is now safely at
-      // if_id_q's output, so id_ex_en will still latch it into ID/EX.
+    end else if (if_id_flush) begin
+      // ex_redirect / mem_redirect / load-use bubble — the branch (or the
+      // load itself in the load-use case) is wrong-path, so always clear.
       if_id_q <= '{default: '0};
+    end else if (pred_taken_q) begin
+      // pred_taken_q fires the cycle AFTER the branch was captured into
+      // if_id_q.  The branch is at if_id_q's output and we want id_ex to
+      // latch it; the wrong-path fall-through that predecode would emit
+      // this cycle must NOT enter if_id_q.  Two cases:
+      //   (a) id_ex_en = 1: id_ex latches the branch this cycle, so we
+      //       can safely clear if_id_q to bubble the wrong-path fetch.
+      //   (b) id_ex_en = 0 (muldiv/mem stall): id_ex cannot accept the
+      //       branch yet.  Clearing if_id_q here would lose the branch
+      //       — closes #86 (mulw → addiw → bne tight-loop wedge).
+      //       Hold if_id_q so id_ex picks up the branch when the stall
+      //       releases.  The wrong-path predecode emit is naturally
+      //       suppressed: `if_id_en` is also 0 under any stall that drops
+      //       id_ex_en, so we don't fall into the latch branch below.
+      if (id_ex_en) begin
+        if_id_q <= '{default: '0};
+      end
     end else if (if_id_en) begin
       if_id_q.pc          <= predecode_instr_pc;
       if_id_q.instr       <= align_instr;

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -129,6 +129,7 @@ SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
         sim-group-crv-smoke \
         sim-diff-% sim-diff-all sim-diff-s5-traced \
         sim-crv-% sim-crv-smoke sim-crv-deep \
+        sim-crv-s6-% sim-crv-smoke-s6 sim-crv-deep-s6 \
         sim-crv-cov-build sim-crv-coverage \
         sim-crv-assists
 
@@ -193,7 +194,7 @@ sim-diff-s5-traced: build-s5
 # ---------------------------------------------------------------------------
 CRV_DIR        := $(OBJ_DIR)/crv
 CRV_SCENARIOS  := int_hazards muldiv_interleave mem_ordering fp_arith \
-                  fdiv_fsqrt branch_pred traps
+                  fdiv_fsqrt branch_pred traps raw_stress
 CRV_SEED       ?= 0
 CRV_LENGTH     ?= 200
 CRV_SEED_BASE  ?= 0
@@ -245,6 +246,51 @@ sim-crv-deep: build-s5
 	   done; \
 	 done; \
 	 [ "$$fail" = "0" ] && echo "PASS  sim-crv-deep ($(CRV_SCENARIOS) × 50 seeds)"; \
+	 exit $$fail
+
+# ---- Stage 6 CRV (issue #82 verification overhaul) ----
+CRV_KRONOS_BIN_S6 = $(SIM_BIN_S6)
+
+sim-crv-s6-%: build-s6
+	@mkdir -p $(CRV_DIR)
+	@$(CRV_RUNNER) \
+	  --scenario $* \
+	  --seed $(CRV_SEED) --length $(CRV_LENGTH) \
+	  --build-dir $(CRV_DIR) \
+	  --kronos-bin $(CRV_KRONOS_BIN_S6) \
+	  --link-script $(CRV_LINK) \
+	  --common-s $(CRV_COMMON_S) \
+	  --sail-trace-script $(CRV_SAIL_SH) \
+	  --diff-script $(CRV_DIFF_PY) \
+	  && echo "PASS  sim-crv-s6-$*  (seed=$(CRV_SEED) length=$(CRV_LENGTH))" \
+	  || { echo "FAIL  sim-crv-s6-$*  (seed=$(CRV_SEED))"; exit 1; }
+
+sim-crv-smoke-s6: build-s6
+	@mkdir -p $(CRV_DIR)
+	@fail=0; \
+	 for sc in $(CRV_SCENARIOS); do \
+	   $(CRV_RUNNER) --scenario $$sc --seed 0 --length $(CRV_LENGTH) \
+	     --build-dir $(CRV_DIR) --kronos-bin $(CRV_KRONOS_BIN_S6) \
+	     --link-script $(CRV_LINK) --common-s $(CRV_COMMON_S) \
+	     --sail-trace-script $(CRV_SAIL_SH) --diff-script $(CRV_DIFF_PY) \
+	     && echo "PASS  sim-crv-s6-$$sc-smoke" \
+	     || { echo "FAIL  sim-crv-s6-$$sc-smoke"; fail=1; }; \
+	 done; exit $$fail
+
+sim-crv-deep-s6: build-s6
+	@mkdir -p $(CRV_DIR)
+	@fail=0; \
+	 for i in $$(seq 0 49); do \
+	   for sc in $(CRV_SCENARIOS); do \
+	     seed=$$(($(CRV_SEED_BASE) + $$i)); \
+	     $(CRV_RUNNER) --scenario $$sc --seed $$seed --length $(CRV_LENGTH) \
+	       --build-dir $(CRV_DIR) --kronos-bin $(CRV_KRONOS_BIN_S6) \
+	       --link-script $(CRV_LINK) --common-s $(CRV_COMMON_S) \
+	       --sail-trace-script $(CRV_SAIL_SH) --diff-script $(CRV_DIFF_PY) \
+	       || { echo "FAIL  sim-crv-s6-$$sc seed=$$seed"; fail=1; }; \
+	   done; \
+	 done; \
+	 [ "$$fail" = "0" ] && echo "PASS  sim-crv-deep-s6 ($(CRV_SCENARIOS) × 50 seeds)"; \
 	 exit $$fail
 
 # ---------------------------------------------------------------------------
@@ -1110,6 +1156,64 @@ sim-s6b: build-s6
 
 .PHONY: sim-s6b run-s6b-%
 
+# ── Cosim: putdec_stack regression smoke (issue #82 reproducer) ──────────────
+# Standalone Verilator: bypass works → emits "12345". Guards regression of the
+# bypass. The same program failing in OpenSoC is environment-specific (xpm).
+.PHONY: sim-cosim-putdec
+sim-cosim-putdec: build-s6
+	@$(MAKE) -C ../sw/cosim build/putdec_stack.hex >/dev/null
+	@out=$$(timeout 30 ./$(SIM_BIN_S6) ../sw/cosim/build/putdec_stack.hex 2>&1); \
+	 x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	 prefix=$$(echo "$$out" | sed -n '1,/x10 = /p'); \
+	 if [ "$$x10" = "0" ] && echo "$$prefix" | grep -q '12345'; then \
+	   echo "PASS  sim-cosim-putdec  (emitted 12345)"; \
+	 else \
+	   echo "FAIL  sim-cosim-putdec  (x10=$$x10  prefix did not contain 12345)"; \
+	   echo "--- captured output ---"; echo "$$out" | tail -30; exit 1; \
+	 fi
+
+# ── Cosim fuzzer: source-level mutational fuzzer (Phase 4) ───────────────────
+COSIM_FUZZ_RUNNER := PYTHONPATH=.. python3 -m tools.cosim_fuzz.runner
+COSIM_FUZZ_OUT    := $(OBJ_DIR)/cosim_fuzz
+COSIM_PROGRAMS    := $(notdir $(wildcard ../sw/cosim/*.c))
+
+.PHONY: sim-cosim-smoke sim-cosim-deep
+sim-cosim-smoke: build-s6
+	@$(MAKE) -C ../sw/cosim >/dev/null
+	@mkdir -p $(COSIM_FUZZ_OUT)
+	@fail=0; \
+	 for p in $(COSIM_PROGRAMS); do \
+	   $(COSIM_FUZZ_RUNNER) \
+	     --program ../sw/cosim/$$p --seed 0 \
+	     --out-dir $(COSIM_FUZZ_OUT) \
+	     --kronos-bin $(SIM_BIN_S6) \
+	     --sail-trace-script ../tools/sail_trace.sh \
+	     --diff-script ../tools/trace_diff.py \
+	     --common-s ../sw/cosim/cosim_common.S \
+	     --link-ld ../sw/stage0/link.ld \
+	   || { echo "FAIL  sim-cosim-smoke $$p seed=0"; fail=1; }; \
+	 done; \
+	 [ "$$fail" = "0" ] && echo "PASS  sim-cosim-smoke ($$(echo $(COSIM_PROGRAMS) | wc -w) programs)" || exit 1
+
+sim-cosim-deep: build-s6
+	@$(MAKE) -C ../sw/cosim >/dev/null
+	@mkdir -p $(COSIM_FUZZ_OUT)
+	@fail=0; \
+	 for s in $$(seq 0 49); do \
+	   for p in $(COSIM_PROGRAMS); do \
+	     $(COSIM_FUZZ_RUNNER) \
+	       --program ../sw/cosim/$$p --seed $$s \
+	       --out-dir $(COSIM_FUZZ_OUT) \
+	       --kronos-bin $(SIM_BIN_S6) \
+	       --sail-trace-script ../tools/sail_trace.sh \
+	       --diff-script ../tools/trace_diff.py \
+	       --common-s ../sw/cosim/cosim_common.S \
+	       --link-ld ../sw/stage0/link.ld \
+	     || { echo "FAIL  sim-cosim-deep $$p seed=$$s"; fail=1; }; \
+	   done; \
+	 done; \
+	 [ "$$fail" = "0" ] && echo "PASS  sim-cosim-deep ($$(echo $(COSIM_PROGRAMS) | wc -w) progs × 50 seeds)" || exit 1
+
 # ---------------------------------------------------------------------------
 # Stage 6c — perf baseline (dhrystone, ±2% gate, main-only via mcycle markers)
 # ---------------------------------------------------------------------------
@@ -1504,11 +1608,49 @@ sim-dcache-pma-s6:
 TB_DCACHE_S6_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
                       $(RTL_DIR_COMMON)/kronos_ram.sv \
                       $(RTL_DIR)/stage6/kronos_dcache.sv \
+                      $(TB_DIR)/stage6/dcache_scoreboard.sv \
                       $(TB_DIR)/stage6/tb_dcache.sv
-sim-dcache-s6:
+build-dcache-s6:
 	$(VERILATOR) $(WAIVER) --binary $(AXI_FLAGS) --Wno-TIMESCALEMOD -Wno-UNUSED \
 	  -Mdir $(OBJ_DIR)/dcache_s6 --top-module tb_dcache $(TB_DCACHE_S6_FILES)
+
+sim-dcache-s6: build-dcache-s6
 	$(OBJ_DIR)/dcache_s6/Vtb_dcache
+
+# ── ci-local: run the PR-blocking gates locally with the same toolchain CI uses
+# Forces /usr/bin/riscv64-unknown-elf-gcc (apt-installed gcc-13.2) instead of
+# whichever gcc happens to be first on PATH locally.  Catches CI-environment-
+# specific failures BEFORE pushing.  Documented in CLAUDE.md as the required
+# pre-push check.
+.PHONY: ci-local
+ci-local:
+	@if [ ! -x /usr/bin/riscv64-unknown-elf-gcc ]; then \
+	  echo "FAIL  ci-local: /usr/bin/riscv64-unknown-elf-gcc not installed (apt install gcc-riscv64-unknown-elf)"; exit 1; \
+	fi
+	@echo "[ci-local] Using $$(/usr/bin/riscv64-unknown-elf-gcc --version | head -1)"
+	@PATH=/usr/bin:$$PATH $(MAKE) sim-cosim-smoke || { echo "FAIL  ci-local: sim-cosim-smoke"; exit 1; }
+	@PATH=/usr/bin:$$PATH $(MAKE) sim-crv-smoke-s6 || { echo "FAIL  ci-local: sim-crv-smoke-s6"; exit 1; }
+	@$(MAKE) sim-dcache-s6-stress || { echo "FAIL  ci-local: sim-dcache-s6-stress"; exit 1; }
+	@$(MAKE) sim-s6 || { echo "FAIL  ci-local: sim-s6"; exit 1; }
+	@$(MAKE) sim-arch-test-s6 || { echo "FAIL  ci-local: sim-arch-test-s6"; exit 1; }
+	@echo "PASS  ci-local"
+
+.PHONY: sim-dcache-s6-stress sim-dcache-s6-stress-deep
+DCACHE_SEED ?= 0
+sim-dcache-s6-stress: build-dcache-s6
+	@out=$$(./$(OBJ_DIR)/dcache_s6/Vtb_dcache +seed=$(DCACHE_SEED) 2>&1); \
+	 echo "$$out" | grep -E '(PASS|FAIL) test_raw_random' || true; \
+	 echo "$$out" | grep -q 'PASS test_raw_random' \
+	  && echo "PASS  sim-dcache-s6-stress (seed=$(DCACHE_SEED))" \
+	  || { echo "FAIL  sim-dcache-s6-stress (seed=$(DCACHE_SEED))"; echo "$$out" | tail -20; exit 1; }
+
+sim-dcache-s6-stress-deep: build-dcache-s6
+	@fail=0; \
+	for s in $$(seq 0 99); do \
+	  ./$(OBJ_DIR)/dcache_s6/Vtb_dcache +seed=$$s 2>&1 | grep -q 'PASS test_raw_random' \
+	    || { echo "FAIL seed=$$s"; fail=1; }; \
+	done; \
+	[ "$$fail" = "0" ] && echo "PASS  sim-dcache-s6-stress-deep (seeds 0..99)" || exit 1
 
 TB_FPU_SB_FILES := $(AXI_PKG_SV) $(RTL_DIR)/kronos_pkg.sv \
                    $(RTL_DIR)/common/fpu/kronos_fpu_scoreboard.sv \

--- a/sw/cosim/Makefile
+++ b/sw/cosim/Makefile
@@ -1,0 +1,28 @@
+# cosim/Makefile — GCC-compiled C corpus for Sail-diff cosimulation.
+# Mirrors the stage6 SW Makefile: -nostdlib, static link, ihex output.
+TOOLCHAIN := riscv64-unknown-elf
+CC        := $(TOOLCHAIN)-gcc
+OBJCOPY   := $(TOOLCHAIN)-objcopy
+
+ARCH      := rv64imafdc_zicsr
+ABI       := lp64
+CFLAGS    := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -Os -T../stage0/link.ld
+
+# Corpus discovery — every .c in this directory.
+SRCS  := $(wildcard *.c)
+TESTS := $(SRCS:%.c=%)
+
+BUILD := build
+
+all: $(TESTS:%=$(BUILD)/%.hex)
+
+$(BUILD)/%.hex: %.c cosim_common.S | $(BUILD)
+	$(CC) $(CFLAGS) -o $(@:.hex=.elf) $^
+	$(OBJCOPY) -O ihex $(@:.hex=.elf) $@
+
+$(BUILD):
+	mkdir -p $@
+
+.PHONY: all clean
+clean:
+	rm -rf $(BUILD)

--- a/sw/cosim/bcd_to_binary.c
+++ b/sw/cosim/bcd_to_binary.c
@@ -1,0 +1,14 @@
+// bcd_to_binary.c — parse a BCD digit stream from stack and emit binary.
+// MUTATE: digits = randint(1, 6)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+int cosim_main(void) {
+  uint8_t bcd[] = {1, 2, 3, 4, 5};
+  uint32_t v = 0;
+  for (unsigned i = 0; i < sizeof(bcd); i++) v = v * 10 + bcd[i];
+  PUT((uint8_t)(v & 0xFF));
+  PUT((uint8_t)((v >> 8) & 0xFF));
+  return 0;
+}

--- a/sw/cosim/bsearch_static.c
+++ b/sw/cosim/bsearch_static.c
@@ -1,0 +1,20 @@
+// bsearch_static.c — binary search in a static const sorted array.
+// MUTATE: target = randint(0, 47)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+static const uint8_t arr[16] = {1,3,5,7,9,11,13,17,19,23,29,31,37,41,43,47};
+
+int cosim_main(void) {
+  enum { TARGET = 31 };
+  int lo = 0, hi = 16;
+  int idx = -1;
+  while (lo < hi) {
+    int mid = (lo + hi) >> 1;
+    if (arr[mid] == TARGET) { idx = mid; break; }
+    if (arr[mid] < TARGET) lo = mid + 1; else hi = mid;
+  }
+  PUT((uint8_t)(idx & 0xFF));
+  return 0;
+}

--- a/sw/cosim/byte_buffer_emit.c
+++ b/sw/cosim/byte_buffer_emit.c
@@ -1,0 +1,14 @@
+// byte_buffer_emit.c — fill a stack buffer byte-by-byte, then emit it
+// in reverse — the exact pattern from issue #82.
+// MUTATE: n = randint(2, 16)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+int cosim_main(void) {
+  enum { N = 8 };
+  char buf[16];
+  for (int i = 0; i < N; i++) buf[i] = '0' + i;
+  for (int i = N - 1; i >= 0; i--) PUT(buf[i]);
+  return 0;
+}

--- a/sw/cosim/cosim_common.S
+++ b/sw/cosim/cosim_common.S
@@ -1,0 +1,43 @@
+# cosim_common.S — cosim corpus startup. Calls cosim_main, halts on return
+# with the program's int return value as the exit code (mirrors sw/stage0/common.S
+# but renames the entry point to avoid clashing if cosim corpus is ever linked
+# alongside stage tests).
+.section .text.start
+.global _start
+_start:
+  la    sp, _stack_top
+  li    t0, 0x6000              # mstatus.FS = Dirty
+  csrrs zero, mstatus, t0
+  mv    a0, zero
+  mv    a1, zero
+  call  cosim_main
+_halt:
+  li    t0, 0x40000000
+  sw    a0, 0(t0)
+  j     _halt
+
+# Minimal libc stubs — GCC may emit calls to these even with -Os.
+.section .text
+.global memcpy
+memcpy:
+  # a0=dst, a1=src, a2=n — byte-at-a-time copy, return original dst
+  mv    t0, a0
+1:beqz  a2, 2f
+  lb    t1, 0(a1)
+  sb    t1, 0(t0)
+  addi  t0, t0,  1
+  addi  a1, a1,  1
+  addi  a2, a2, -1
+  j     1b
+2:ret
+
+.global memset
+memset:
+  # a0=dst, a1=val, a2=n — return original dst
+  mv    t0, a0
+1:beqz  a2, 2f
+  sb    a1, 0(t0)
+  addi  t0, t0,  1
+  addi  a2, a2, -1
+  j     1b
+2:ret

--- a/sw/cosim/crc8_byte.c
+++ b/sw/cosim/crc8_byte.c
@@ -1,0 +1,20 @@
+// crc8_byte.c — CRC-8 over a stack buffer.
+// MUTATE: n_bytes = randint(2, 32)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+static uint8_t crc8(const uint8_t *p, int n) {
+  uint8_t c = 0xFF;
+  for (int i = 0; i < n; i++) {
+    c ^= p[i];
+    for (int b = 0; b < 8; b++) c = (c & 0x80) ? (uint8_t)((c << 1) ^ 0x07) : (uint8_t)(c << 1);
+  }
+  return c;
+}
+
+int cosim_main(void) {
+  uint8_t buf[16] = {1,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0};
+  PUT(crc8(buf, 8));
+  return 0;
+}

--- a/sw/cosim/fp_stack_spill.c
+++ b/sw/cosim/fp_stack_spill.c
@@ -1,0 +1,20 @@
+// fp_stack_spill.c — force FP regfile spills to stack, then reload.
+// MUTATE: depth = randint(2, 8)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+static double mix(double a, double b, double c, double d, double e,
+                  double f, double g, double h) {
+  double s = a + b - c * d + e / (f + 1.0) - g + h;
+  return s;
+}
+
+int cosim_main(void) {
+  double r = mix(1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5);
+  uint64_t bits;
+  __builtin_memcpy(&bits, &r, sizeof(bits));
+  PUT((uint8_t)(bits & 0xFF));
+  PUT((uint8_t)((bits >> 8) & 0xFF));
+  return 0;
+}

--- a/sw/cosim/linked_list_traverse.c
+++ b/sw/cosim/linked_list_traverse.c
@@ -1,0 +1,17 @@
+// linked_list_traverse.c — build a small linked list on stack, traverse.
+// MUTATE: n_nodes = randint(2, 6)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+typedef struct node { struct node *next; uint8_t val; } node_t;
+
+int cosim_main(void) {
+  node_t a = { 0, 'A' };
+  node_t b = { 0, 'B' };
+  node_t c = { 0, 'C' };
+  node_t d = { 0, 'D' };
+  a.next = &b; b.next = &c; c.next = &d;
+  for (node_t *p = &a; p; p = p->next) PUT(p->val);
+  return 0;
+}

--- a/sw/cosim/memcpy_byte_loop.c
+++ b/sw/cosim/memcpy_byte_loop.c
@@ -1,0 +1,18 @@
+// memcpy_byte_loop.c — byte-loop memcpy, then emit a CRC of the destination.
+// MUTATE: src_pad   = randint(0, 16)
+// MUTATE: copy_len  = randint(8, 128)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+static const char src[136] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!?<>$%&";
+
+int cosim_main(void) {
+  enum { SRC_PAD = 0, COPY_LEN = 64 };
+  char dst[160];
+  for (int i = 0; i < COPY_LEN; i++) dst[i + SRC_PAD] = src[i];
+  uint8_t crc = 0;
+  for (int i = 0; i < COPY_LEN; i++) crc ^= dst[i + SRC_PAD];
+  PUT(crc);
+  return 0;
+}

--- a/sw/cosim/memset_word_loop.c
+++ b/sw/cosim/memset_word_loop.c
@@ -1,0 +1,17 @@
+// memset_word_loop.c — set N words to a pattern, emit XOR.
+// MUTATE: n_words = randint(4, 64)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+int cosim_main(void) {
+  enum { N_WORDS = 16 };
+  uint32_t buf[64];
+  uint32_t pat = 0xDEADBEEFu;
+  for (int i = 0; i < N_WORDS; i++) buf[i] = pat;
+  uint32_t x = 0;
+  for (int i = 0; i < N_WORDS; i++) x ^= buf[i];
+  PUT((uint8_t)(x       & 0xFF));
+  PUT((uint8_t)((x >> 8) & 0xFF));
+  return 0;
+}

--- a/sw/cosim/mmio_interleave.c
+++ b/sw/cosim/mmio_interleave.c
@@ -1,0 +1,15 @@
+// mmio_interleave.c — interleave MMIO writes with cacheable RAM ops.
+// MUTATE: n = randint(1, 8)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+int cosim_main(void) {
+  enum { N = 4 };
+  char tmp[16];
+  for (int i = 0; i < N; i++) {
+    tmp[i] = (char)('A' + i);
+    PUT(tmp[i]);
+  }
+  return 0;
+}

--- a/sw/cosim/putdec_stack.c
+++ b/sw/cosim/putdec_stack.c
@@ -1,0 +1,29 @@
+// putdec_stack.c — issue #82 reproducer.
+// Emits "12345" to MMIO console and halts with exit code 0.
+// On v0.6.2 (broken): emits five NUL bytes; cosim_main returns 0 but digits wrong.
+// With Phase 1 fix: emits "12345"; cosim_main returns 0.
+//
+// MUTATE-stable: this is the directed reproducer. The Phase-4 fuzzer
+// targets other corpus files, not this one.
+
+#include <stdint.h>
+
+// Console output port (sim_main.cpp line ~554: 0x10000000 -> putchar per byte)
+#define CONSOLE ((volatile uint32_t*)0x10000000UL)
+#define PUT(c) (*CONSOLE = (uint8_t)(c))
+
+static void putdec_stack(uint32_t v) {
+  char buf[11];
+  int  pos = 0;
+  if (v == 0) { PUT('0'); return; }
+  while (v > 0) { buf[pos++] = '0' + (v % 10); v /= 10; }
+  while (pos > 0) PUT(buf[--pos]);
+}
+
+int cosim_main(void) {
+  // Emit
+  putdec_stack(12345);
+  // Self-check via shadow buffer (avoids stalling the test on a stuck MMIO)
+  // — the Verilator harness compares MMIO writes against expected[] separately.
+  return 0;  // 0 == pass; harness independently asserts MMIO byte stream
+}

--- a/sw/cosim/recursive_factorial.c
+++ b/sw/cosim/recursive_factorial.c
@@ -1,0 +1,15 @@
+// recursive_factorial.c — recursion-heavy callee-save reload pattern.
+// MUTATE: n = randint(2, 12)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+static uint64_t fact(int n) { return (n <= 1) ? 1 : (uint64_t)n * fact(n - 1); }
+
+int cosim_main(void) {
+  enum { N = 8 };
+  uint64_t v = fact(N);
+  PUT((uint8_t)(v       & 0xFF));
+  PUT((uint8_t)((v >> 8) & 0xFF));
+  return 0;
+}

--- a/sw/cosim/string_reverse.c
+++ b/sw/cosim/string_reverse.c
@@ -1,0 +1,15 @@
+// string_reverse.c — in-place string reverse on stack, emit result.
+// MUTATE: pad = randint(0, 8)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+int cosim_main(void) {
+  char s[16] = "abcdefg";
+  int n = 7;
+  for (int i = 0, j = n - 1; i < j; i++, j--) {
+    char t = s[i]; s[i] = s[j]; s[j] = t;
+  }
+  for (int i = 0; i < n; i++) PUT(s[i]);
+  return 0;
+}

--- a/sw/cosim/struct_copy.c
+++ b/sw/cosim/struct_copy.c
@@ -1,0 +1,18 @@
+// struct_copy.c — copy a packed struct field-by-field, emit a checksum.
+// MUTATE: a_init = randint(0, 255)
+#include <stdint.h>
+#define MMIO 0x10000000UL
+#define PUT(c) (*((volatile uint32_t*)MMIO) = (uint8_t)(c))
+
+typedef struct { uint8_t a; uint16_t b; uint32_t c; uint64_t d; } pkt_t;
+
+int cosim_main(void) {
+  pkt_t s = { .a = 0x55, .b = 0xCAFE, .c = 0xDEADBEEF, .d = 0x1122334455667788ULL };
+  pkt_t t;
+  t.a = s.a; t.b = s.b; t.c = s.c; t.d = s.d;
+  PUT(t.a);
+  PUT((uint8_t)(t.b & 0xFF));
+  PUT((uint8_t)((t.c >> 24) & 0xFF));
+  PUT((uint8_t)(t.d & 0xFF));
+  return 0;
+}

--- a/sw/stage6/Makefile
+++ b/sw/stage6/Makefile
@@ -8,7 +8,8 @@ ABI    := lp64
 CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
 
 TESTS  := test_priv_smode test_delegation test_pmp_basic test_sret test_csr_priv test_priv_smoke \
-          test_pma_mmio_load test_pma_mmio_store test_pma_amo_trap
+          test_pma_mmio_load test_pma_mmio_store test_pma_amo_trap \
+          test_dcache_raw
 
 BUILD_DIR := build
 

--- a/sw/stage6/test_dcache_raw.S
+++ b/sw/stage6/test_dcache_raw.S
@@ -1,0 +1,56 @@
+# test_dcache_raw.S — directed regression for issue #82.
+# 5 sub-tests, each writes a known pattern, immediately reads it back, ORs any
+# mismatch into x10 (failure count). Self-checking: x10 == 0 = pass.
+#
+# All accesses use the stack (sp) so they hit cacheable memory in a single line.
+
+.section .text
+.global main
+main:
+  li   a0, 0                 # failure count (a0 = x10 per ABI)
+
+  # ----- sub-test 1: sb -> lbu (the issue #82 reproducer) -----
+  li   x11, 0x55
+  sb   x11, 0(sp)
+  lbu  x12, 0(sp)
+  xor  x13, x12, x11         # 0 if equal
+  snez x13, x13              # 1 if mismatch
+  add  a0, a0, x13
+
+  # ----- sub-test 2: sh -> lhu -----
+  li   x11, 0xCAFE
+  sh   x11, 4(sp)
+  lhu  x12, 4(sp)
+  xor  x13, x12, x11
+  snez x13, x13
+  add  a0, a0, x13
+
+  # ----- sub-test 3: sw -> lw -----
+  li   x11, 0xDEADBEEF
+  sw   x11, 8(sp)
+  lw   x12, 8(sp)
+  # sign-extend x11 to 64-bit for compare with lw result
+  slli x14, x11, 32
+  srai x14, x14, 32
+  xor  x13, x12, x14
+  snez x13, x13
+  add  a0, a0, x13
+
+  # ----- sub-test 4: sd -> ld -----
+  li   x11, 0x1122334455667788
+  sd   x11, 16(sp)
+  ld   x12, 16(sp)
+  xor  x13, x12, x11
+  snez x13, x13
+  add  a0, a0, x13
+
+  # ----- sub-test 5: sw -> lbu (low byte of just-stored word) -----
+  li   x11, 0x44332211
+  sw   x11, 24(sp)
+  lbu  x12, 24(sp)           # expect 0x11
+  li   x14, 0x11
+  xor  x13, x12, x14
+  snez x13, x13
+  add  a0, a0, x13
+
+  ret

--- a/tb/stage6/dcache_scoreboard.sv
+++ b/tb/stage6/dcache_scoreboard.sv
@@ -1,0 +1,47 @@
+// Copyright 2026 Vlad-Dumitru Popescu
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// dcache_scoreboard — pure architectural-memory mirror.
+// Tracks every retired byte-write the testbench drives into the dcache and
+// returns the expected load value for any address. Knows nothing about
+// cache state (tags, lines, MESI) — only architectural memory contents.
+
+module dcache_scoreboard #(
+  parameter int unsigned MEM_BYTES = 1 << 16,
+  parameter int unsigned MEM_BASE  = 32'h0
+)(
+  input logic clk_i,
+  input logic rst_ni
+);
+
+  logic [7:0] mem [MEM_BYTES];
+
+  task automatic store(input [63:0] addr, input [2:0] sz, input [63:0] data);
+    int n;
+    int idx;
+    n = 1 << sz;
+    for (int i = 0; i < n; i++) begin
+      idx = int'(addr) - MEM_BASE + i;
+      if (idx >= 0 && idx < MEM_BYTES) mem[idx] = data[i*8 +: 8];
+    end
+  endtask
+
+  function automatic [63:0] expected(input [63:0] addr, input [2:0] sz);
+    logic [63:0] v;
+    int n;
+    int idx;
+    v = 64'h0;
+    n = 1 << sz;
+    for (int i = 0; i < n; i++) begin
+      idx = int'(addr) - MEM_BASE + i;
+      if (idx >= 0 && idx < MEM_BYTES) v[i*8 +: 8] = mem[idx];
+    end
+    return v;
+  endfunction
+
+  initial begin
+    foreach (mem[i]) mem[i] = 8'h00;
+  end
+
+endmodule

--- a/tb/stage6/tb_dcache.sv
+++ b/tb/stage6/tb_dcache.sv
@@ -113,6 +113,15 @@ module tb_dcache
     .miss_pulse_o      (miss_pulse)
   );
 
+  // ---- Reference model — pure architectural mirror (no cache state) ------
+  dcache_scoreboard #(
+    .MEM_BYTES (1 << 18),
+    .MEM_BASE  (32'h0)
+  ) u_sb (
+    .clk_i  (clk_i),
+    .rst_ni (rst_ni)
+  );
+
   // ---- AXI memory model + read burst driver ------------------------------
   // Behavioural single-issue memory.  Sized large enough to hold the
   // working set used by the tests below; addresses are >> 3 to index by
@@ -245,7 +254,8 @@ module tb_dcache
   // drive req on the next.  Captures rdata into last_rdata at the cycle
   // data_valid fires (single-cycle bypass pulses would otherwise clear
   // before the test asserts on rdata).
-  task automatic drv_load(input [63:0] a, input [2:0] sz);
+  task automatic drv_load(input [63:0] a, input [2:0] sz, input int gap_cycles = 1);
+    if (gap_cycles > 1) repeat (gap_cycles - 1) @(posedge clk_i);
     prelaunch(a);
     @(posedge clk_i);                    // BRAM read launches here
     @(negedge clk_i);
@@ -264,7 +274,9 @@ module tb_dcache
   // Issue a store.  Same pre-launch shape — store-hit fire wants port-A
   // write + port-B read in the same cycle (WRITE_FIRST forwarding for
   // any concurrent same-beat load); we drive a clean hit/store cycle.
-  task automatic drv_store(input [63:0] a, input [2:0] sz, input [63:0] d);
+  task automatic drv_store(input [63:0] a, input [2:0] sz, input [63:0] d,
+                           input int gap_cycles = 1);
+    if (gap_cycles > 1) repeat (gap_cycles - 1) @(posedge clk_i);
     prelaunch(a);
     @(posedge clk_i);
     @(negedge clk_i);
@@ -284,7 +296,9 @@ module tb_dcache
   // Issue an AMO.  amo_op is the funct5 field (AMOADD = 5'b00000).
   // Captures the OLD value (returned via rdata when amo_done fires).
   task automatic drv_amo(input [63:0] a, input [2:0] sz,
-                         input [4:0]  op, input [63:0] src);
+                         input [4:0]  op, input [63:0] src,
+                         input int gap_cycles = 1);
+    if (gap_cycles > 1) repeat (gap_cycles - 1) @(posedge clk_i);
     prelaunch(a);
     @(posedge clk_i);
     @(negedge clk_i);
@@ -492,6 +506,93 @@ module tb_dcache
                     last_rdata, tb_mem[15'((line >> 3) + 64'd3)]));
   endtask
 
+  // ---- test_raw_random --------------------------------------------------
+  // 10,000 randomised dcache ops with weighted op/size/address/gap. Every
+  // store updates the scoreboard; every load asserts against scoreboard
+  // expected. First mismatch prints full repro context and the test bails
+  // after 3 mismatches.
+  task automatic test_raw_random(input int seed = 0);
+    int          rng_state;
+    int          n_ops;
+    int          op_kind;
+    int          sz;
+    int          gap;
+    int          bucket;
+    int          size_bucket;
+    int          in_hot;
+    logic [63:0] a;
+    logic [63:0] line_base;
+    logic [63:0] data;
+    logic [63:0] expected_v;
+    logic [63:0] wdata_init;
+    int          local_errors;
+    rng_state    = seed;
+    local_errors = 0;
+    n_ops        = 10000;
+    // Use a region that the directed tests (1-5) do not touch.
+    line_base    = 64'h0000_0000_0000_8000;
+
+    // Mirror the initial AXI memory state into the scoreboard so that loads
+    // to cold addresses get the correct expected value.
+    for (int w = 0; w < 32768; w++) begin
+      wdata_init = tb_mem[w];
+      u_sb.store(64'(w * 8), 3'd3, wdata_init);
+    end
+
+    // Seed the thread-local RNG.
+    void'($urandom(rng_state));
+
+    for (int i = 0; i < n_ops; i++) begin
+      bucket      = $urandom() % 100;
+      op_kind     = (bucket < 40) ? 0 : (bucket < 80) ? 1 : 2;
+
+      size_bucket = $urandom() % 4;
+      sz          = size_bucket;
+
+      in_hot      = int'(($urandom() % 100) < 80);
+      // Hot: within 4 KB of line_base; cold: 2..5 lines away (stays in tb_mem).
+      a = (in_hot != 0)
+          ? line_base + 64'($urandom() % (1 << 12))
+          : line_base + (64'($urandom() % 4) + 2) * (1 << 12) +
+                        64'($urandom() % (1 << 12));
+      a = a & ~((64'h1 << sz) - 1);
+
+      bucket      = $urandom() % 100;
+      gap         = (bucket < 60) ? 0 : (bucket < 90) ? 1 : 2;
+
+      // Wait for any in-progress refill/AMO-RMW to complete before
+      // pre-launching the next op. Mirrors the pipeline stall the LSU
+      // would see in real hardware.
+      while (stall) @(posedge clk_i);
+
+      if (op_kind == 0) begin
+        drv_load(a, sz[2:0], gap);
+        expected_v = u_sb.expected(a, sz[2:0]);
+        if ((last_rdata & ((64'h1 << (8 << sz)) - 64'd1)) !==
+            (expected_v & ((64'h1 << (8 << sz)) - 64'd1))) begin
+          $display("FAIL test_raw_random[%0d]: addr=%h sz=%0d gap=%0d got=%h expected=%h (seed=%0d)",
+                   i, a, sz, gap, last_rdata, expected_v, seed);
+          local_errors++;
+          if (local_errors >= 3) break;
+        end
+      end else if (op_kind == 1) begin
+        data = {$urandom(), $urandom()};
+        drv_store(a, sz[2:0], data, gap);
+        u_sb.store(a, sz[2:0], data);
+      end else begin
+        // AMO: clamp size to word/double (byte/half AMOs are illegal in RV64).
+        sz   = (size_bucket < 2) ? 2 : 3;
+        a    = a & ~((64'h1 << sz) - 64'd1);
+        data = {$urandom(), $urandom()};
+        drv_amo(a, sz[2:0], 5'b00001, data, gap);
+        u_sb.store(a, sz[2:0], data);
+      end
+    end
+
+    if (local_errors == 0) $display("PASS test_raw_random (seed=%0d, n_ops=%0d)", seed, n_ops);
+    errors = errors + local_errors;
+  endtask
+
   // ---- Sequencer ---------------------------------------------------------
   initial begin
     drv_reset();
@@ -502,7 +603,13 @@ module tb_dcache
     test_amo_hit_then_load();
     test_refill_window_load();
 
-    if (errors == 0) $display("PASS: tb_dcache (5 stage6g cases)");
+    begin : run_random
+      int rseed;
+      if (!$value$plusargs("seed=%d", rseed)) rseed = 0;
+      test_raw_random(rseed);
+    end
+
+    if (errors == 0) $display("PASS: tb_dcache (5 stage6g cases + random stressor)");
     else             $display("FAIL: tb_dcache (%0d errors)", errors);
     $finish;
   end

--- a/tools/cosim_fuzz/__init__.py
+++ b/tools/cosim_fuzz/__init__.py
@@ -1,0 +1,1 @@
+"""cosim_fuzz — source-level mutational fuzzer for GCC-compiled C cosim."""

--- a/tools/cosim_fuzz/mutator.py
+++ b/tools/cosim_fuzz/mutator.py
@@ -1,0 +1,71 @@
+"""Mutator: parse `// MUTATE:` headers in a C source file and produce a
+mutated copy.
+
+Mutation grammar (per line in source):
+    // MUTATE: <name> = randint(<lo>, <hi>)
+    // MUTATE: <name> = choice([<v1>, <v2>, ...])
+
+The mutator does NOT rewrite the C body. Each base program is responsible
+for capturing its mutable parameters in `enum { ... }` constants whose
+*values* the mutator substitutes via simple regex replacement on
+`<NAME> = <number>` patterns matching the enum identifier in upper case.
+"""
+from __future__ import annotations
+import re
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+_HEADER_RE_RANGE  = re.compile(r"//\s*MUTATE:\s*(\w+)\s*=\s*randint\(\s*(-?\d+)\s*,\s*(-?\d+)\s*\)")
+_HEADER_RE_CHOICE = re.compile(r"//\s*MUTATE:\s*(\w+)\s*=\s*choice\(\s*\[([^\]]+)\]\s*\)")
+
+
+@dataclass
+class Mutation:
+    name: str
+    value: object
+
+    def __str__(self) -> str:
+        return f"{self.name}={self.value}"
+
+
+def parse_headers(src: str) -> Dict[str, Tuple[str, list]]:
+    decls: Dict[str, Tuple[str, list]] = {}
+    for m in _HEADER_RE_RANGE.finditer(src):
+        decls[m.group(1)] = ("range", [int(m.group(2)), int(m.group(3))])
+    for m in _HEADER_RE_CHOICE.finditer(src):
+        opts = [s.strip().strip('"').strip("'") for s in m.group(2).split(",")]
+        decls[m.group(1)] = ("choice", opts)
+    return decls
+
+
+def pick(decls: Dict[str, Tuple[str, list]], rng: random.Random) -> List[Mutation]:
+    out: List[Mutation] = []
+    for name, (kind, args) in decls.items():
+        if kind == "range":
+            out.append(Mutation(name, rng.randint(args[0], args[1])))
+        elif kind == "choice":
+            out.append(Mutation(name, rng.choice(args)))
+    return out
+
+
+def apply(src: str, mutations: List[Mutation]) -> str:
+    out = src
+    for m in mutations:
+        upper = m.name.upper()
+        pattern = re.compile(rf"\b{re.escape(upper)}\s*=\s*-?\d+")
+        out, n = pattern.subn(f"{upper} = {m.value}", out, count=1)
+        if n == 0:
+            pattern2 = re.compile(rf"\b{re.escape(m.name)}\s*=\s*-?\d+")
+            out, _ = pattern2.subn(f"{m.name} = {m.value}", out, count=1)
+    return out
+
+
+def mutate_file(path: Path, seed: int) -> Tuple[str, List[Mutation]]:
+    src = path.read_text()
+    decls = parse_headers(src)
+    rng = random.Random(seed)
+    muts = pick(decls, rng)
+    return apply(src, muts), muts

--- a/tools/cosim_fuzz/runner.py
+++ b/tools/cosim_fuzz/runner.py
@@ -1,0 +1,176 @@
+"""Cosim runner: for each base program × mutation seed, generate, compile,
+run on Kronos with retire-trace, run on Sail, diff, and report.
+
+CLI:
+  python3 -m tools.cosim_fuzz.runner \\
+    --program sw/cosim/recursive_factorial.c \\
+    --seed 0 \\
+    --out-dir sim/obj_dir/cosim_fuzz/ \\
+    --kronos-bin sim/obj_dir/s6/Vsim_top \\
+    --sail-trace-script tools/sail_trace.sh \\
+    --diff-script tools/trace_diff.py
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from .mutator import mutate_file
+
+
+CFLAGS = [
+    # Match the proven CRV-runner toolchain string. CI's apt-installed
+    # gcc-riscv64-unknown-elf does not recognise `_zifencei` as a separate
+    # extension; using the same `_zicsr` variant the existing CRV harness
+    # uses keeps both runners on a single, supported flag set.
+    "-march=rv64imafdc_zicsr", "-mabi=lp64",
+    "-nostdlib", "-static", "-Os",
+]
+TOOLCHAIN = "riscv64-unknown-elf"
+HALT_TIMEOUT_S = 30
+
+
+def _hash(src: str) -> str:
+    return hashlib.sha256(src.encode()).hexdigest()[:12]
+
+
+def compile_program(src: str, common_s: Path, link_ld: Path, out_dir: Path,
+                    name: str) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    src_path = out_dir / f"{name}.c"
+    elf_path = out_dir / f"{name}.elf"
+    hex_path = out_dir / f"{name}.hex"
+    src_path.write_text(src)
+
+    cc = ([f"{TOOLCHAIN}-gcc"] + CFLAGS +
+          ["-T", str(link_ld), "-o", str(elf_path),
+           str(src_path), str(common_s)])
+    subprocess.run(cc, check=True)
+    subprocess.run([f"{TOOLCHAIN}-objcopy", "-O", "ihex",
+                    str(elf_path), str(hex_path)], check=True)
+    return elf_path, hex_path
+
+
+def run_kronos(kronos_bin: Path, hex_path: Path, trace_path: Path) -> int:
+    """Returns x10 on halt, -2 on subprocess hang, -1 on missing-x10.
+
+    On hang or sim-side timeout, dumps the tail of the in-progress retire
+    trace + stderr so the cosim diagnostic block can show where the program
+    wedged.  SIM_MAX_CYCLES is set well above all known cosim-corpus runs
+    so the sim's own cycle limit fires before the subprocess timeout —
+    the sim's [sim] TIMEOUT message identifies the wedge PC for free.
+    """
+    env = dict(os.environ)
+    env["SIM_TRACE"] = str(trace_path)
+    env["SIM_MAX_CYCLES"] = "2000000"
+    try:
+        res = subprocess.run([str(kronos_bin), str(hex_path)],
+                             env=env, capture_output=True,
+                             timeout=HALT_TIMEOUT_S)
+    except subprocess.TimeoutExpired as exc:
+        print(f"  [run_kronos] subprocess timeout after {HALT_TIMEOUT_S}s")
+        if trace_path.exists():
+            tail = trace_path.read_text().splitlines()[-15:]
+            print(f"  trace tail ({len(tail)} of "
+                  f"{sum(1 for _ in trace_path.open())} lines):")
+            for line in tail:
+                print(f"    {line}")
+        if exc.stderr:
+            stderr_tail = exc.stderr.decode("utf-8", errors="replace").splitlines()[-15:]
+            print("  stderr tail:")
+            for line in stderr_tail:
+                print(f"    {line}")
+        return -2
+    stdout = res.stdout.decode("utf-8", errors="replace")
+    stderr = res.stderr.decode("utf-8", errors="replace")
+    for line in stdout.splitlines() + stderr.splitlines():
+        if "x10 = " in line:
+            try:
+                return int(line.split("x10 = ")[1].split()[0])
+            except Exception:
+                pass
+    # No x10 line — sim halted abnormally or hit SIM_MAX_CYCLES.  Dump tail
+    # of trace + stderr so the wedge PC is visible in CI logs.
+    print(f"  [run_kronos] no halt-x10 line (sim self-terminated or crashed)")
+    if trace_path.exists():
+        tail = trace_path.read_text().splitlines()[-10:]
+        print(f"  trace tail:")
+        for line in tail:
+            print(f"    {line}")
+    if stderr:
+        for line in stderr.splitlines()[-10:]:
+            print(f"  stderr: {line}")
+    return -1
+
+
+def run_sail(sail_script: Path, elf_path: Path, trace_path: Path) -> None:
+    with open(trace_path, "wb") as fp:
+        subprocess.run([str(sail_script), str(elf_path)], stdout=fp,
+                       check=True, timeout=HALT_TIMEOUT_S)
+
+
+def diff_traces(diff_script: Path, k_trace: Path, s_trace: Path) -> tuple[bool, str]:
+    # --strip-noeffect drops pure-control-flow lines from both traces so the
+    # Sail (per-instruction) and Kronos (retire-with-effect-only) streams align.
+    res = subprocess.run([str(diff_script), "--strip-noeffect",
+                          str(k_trace), str(s_trace)],
+                         capture_output=True, text=True)
+    return res.returncode == 0, res.stdout + res.stderr
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--program", required=True, type=Path)
+    ap.add_argument("--seed", required=True, type=int)
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--kronos-bin", required=True, type=Path)
+    ap.add_argument("--sail-trace-script", required=True, type=Path)
+    ap.add_argument("--diff-script", required=True, type=Path)
+    ap.add_argument("--common-s", default=Path("sw/cosim/cosim_common.S"), type=Path)
+    ap.add_argument("--link-ld", default=Path("sw/stage0/link.ld"), type=Path)
+    args = ap.parse_args()
+
+    src_mut, muts = mutate_file(args.program, args.seed)
+    name = f"{args.program.stem}_seed{args.seed}_{_hash(src_mut)}"
+    print(f"[cosim_fuzz] {name} mutations={[str(m) for m in muts]}")
+
+    out_dir = args.out_dir / name
+    elf_path, hex_path = compile_program(src_mut, args.common_s, args.link_ld,
+                                         out_dir, name)
+
+    k_trace = out_dir / "kronos.trace"
+    s_trace = out_dir / "sail.trace"
+
+    kronos_x10 = run_kronos(args.kronos_bin, hex_path, k_trace)
+    if kronos_x10 != 0:
+        print(f"[cosim_fuzz] FAIL {name} (kronos x10 = {kronos_x10})")
+        sys.exit(1)
+
+    run_sail(args.sail_trace_script, elf_path, s_trace)
+    ok, diff = diff_traces(args.diff_script, k_trace, s_trace)
+    if not ok:
+        print(f"[cosim_fuzz] FAIL {name} (trace diff)")
+        # On failure, dump trace sizes + first/last few lines of each so the CI
+        # log surfaces enough context to debug Sail-side problems (empty trace,
+        # different reset PC, etc.) without needing artefact upload.
+        for label, p in (("kronos", k_trace), ("sail", s_trace)):
+            if p.exists():
+                lines = p.read_text().splitlines()
+                print(f"  [{label}] {len(lines)} lines, {p.stat().st_size} bytes")
+                for line in lines[:3]:
+                    print(f"    {label} head: {line}")
+                for line in lines[-3:]:
+                    print(f"    {label} tail: {line}")
+            else:
+                print(f"  [{label}] trace file MISSING")
+        print(diff[:4000])
+        sys.exit(1)
+
+    print(f"[cosim_fuzz] PASS {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/crv/README.md
+++ b/tools/crv/README.md
@@ -1,0 +1,70 @@
+# tools/crv — Constrained-Random Verification harness
+
+Generates random RV64IMAFDC assembly programs, runs them on Kronos and on the
+Sail ISA reference model, and diffs the retire traces instruction-by-instruction.
+
+## Scenarios
+
+| Scenario | Focus |
+|---|---|
+| `int_hazards` | RAW/WAW/WAR hazards across integer ALU ops |
+| `muldiv_interleave` | MUL/DIV interleaved with integer ALU |
+| `mem_ordering` | Back-to-back and interleaved loads/stores to DATA + ATOMIC regions |
+| `fp_arith` | Single- and double-precision FP arithmetic |
+| `fdiv_fsqrt` | FDIV/FSQRT with stall hazards |
+| `branch_pred` | Branch-heavy programs stressing the predictor |
+| `traps` | Illegal instructions and environment calls |
+| `raw_stress` | Back-to-back same-address store→load for all four widths (issue #82 class) |
+
+## Quick start
+
+```bash
+# Single scenario, one seed
+cd sim
+make sim-crv-s6-mem_ordering CRV_SEED=0
+
+# All 8 scenarios, seed 0 (smoke)
+make sim-crv-smoke-s6
+
+# All 8 scenarios × 50 seeds (deep regression)
+make sim-crv-deep-s6
+```
+
+Stage 5 equivalents: `sim-crv-<scenario>`, `sim-crv-smoke`, `sim-crv-deep`.
+
+## Reproducing a failing seed on Stage 6
+
+When `sim-crv-deep-s6` reports a failing seed, reproduce locally with:
+
+```bash
+# Replace SCENARIO and SEED with the values from the failure log.
+cd sim
+make sim-crv-s6-<SCENARIO> CRV_SEED=<SEED> CRV_LENGTH=200
+```
+
+For a side-by-side trace diff:
+
+```bash
+# 1. Run the runner directly (from the repo root).
+PYTHONPATH=. python3 -m tools.crv.runner \
+  --scenario <SCENARIO> --seed <SEED> --length 200 \
+  --build-dir sim/obj_dir/crv \
+  --kronos-bin sim/obj_dir/s6/Vsim_top \
+  --link-script sw/stage0/link.ld \
+  --common-s   sw/stage0/common.S \
+  --sail-trace-script tools/sail_trace.sh \
+  --diff-script tools/trace_diff.py
+
+# 2. The runner saves artefacts on divergence. Inspect:
+ls sim/obj_dir/crv/<SCENARIO>_<SEED>/
+cat sim/obj_dir/crv/<SCENARIO>_<SEED>/diff.txt
+```
+
+The diff prints the first divergence — PC, expected vs observed register
+write or memory write. From there, narrow with `SIM_DEBUG=1
+SIM_PC_RANGE=<lo>-<hi>` to capture cycle-by-cycle trace:
+
+```bash
+SIM_DEBUG=1 SIM_PC_RANGE=<lo_hex>-<hi_hex> \
+  sim/obj_dir/s6/Vsim_top sim/obj_dir/crv/<SCENARIO>_<SEED>/prog.hex
+```

--- a/tools/crv/scenarios/__init__.py
+++ b/tools/crv/scenarios/__init__.py
@@ -19,6 +19,7 @@ _SCENARIOS = {
     "fdiv_fsqrt":         "tools.crv.scenarios.fdiv_fsqrt",
     "branch_pred":        "tools.crv.scenarios.branch_pred",
     "traps":              "tools.crv.scenarios.traps",
+    "raw_stress":         "tools.crv.scenarios.raw_stress",
 }
 
 

--- a/tools/crv/scenarios/raw_stress.py
+++ b/tools/crv/scenarios/raw_stress.py
@@ -1,0 +1,92 @@
+"""Scenario: raw_stress.
+
+Targets the issue #82 bug class: back-to-back same-address store→load with
+varying byte/half/word/double sizes and minimal pipeline gap.  The pattern
+exercises the dcache hit_beat bypass that handles same-cycle write+read
+collisions for every supported access width.
+
+Constraints:
+  - Back-to-back store immediately followed by load to the same aligned
+    address, covering all four widths (byte/half/word/double).
+  - Hot 4 KiB data region to maximise cache-line reuse.
+  - x10 = base of DATA region, excluded from writable destinations.
+"""
+from __future__ import annotations
+from typing import List
+import random
+
+from ..encoding import (
+    Reg, AsmInstr,
+    addi, lui,
+    lb, lh, lw, ld,
+    sb, sh, sw, sd,
+)
+from ..regfile import GPState, FPState
+from ..memory import DATA_BASE
+
+# x0  = hardwired zero
+# x1  = ra (saved by prologue)
+# x2  = sp (stack pointer)
+# x10 = DATA pointer
+_RESERVED = frozenset({Reg.X0, Reg.X1, Reg.X2, Reg.X10})
+_WRITABLE  = [r for r in Reg if r not in _RESERVED]
+
+# (bytes, store_fn, load_fn)
+_SIZES = [
+    (1, sb, lb),
+    (2, sh, lh),
+    (4, sw, lw),
+    (8, sd, ld),
+]
+
+_HOT_REGION = 4096  # bytes — stays within a few cache lines
+
+
+def _random_writable(rng: random.Random) -> Reg:
+    return rng.choice(_WRITABLE)
+
+
+def generate(rng: random.Random, gp: GPState, fp: FPState,
+             length: int) -> List[AsmInstr]:
+    out: List[AsmInstr] = []
+
+    # Set up x10 = DATA_BASE.
+    upper = (DATA_BASE >> 12) & 0xFFFFF
+    lower = DATA_BASE & 0xFFF
+    if lower & 0x800:
+        upper = (upper + 1) & 0xFFFFF
+        lower = lower - 0x1000
+    out.append(lui(Reg.X10, upper))
+    out.append(addi(Reg.X10, Reg.X10, lower))
+    gp.write(Reg.X10)
+
+    while len(out) < length + 2:
+        sz_bytes, store_op, load_op = rng.choice(_SIZES)
+
+        # Aligned offset within the hot region.
+        max_slots = (_HOT_REGION // sz_bytes) - 1
+        off = rng.randint(0, max_slots) * sz_bytes
+
+        # Cap at signed 12-bit range (−2048..2047); offsets here are 0..4088
+        # which may exceed 2047 for 8-byte accesses — clamp to stay in range.
+        if off > 2040:
+            off = off % 2040 // sz_bytes * sz_bytes
+
+        # Pick a register to hold the store value from live GP regs.
+        rs2 = gp.random_live(rng)
+
+        # Pick a destination register for the load (any non-reserved reg).
+        rd = _random_writable(rng)
+
+        # addi to write a fresh value into rs2 (guards against stale x0 reads).
+        val = rng.randint(-2048, 2047)
+        rs2 = _random_writable(rng)
+        out.append(addi(rs2, Reg.X0, val))
+        gp.write(rs2)
+
+        # Back-to-back: store then load at the same address.
+        out.append(store_op(rs2, Reg.X10, off))
+        out.append(load_op(rd, Reg.X10, off))
+        gp.write(rd)
+
+    return out

--- a/tools/sail_trace.sh
+++ b/tools/sail_trace.sh
@@ -28,6 +28,9 @@ trap 'rm -f "$TRACE_TMP"' EXIT
 # naturally via HTIF before hitting this limit.  Override via SIM_INST_LIMIT.
 INST_LIMIT=${SIM_INST_LIMIT:-50000}
 
+SAIL_ERR=$(mktemp /tmp/sail_trace_err_XXXXXX.txt)
+trap 'rm -f "$TRACE_TMP" "$SAIL_ERR"' EXIT
+
 sail_riscv_sim \
   --trace-instr \
   --trace-reg \
@@ -36,6 +39,15 @@ sail_riscv_sim \
   --config "$SAIL_CONFIG" \
   --inst-limit "$INST_LIMIT" \
   "$ELF" \
-  >/dev/null 2>&1 || true
+  >/dev/null 2>"$SAIL_ERR" || true
+
+# If Sail produced nothing (crash, missing config, unknown ELF format, etc.),
+# surface its stderr on OUR stderr so the caller can see the cause. CRV traces
+# are large enough that this branch never fires for them — only the cosim
+# runner reaches it on truly broken Sail invocations.
+if [[ ! -s "$TRACE_TMP" ]]; then
+  echo "[sail_trace.sh] Sail produced no trace; stderr follows:" >&2
+  sed -n '1,40p' "$SAIL_ERR" >&2
+fi
 
 python3 "$SCRIPT_DIR/sail_trace_normalize.py" < "$TRACE_TMP"

--- a/tools/trace_diff.py
+++ b/tools/trace_diff.py
@@ -63,12 +63,19 @@ def _csr_write_visible(line: str) -> bool:
     return rs1 != 0
 
 
-def strip_ignored(line: str) -> str:
+def strip_ignored(line: str, strip_noeffect: bool = False) -> str:
     """Remove mem[...] effects in halt/sig regions and csr[...] effects on
     non-CSR instructions (implicit FS/fflags/trap-CSR writes that Kronos's
     retire trace doesn't surface).
 
     Explicit csr[...] writes on Zicsr instructions are kept and diffed.
+
+    When `strip_noeffect=True`, also drop any line whose remaining content has
+    no observable effect (no register / memory / CSR write — e.g. pure
+    control-flow branches and NOPs). Kronos only emits retire events for
+    instructions with effects; Sail emits one per instruction. Cosim diffs use
+    this to align the two streams. The directed pytest fixtures intentionally
+    use no-effect lines to test line-number alignment, so they leave it off.
 
     Returns cleaned line, or empty string if all observable effects are gone.
     """
@@ -85,10 +92,12 @@ def strip_ignored(line: str) -> str:
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if had_mem and not EFFECT_RE.search(cleaned):
         return ""
+    if strip_noeffect and not EFFECT_RE.search(cleaned):
+        return ""
     return cleaned
 
 
-def load(path: Path) -> list[str]:
+def load(path: Path, strip_noeffect: bool = False) -> list[str]:
     lines: list[str] = []
     for raw in path.read_text().splitlines():
         raw = raw.strip()
@@ -98,7 +107,7 @@ def load(path: Path) -> list[str]:
         # (which spins indefinitely) does not cause a spurious length mismatch.
         if HALT_SENTINEL in raw:
             break
-        s = strip_ignored(raw)
+        s = strip_ignored(raw, strip_noeffect=strip_noeffect)
         if s:
             lines.append(s)
     return lines
@@ -126,19 +135,39 @@ def for_compare(line: str) -> str:
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 3:
-        print(f"Usage: {argv[0]} <kronos_trace> <sail_trace>", file=sys.stderr)
+    # Backward-compatible CLI: the historical positional form is
+    #   trace_diff.py <kronos> <sail>
+    # The cosim runner (Phase 4) passes an extra --strip-noeffect flag to
+    # drop pure-control-flow lines so Sail (per-instruction) and Kronos
+    # (retire-with-effect-only) align. Existing callers (sim-diff-s5,
+    # pytest fixtures) keep the default off.
+    strip_noeffect = False
+    args = list(argv[1:])
+    if "--strip-noeffect" in args:
+        strip_noeffect = True
+        args = [a for a in args if a != "--strip-noeffect"]
+    if len(args) != 2:
+        print(f"Usage: {argv[0]} [--strip-noeffect] <kronos_trace> <sail_trace>",
+              file=sys.stderr)
         return 2
-    a = load(Path(argv[1]))
-    b = load(Path(argv[2]))
+    a = load(Path(args[0]), strip_noeffect=strip_noeffect)
+    b = load(Path(args[1]), strip_noeffect=strip_noeffect)
     if not a:
         print("MISMATCH: Kronos trace is empty", file=sys.stderr)
         return 1
     # Sync: the Kronos retire trace misses startup instructions (pipeline fill
     # and JAL redirect penalty).  Find the first Kronos line in the Sail trace
-    # by matching PC:instr, then compare from that point forward.
+    # by matching PC:instr, then compare from that point forward.  Fallback
+    # to PC-only sync when the encoding differs — Kronos retire-traces the
+    # decompressed (32-bit) form for C-extension instructions while Sail traces
+    # the original 16-bit form, so the same PC has different opcode bytes in
+    # the two streams.  for_compare() already ignores the encoding for content
+    # comparison, so it is safe to anchor on PC alone.
     first_key = pc_instr(a[0])
     sail_start = next((i for i, l in enumerate(b) if pc_instr(l) == first_key), None)
+    if sail_start is None:
+        first_pc = a[0].split(":", 1)[0]
+        sail_start = next((i for i, l in enumerate(b) if l.split(":", 1)[0] == first_pc), None)
     if sail_start is None:
         print(f"SYNC FAIL: Kronos first instruction '{first_key}' not found in Sail trace")
         return 1


### PR DESCRIPTION
## Summary

Closes the verification gap that allowed [issue #82](https://github.com/vladdum/kronos-riscv/issues/82) to ship in v0.6.2 — store-to-load on cacheable memory returning 0 in OpenSoC SW tests.

**Diagnosis (from the spec):** `kronos_dcache.sv:536-551` already had a byte-mask-aware `hit_beat` bypass (added in stage6g/`ce6569d`) that handles same-cycle port-A write + port-B read collisions correctly **in standalone Verilator**. The OpenSoC failure surfaces only with the FPGA xpm `WRITE_MODE_B="no_change"` semantics differing from our behavioral SDP model, plus AXI/MMIO timing the standalone harness does not replicate. **No RTL change is needed for this PR** — the fix landed with the bypass; the verification gap is the real issue.

This PR raises the verification floor across four phases, all delivered as 16 commits on `stage6i-verification-overhaul`:

**Phase 1 — Directed regression**
- `sw/stage6/test_dcache_raw.S` — 5-subtest asm probe (sb→lbu, sh→lhu, sw→lw, sd→ld, sw→lbu) guarding the bypass
- `sw/cosim/{Makefile,cosim_common.S,putdec_stack.c}` — exact issue #82 reproducer (passes locally; documents the failing OpenSoC pattern)
- `make sim-cosim-putdec` Make target

**Phase 2 — Unit-TB constrained-random LSU stressor**
- `tb/stage6/dcache_scoreboard.sv` — pure architectural-memory mirror
- `test_raw_random` task in `tb_dcache.sv`: 10k ops, weighted load/store/AMO, random size/address/gap, scoreboard-checked
- `make sim-dcache-s6-stress` (seed 0, gating) and `sim-dcache-s6-stress-deep` (100 seeds, nightly)
- 100/100 seeds × 10k ops PASS

**Phase 3 — Port CRV/Sail diff harness to Stage 6**
- `make sim-crv-s6-%`, `sim-crv-smoke-s6`, `sim-crv-deep-s6` Make targets
- New `tools/crv/scenarios/raw_stress.py` — back-to-back same-line ops targeting issue #82's class
- `tools/crv/README.md` — failing-seed reproduction recipe
- All 8 scenarios PASS on Stage 6 against Sail at seed 0

**Phase 4 — Source-level mutational fuzzer**
- 13-program GCC-compiled C cosim corpus in `sw/cosim/` (callee-save, putdec, memcpy, memset, struct copy, FP spill, MMIO interleave, string reverse, BCD, CRC8, bsearch, linked-list traversal)
- `tools/cosim_fuzz/{mutator.py, runner.py}` — template-grammar mutator (~80 lines) + Sail-diff runner (~120 lines)
- `make sim-cosim-smoke` (13 progs × 1 mutation, gating) and `sim-cosim-deep` (× 50 mutations, nightly)
- Trace-fidelity finding: `sim_main.cpp` AMO retire records operand instead of new value, and write-back dcache batches stores below per-instruction granularity. Two corpus programs (`atomic_rmw_chain.c`, `fixed_priority_queue.c`) excluded as a result. `tools/trace_diff.py` extended to drop no-effect lines from Sail traces. The trace-fidelity gaps are documented for follow-up.

**CI integration**
- Per-PR (~7 min total): `dcache-stress-s6`, `crv-smoke-s6`, `cosim-smoke`
- Nightly (~30-40 min added): `dcache-stress-deep-s6`, `crv-deep-s6`, `cosim-deep`

## Test plan

- [x] `make sim-arch-test-s6` — 333/333 (no regression)
- [x] `make sim-s6` — 10/10 stage-6 SW tests pass
- [x] `make run-s6-test_dcache_raw` — x10 = 0
- [x] `make sim-cosim-putdec` — emits `12345`
- [x] `make sim-dcache-s6` — all unit-TB tests pass
- [x] `make sim-dcache-s6-stress` — 10k ops, scoreboard clean
- [x] `make sim-dcache-s6-stress-deep` — 100 seeds × 10k ops PASS
- [x] `make sim-crv-smoke-s6` — 8 scenarios × seed 0 all PASS against Sail
- [x] `make sim-cosim-smoke` — 13 programs × 1 mutation all PASS

## Follow-ups (out of scope for this PR)

- Investigate the OpenSoC-specific bug path (xpm vs behavioral SDP, MMIO/AXI timing). Likely requires standing up the OpenSoC harness locally or adding xpm simulation models to the standalone build.
- Trace-fidelity fixes in `sim_main.cpp` for AMOs (record new value instead of operand) and store-batching granularity. Would unlock `atomic_rmw_chain.c` and `fixed_priority_queue.c` in the cosim corpus.
- Optional `priv_mode` CRV scenario (M/S/U mode transitions) — requires encoder helpers `csrr/ecall/mret/sret`.

After this PR merges, the OpenSoC submodule bump from v0.6.1 → v0.6.3 unblocks (separate PR in OpenSoC).