### PR TITLE
fix(icache): stall S2 when bypass takes the FB slot (closes #85)

### DIFF
--- a/rtl/stage5/kronos_icache.sv
+++ b/rtl/stage5/kronos_icache.sv
@@ -242,7 +242,12 @@ module kronos_icache
 
   // ---- Pipeline back-pressure ----------------------------------------------
   assign s2_held_hit = s2_valid_q & s2_hit_q & ~s2_kill_i;
-  assign s2_stall    = s2_held_hit & ~s2_enq_ready_i;
+  // bypass_drive overrides the s2_enq_pc_o / s2_enq_data_o mux when active,
+  // so a same-cycle s2-hit-push would silently lose its tuple — the FB only
+  // accepts one entry per cycle and the bypass wins the priority mux. Stall
+  // s2 while the bypass is taking the FB slot so the held hit pushes next
+  // cycle (after bypass_pending_q clears).
+  assign s2_stall    = s2_held_hit & (~s2_enq_ready_i | bypass_drive);
   assign s1_advance  = s1_valid_q & ~s2_stall & (state_q == ICACHE_IDLE);
   assign s0_ready_o  = (state_q == ICACHE_IDLE) & ~s2_stall;
   assign s0_accept   = s0_valid_i & s0_ready_o;

--- a/rtl/stage6/kronos_icache.sv
+++ b/rtl/stage6/kronos_icache.sv
@@ -312,7 +312,12 @@ module kronos_icache
   // ---- Pipeline back-pressure ----------------------------------------------
   // S2 holds a hit that has not yet been drained into the FB.
   assign s2_held_hit = s2_valid_q & s2_hit_q & ~s2_kill_i;
-  assign s2_stall    = s2_held_hit & ~s2_enq_ready_i;
+  // bypass_drive overrides the s2_enq_pc_o / s2_enq_data_o mux when active,
+  // so a same-cycle s2-hit-push would silently lose its tuple — the FB only
+  // accepts one entry per cycle and the bypass wins the priority mux. Stall
+  // s2 while the bypass is taking the FB slot so the held hit pushes next
+  // cycle (after bypass_pending_q clears).
+  assign s2_stall    = s2_held_hit & (~s2_enq_ready_i | bypass_drive);
 
   // S1 may advance to S2 only when S2 has slack and we're idle (not in
   // refill).  During refill the BRAM is being written, no read happens.


### PR DESCRIPTION
## Summary
- Stall S2 in the icache while `bypass_drive` is active so a held S2-hit doesn't get silently dropped from the FB stream when both fire in the same cycle.
- Same one-line change mirrored in `rtl/stage5/kronos_icache.sv` and `rtl/stage6/kronos_icache.sv`.
- Closes #85.

## Root cause
`s2_enq_valid_o = s2_held_hit | bypass_drive` and the FB has one push port per cycle. When both fire together, the bypass wins the priority mux for `s2_enq_pc_o` / `s2_enq_data_o`, but S2 still sees `(s2_enq_v_o & s2_enq_rdy_i)` and advances next cycle — losing its cached word from the FB stream. The drop bites when a held bypass (`bypass_pending_q` from a cold-start miss whose critical word didn't fit in a full FB) finally drains while S2 has progressed to a sequential hit.

`predecode` then splices the upper half of a 32-bit instruction at a non-4-byte-aligned PC from the wrong word and emits a phantom opcode at the right PC.

For seed `20260503001`, line 99 of the trace shows kronos `0x182:017646b3 x13=-1` versus sail `0x182:027546b3 x13=0` — the upper half `0176` is the lower halfword of the word at PC+6 (`0x188`), confirming a one-word gap in the stream rather than a decode or retire-trace bug.

## Fix
```systemverilog
- assign s2_stall = s2_held_hit & ~s2_enq_ready_i;
+ assign s2_stall = s2_held_hit & (~s2_enq_ready_i | bypass_drive);
```
S2 now holds while bypass is taking the FB slot; the held hit pushes the cycle after `bypass_pending_q` clears.

## Test plan
- [x] Five reported failing CRV seeds now PASS (`muldiv_interleave` 20260503001/016/020/021, `mem_ordering` 20260503012)
- [x] `make sim-crv-deep` (s5 + s6, 8 scenarios × 50 seeds = 400 runs each) clean
- [x] ACT4 — 307/307 stage 5, 305/305 stage 6
- [x] `make -C sim ci-local` PASS (cosim-smoke, crv-smoke-s6, dcache-s6-stress, sim-s6, arch-test-s6)
- [x] `sim-perf-baseline-s6` dhrystone 992 254 cycles (within ±2% gate)
- [x] `sim-all` green