### PR TITLE
refactor(rtl,tb): hoist in-process decls to module-scope blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -635,10 +635,6 @@ After that, every `git commit` runs the hook on staged files in **delta mode** �
 
 Run a full repository scan manually with `python3 scripts/check_rtl_rules.py` (no `--staged`). Bypass the hook with `git commit --no-verify` only when you have a justified reason.
 
-### Known full-scan offenders
-
-A full-repo scan (no `--staged`) currently flags around 700 R1 violations concentrated in the FPU pipeline files (`rtl/stage5/fpu/kronos_fpu_fma.sv`, `kronos_fpu_fmul.sv`, `kronos_fpu_fcvt.sv`, `kronos_fpu_iter.sv`, `kronos_fpu_fadd.sv`, plus their stage-6 mirrors and `kronos_dcache.sv`). These files use a per-pipeline-stage layout — sectioned blocks of `logic` declarations interleaved with the corresponding `always_ff` / `always_comb` blocks — instead of the canonical "single decl block at the top." The pattern is established and not a hazard, but it does not match R1. A dedicated FPU restructuring pass would consolidate the decls; until that lands, the hook's delta mode is the practical guardrail.
-
 ## OpenSoC Integration
 
 The parent project is at `/home/popes/opensoc`. kronos-riscv is added as a

--- a/rtl/common/fpu/kronos_fpu_fma.sv
+++ b/rtl/common/fpu/kronos_fpu_fma.sv
@@ -125,6 +125,243 @@ module kronos_fpu_fma
   logic [kronos_pkg::FLEN-1:0]    s1_special_result;
   logic [4:0]         s1_special_flags;
 
+  // Stage 1 -> Stage 2 register
+  logic               s2_valid;
+  logic               s2_special;
+  logic [kronos_pkg::FLEN-1:0]    s2_special_result;
+  logic [4:0]         s2_special_flags;
+  logic               s2_fmt_d;
+  logic [2:0]         s2_rm;
+  logic               s2_prod_sign;
+  logic               s2_addend_sign;
+  logic signed [12:0] s2_prod_exp;
+  logic signed [12:0] s2_c_exp;
+  logic [SIG_W-1:0]   s2_a_sig;
+  logic [SIG_W-1:0]   s2_b_sig;
+  logic [SIG_W-1:0]   s2_c_sig;
+  logic               s2_prod_zero;
+  logic               s2_c_zero;
+  fpu_tag_t           s2_tag;
+
+  // Stage 2 -> Stage 2b register (re-latch for DSP retiming)
+  logic               s2b_valid;
+  logic               s2b_special;
+  logic [kronos_pkg::FLEN-1:0]    s2b_special_result;
+  logic [4:0]         s2b_special_flags;
+  logic               s2b_fmt_d;
+  logic [2:0]         s2b_rm;
+  logic               s2b_prod_sign;
+  logic               s2b_addend_sign;
+  logic signed [12:0] s2b_prod_exp;
+  logic signed [12:0] s2b_c_exp;
+  logic [SIG_W-1:0]   s2b_a_sig;
+  logic [SIG_W-1:0]   s2b_b_sig;
+  logic [SIG_W-1:0]   s2b_c_sig;
+  logic               s2b_prod_zero;
+  logic               s2b_c_zero;
+  fpu_tag_t           s2b_tag;
+
+  // Stage 2b multiply output (combinational, drives S3 register)
+  logic [PROD_W-1:0]  s2_product_comb;
+
+  // Stage 2b -> Stage 3 register
+  logic               s3_valid;
+  logic               s3_special;
+  logic [kronos_pkg::FLEN-1:0]    s3_special_result;
+  logic [4:0]         s3_special_flags;
+  logic               s3_fmt_d;
+  logic [2:0]         s3_rm;
+  logic               s3_prod_sign;
+  logic               s3_addend_sign;
+  logic signed [12:0] s3_prod_exp;
+  logic signed [12:0] s3_c_exp;
+  logic [PROD_W-1:0]  s3_product;
+  logic [SIG_W-1:0]   s3_c_sig;
+  logic               s3_prod_zero;
+  logic               s3_c_zero;
+  fpu_tag_t           s3_tag;
+
+  // Stage 3 align: pre-shift outputs (written in S3 comb, read by proc_s3b_regs).
+  logic signed [12:0] s3a_base_exp_comb;
+  logic               s3a_eff_sub_comb;
+  logic [7:0]         s3a_sh_comb;          // clamped shift amount (0..159)
+  logic [SUM_W-1:0]   s3a_shift_src_comb;   // operand to be shifted right
+  logic [SUM_W-1:0]   s3a_passthrough_comb; // operand to pass through unshifted
+  // s3a_shift_is_c_comb=1 -> s3_c_lane = shifted, s3_prod_lane = passthrough.
+  // s3a_shift_is_c_comb=0 -> s3_c_lane = passthrough, s3_prod_lane = shifted.
+  logic               s3a_shift_is_c_comb;
+  logic               s3a_zero_shift_comb;  // 1 when one side is zero
+  logic               s3a_prod_zero_comb;   // 1 -> output s3_prod_lane forced to 0
+  logic               s3a_c_zero_comb;      // 1 -> output s3_c_lane forced to 0
+
+  // Stage 3 align comb scratch
+  logic signed [13:0] s3a_exp_diff;
+  logic signed [13:0] s3a_shift_amt;
+  logic [SUM_W-1:0]   s3a_c_extended;
+  logic [SUM_W-1:0]   s3a_p_extended;
+  int unsigned        s3a_sh;
+
+  // Stage 3 -> Stage 3b register
+  logic               s3b_valid;
+  logic               s3b_special;
+  logic [kronos_pkg::FLEN-1:0]    s3b_special_result;
+  logic [4:0]         s3b_special_flags;
+  logic               s3b_fmt_d;
+  logic [2:0]         s3b_rm;
+  logic               s3b_prod_sign;
+  logic               s3b_addend_sign;
+  logic signed [12:0] s3b_base_exp;
+  logic               s3b_eff_sub;
+  logic [7:0]         s3b_sh;
+  logic [SUM_W-1:0]   s3b_shift_src;
+  logic [SUM_W-1:0]   s3b_passthrough;
+  logic               s3b_shift_is_c;
+  logic               s3b_zero_shift;
+  logic               s3b_prod_zero_flag;
+  logic               s3b_c_zero_flag;
+  fpu_tag_t           s3b_tag;
+
+  // Stage 3b combinational outputs
+  logic [SUM_W-1:0]   s3b_prod_lane_comb;
+  logic [SUM_W-1:0]   s3b_c_lane_comb;
+  logic signed [12:0] s3b_base_exp_out_comb;
+  logic               s3b_eff_sub_out_comb;
+
+  // Stage 3b shift scratch
+  logic [SUM_W-1:0]   s3b_shifted;
+  logic               s3b_sticky;
+  int unsigned        s3b_sh_int;
+
+  // Stage 3b -> Stage 4 register
+  logic               s4_valid;
+  logic               s4_special;
+  logic [kronos_pkg::FLEN-1:0]    s4_special_result;
+  logic [4:0]         s4_special_flags;
+  logic               s4_fmt_d;
+  logic [2:0]         s4_rm;
+  logic               s4_prod_sign;
+  logic               s4_addend_sign;
+  logic signed [12:0] s4_base_exp;
+  logic [SUM_W-1:0]   s4_prod_lane;
+  logic [SUM_W-1:0]   s4_c_lane;
+  logic               s4_eff_sub;
+  fpu_tag_t           s4_tag;
+
+  // Stage 4 -> Stage 4b register (after 160-bit add, before LZC)
+  logic               s4b_valid;
+  logic               s4b_special;
+  logic [kronos_pkg::FLEN-1:0]    s4b_special_result;
+  logic [4:0]         s4b_special_flags;
+  logic               s4b_fmt_d;
+  logic [2:0]         s4b_rm;
+  logic               s4b_res_sign;
+  logic               s4b_zero;
+  logic signed [12:0] s4b_base_exp;
+  logic [SUM_W-1:0]   s4b_mag;
+  logic               s4b_eff_sub;
+  logic               s4b_prod_sign;
+  fpu_tag_t           s4b_tag;
+
+  // Stage 4 combinational outputs
+  logic [SUM_W:0]     s4_sum_comb;
+  logic               s4_res_sign_comb;
+  logic               s4_zero_comb;
+  logic [SUM_W-1:0]   s4_mag_comb;
+  logic [SUM_W-1:0]   s4_diff;
+
+  // Stage 4b LZC outputs
+  logic [8:0]         s4b_msb_pos_comb;
+  logic signed [12:0] s4b_norm_exp_comb;
+  // Stage 4b LZC scratch
+  int                 s4b_lzc_m;
+  logic signed [12:0] s4b_ref_pos_s;
+
+  // Stage 4b -> Stage 5 register
+  logic               s5_valid;
+  logic               s5_special;
+  logic [kronos_pkg::FLEN-1:0]    s5_special_result;
+  logic [4:0]         s5_special_flags;
+  logic               s5_fmt_d;
+  logic [2:0]         s5_rm;
+  logic               s5_res_sign;
+  logic               s5_zero;
+  logic signed [12:0] s5_norm_exp;
+  logic [SUM_W-1:0]   s5_norm_mag;
+  logic               s5_eff_sub;
+  logic               s5_prod_sign;
+  logic [8:0]         s5_msb_pos;
+  fpu_tag_t           s5_tag;
+
+  // Stage 5 combinational outputs (barrel shift + GRS)
+  logic [SIG_W-1:0]   s5_raw_sig_comb;
+  logic               s5_guard_comb;
+  logic               s5_round_b_comb;
+  logic               s5_sticky_comb;
+  logic signed [12:0] s5_exp_comb;
+  logic signed [12:0] s5_exp_pre_tiny_comb;
+  logic               s5_tiny_comb;
+  logic [31:0]        s5_normal_shift_comb;
+
+  // Stage 5 scratch
+  int unsigned        s5_frac_w;
+  int signed          s5_bias;
+  logic signed [12:0] s5_emin;
+  logic [SUM_W-1:0]   s5_mag;
+  logic signed [12:0] s5_exp;
+  logic signed [12:0] s5_exp_pre_tiny;
+  logic               s5_tiny;
+  int unsigned        s5_shift_right_amt;
+  int unsigned        s5_normal_shift;
+  logic [SUM_W-1:0]   s5_pre_mag;
+
+  // Stage 5 -> 5b register (after barrel shift, before round)
+  logic               s5b_valid;
+  logic               s5b_special;
+  logic [kronos_pkg::FLEN-1:0]    s5b_special_result;
+  logic [4:0]         s5b_special_flags;
+  logic               s5b_fmt_d;
+  logic [2:0]         s5b_rm;
+  logic               s5b_res_sign;
+  logic               s5b_zero;
+  logic               s5b_eff_sub;
+  logic               s5b_prod_sign;
+  logic signed [12:0] s5b_exp;
+  logic signed [12:0] s5b_exp_pre_tiny;
+  logic [SIG_W-1:0]   s5b_raw_sig;
+  logic               s5b_guard;
+  logic               s5b_round_b;
+  logic               s5b_sticky;
+  logic               s5b_tiny;
+  logic [SUM_W-1:0]   s5b_mag;
+  logic [31:0]        s5b_normal_shift;
+  fpu_tag_t           s5b_tag;
+
+  // Stage 5b combinational outputs (round, pack)
+  logic [kronos_pkg::FLEN-1:0]    s5b_result_comb;
+  logic [4:0]         s5b_flags_comb;
+
+  // Stage 5b scratch
+  int unsigned                s5b_frac_w;
+  int signed                  s5b_bias;
+  logic signed [12:0]         s5b_emin;
+  logic signed [12:0]         s5b_emax;
+  logic [SIG_W:0]             s5b_rounded_sig;
+  logic                       s5b_inexact;
+  logic                       s5b_overflow_ovf;
+  logic                       s5b_round_up;
+  logic signed [12:0]         s5b_final_exp;
+  logic [SIG_W-1:0]           s5b_final_sig;
+  logic [kronos_pkg::FP_D_EXP_W-1:0]      s5b_exp_field_d;
+  logic [kronos_pkg::FP_S_EXP_W-1:0]      s5b_exp_field_s;
+  // Tininess-after-rounding scratch ("_n" here = "narrow" per file convention).
+  logic [SIG_W-1:0]           s5b_raw_sig_n;
+  logic                       s5b_guard_n, s5b_round_n, s5b_sticky_n;
+  logic                       s5b_round_up_n;
+  logic                       s5b_carry_n;
+  logic [SUM_W-1:0]           s5b_pre_mag_n;
+  int unsigned                s5b_normal_shift_local;
+  int unsigned                s5b_lzc_i;
+
   always_comb begin
     // NaN-unbox single operands
     a_s = (a_i[63:32] == kronos_pkg::FP_NANBOX_UPPER) ? a_i[31:0] : kronos_pkg::FP_CANON_QNAN_S;
@@ -253,23 +490,6 @@ module kronos_fpu_fma
   // ---------------------------------------------------------------------------
   // Stage 1 -> Stage 2 register
   // ---------------------------------------------------------------------------
-  logic               s2_valid;
-  logic               s2_special;
-  logic [kronos_pkg::FLEN-1:0]    s2_special_result;
-  logic [4:0]         s2_special_flags;
-  logic               s2_fmt_d;
-  logic [2:0]         s2_rm;
-  logic               s2_prod_sign;
-  logic               s2_addend_sign;
-  logic signed [12:0] s2_prod_exp;
-  logic signed [12:0] s2_c_exp;
-  logic [SIG_W-1:0]   s2_a_sig;
-  logic [SIG_W-1:0]   s2_b_sig;
-  logic [SIG_W-1:0]   s2_c_sig;
-  logic               s2_prod_zero;
-  logic               s2_c_zero;
-  fpu_tag_t           s2_tag;
-
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s2_regs
     if (!rst_ni) begin
       s2_valid          <= 1'b0;
@@ -313,23 +533,6 @@ module kronos_fpu_fma
   // gives Vivado retiming room inside the 53x53 DSP cascade. No new functional
   // content.
   // ---------------------------------------------------------------------------
-  logic               s2b_valid;
-  logic               s2b_special;
-  logic [kronos_pkg::FLEN-1:0]    s2b_special_result;
-  logic [4:0]         s2b_special_flags;
-  logic               s2b_fmt_d;
-  logic [2:0]         s2b_rm;
-  logic               s2b_prod_sign;
-  logic               s2b_addend_sign;
-  logic signed [12:0] s2b_prod_exp;
-  logic signed [12:0] s2b_c_exp;
-  logic [SIG_W-1:0]   s2b_a_sig;
-  logic [SIG_W-1:0]   s2b_b_sig;
-  logic [SIG_W-1:0]   s2b_c_sig;
-  logic               s2b_prod_zero;
-  logic               s2b_c_zero;
-  fpu_tag_t           s2b_tag;
-
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_s2b_regs
     if (!rst_ni) begin
       s2b_valid          <= 1'b0;
@@ -370,219 +573,6 @@ module kronos_fpu_fma
 
   // ---------------------------------------------------------------------------
   // multiply significands (reads from s2b to break DSP cascade path)
-  // ---------------------------------------------------------------------------
-  logic [PROD_W-1:0]  s2_product_comb;
-
-  // Stage 2b -> Stage 3 register
-  logic               s3_valid;
-  logic               s3_special;
-  logic [kronos_pkg::FLEN-1:0]    s3_special_result;
-  logic [4:0]         s3_special_flags;
-  logic               s3_fmt_d;
-  logic [2:0]         s3_rm;
-  logic               s3_prod_sign;
-  logic               s3_addend_sign;
-  logic signed [12:0] s3_prod_exp;
-  logic signed [12:0] s3_c_exp;
-  logic [PROD_W-1:0]  s3_product;
-  logic [SIG_W-1:0]   s3_c_sig;
-  logic               s3_prod_zero;
-  logic               s3_c_zero;
-  fpu_tag_t           s3_tag;
-
-  // Pre-shift outputs (written in S3 comb, read by proc_s3b_regs).
-  logic signed [12:0] s3a_base_exp_comb;
-  logic               s3a_eff_sub_comb;
-  logic [7:0]         s3a_sh_comb;          // clamped shift amount (0..159)
-  logic [SUM_W-1:0]   s3a_shift_src_comb;   // operand to be shifted right
-  logic [SUM_W-1:0]   s3a_passthrough_comb; // operand to pass through unshifted
-  // s3a_shift_is_c_comb=1 -> s3_c_lane = shifted, s3_prod_lane = passthrough.
-  // s3a_shift_is_c_comb=0 -> s3_c_lane = passthrough, s3_prod_lane = shifted.
-  logic               s3a_shift_is_c_comb;
-  logic               s3a_zero_shift_comb;  // 1 when one side is zero
-  logic               s3a_prod_zero_comb;   // 1 -> output s3_prod_lane forced to 0
-  logic               s3a_c_zero_comb;      // 1 -> output s3_c_lane forced to 0
-
-  // S3 align comb scratch (promoted to module scope per RTL guidelines).
-  logic signed [13:0] s3a_exp_diff;
-  logic signed [13:0] s3a_shift_amt;
-  logic [SUM_W-1:0]   s3a_c_extended;
-  logic [SUM_W-1:0]   s3a_p_extended;
-  int unsigned        s3a_sh;
-
-  // ---------------------------------------------------------------------------
-  // Stage 3 -> Stage 3b register
-  // ---------------------------------------------------------------------------
-  logic               s3b_valid;
-  logic               s3b_special;
-  logic [kronos_pkg::FLEN-1:0]    s3b_special_result;
-  logic [4:0]         s3b_special_flags;
-  logic               s3b_fmt_d;
-  logic [2:0]         s3b_rm;
-  logic               s3b_prod_sign;
-  logic               s3b_addend_sign;
-  logic signed [12:0] s3b_base_exp;
-  logic               s3b_eff_sub;
-  logic [7:0]         s3b_sh;
-  logic [SUM_W-1:0]   s3b_shift_src;
-  logic [SUM_W-1:0]   s3b_passthrough;
-  logic               s3b_shift_is_c;
-  logic               s3b_zero_shift;
-  logic               s3b_prod_zero_flag;
-  logic               s3b_c_zero_flag;
-  fpu_tag_t           s3b_tag;
-
-  // S3b combinational outputs
-  logic [SUM_W-1:0]   s3b_prod_lane_comb;
-  logic [SUM_W-1:0]   s3b_c_lane_comb;
-  logic signed [12:0] s3b_base_exp_out_comb;
-  logic               s3b_eff_sub_out_comb;
-
-  // S3b shift scratch
-  logic [SUM_W-1:0]   s3b_shifted;
-  logic               s3b_sticky;
-  int unsigned        s3b_sh_int;
-
-  // ---------------------------------------------------------------------------
-  // Stage 3b -> Stage 4 register
-  // ---------------------------------------------------------------------------
-  logic               s4_valid;
-  logic               s4_special;
-  logic [kronos_pkg::FLEN-1:0]    s4_special_result;
-  logic [4:0]         s4_special_flags;
-  logic               s4_fmt_d;
-  logic [2:0]         s4_rm;
-  logic               s4_prod_sign;
-  logic               s4_addend_sign;
-  logic signed [12:0] s4_base_exp;
-  logic [SUM_W-1:0]   s4_prod_lane;
-  logic [SUM_W-1:0]   s4_c_lane;
-  logic               s4_eff_sub;
-  fpu_tag_t           s4_tag;
-
-  // ---------------------------------------------------------------------------
-  // Stage 4 -> 4b register (after 160-bit add, before LZC)
-  // ---------------------------------------------------------------------------
-  logic               s4b_valid;
-  logic               s4b_special;
-  logic [kronos_pkg::FLEN-1:0]    s4b_special_result;
-  logic [4:0]         s4b_special_flags;
-  logic               s4b_fmt_d;
-  logic [2:0]         s4b_rm;
-  logic               s4b_res_sign;
-  logic               s4b_zero;
-  logic signed [12:0] s4b_base_exp;
-  logic [SUM_W-1:0]   s4b_mag;
-  logic               s4b_eff_sub;
-  logic               s4b_prod_sign;
-  fpu_tag_t           s4b_tag;
-
-  // Stage 4 combinational outputs
-  logic [SUM_W:0]     s4_sum_comb;
-  logic               s4_res_sign_comb;
-  logic               s4_zero_comb;
-  logic [SUM_W-1:0]   s4_mag_comb;
-  logic [SUM_W-1:0]   s4_diff;
-
-  // Stage 4b LZC outputs
-  logic [8:0]         s4b_msb_pos_comb;
-  logic signed [12:0] s4b_norm_exp_comb;
-  // S4b LZC scratch
-  int                 s4b_lzc_m;
-  logic signed [12:0] s4b_ref_pos_s;
-
-  // ---------------------------------------------------------------------------
-  // Stage 4b -> Stage 5 register
-  // ---------------------------------------------------------------------------
-  logic               s5_valid;
-  logic               s5_special;
-  logic [kronos_pkg::FLEN-1:0]    s5_special_result;
-  logic [4:0]         s5_special_flags;
-  logic               s5_fmt_d;
-  logic [2:0]         s5_rm;
-  logic               s5_res_sign;
-  logic               s5_zero;
-  logic signed [12:0] s5_norm_exp;
-  logic [SUM_W-1:0]   s5_norm_mag;
-  logic               s5_eff_sub;
-  logic               s5_prod_sign;
-  logic [8:0]         s5_msb_pos;
-  fpu_tag_t           s5_tag;
-
-  // Stage 5 combinational outputs (barrel shift + GRS)
-  logic [SIG_W-1:0]   s5_raw_sig_comb;
-  logic               s5_guard_comb;
-  logic               s5_round_b_comb;
-  logic               s5_sticky_comb;
-  logic signed [12:0] s5_exp_comb;
-  logic signed [12:0] s5_exp_pre_tiny_comb;
-  logic               s5_tiny_comb;
-  logic [31:0]        s5_normal_shift_comb;
-
-  // S5 scratch
-  int unsigned        s5_frac_w;
-  int signed          s5_bias;
-  logic signed [12:0] s5_emin;
-  logic [SUM_W-1:0]   s5_mag;
-  logic signed [12:0] s5_exp;
-  logic signed [12:0] s5_exp_pre_tiny;
-  logic               s5_tiny;
-  int unsigned        s5_shift_right_amt;
-  int unsigned        s5_normal_shift;
-  logic [SUM_W-1:0]   s5_pre_mag;
-
-  // ---------------------------------------------------------------------------
-  // Stage 5 -> 5b register (after barrel shift, before round)
-  // ---------------------------------------------------------------------------
-  logic               s5b_valid;
-  logic               s5b_special;
-  logic [kronos_pkg::FLEN-1:0]    s5b_special_result;
-  logic [4:0]         s5b_special_flags;
-  logic               s5b_fmt_d;
-  logic [2:0]         s5b_rm;
-  logic               s5b_res_sign;
-  logic               s5b_zero;
-  logic               s5b_eff_sub;
-  logic               s5b_prod_sign;
-  logic signed [12:0] s5b_exp;
-  logic signed [12:0] s5b_exp_pre_tiny;
-  logic [SIG_W-1:0]   s5b_raw_sig;
-  logic               s5b_guard;
-  logic               s5b_round_b;
-  logic               s5b_sticky;
-  logic               s5b_tiny;
-  logic [SUM_W-1:0]   s5b_mag;
-  logic [31:0]        s5b_normal_shift;
-  fpu_tag_t           s5b_tag;
-
-  // Stage 5b combinational outputs (round, pack)
-  logic [kronos_pkg::FLEN-1:0]    s5b_result_comb;
-  logic [4:0]         s5b_flags_comb;
-
-  // S5b scratch
-  int unsigned                s5b_frac_w;
-  int signed                  s5b_bias;
-  logic signed [12:0]         s5b_emin;
-  logic signed [12:0]         s5b_emax;
-  logic [SIG_W:0]             s5b_rounded_sig;
-  logic                       s5b_inexact;
-  logic                       s5b_overflow_ovf;
-  logic                       s5b_round_up;
-  logic signed [12:0]         s5b_final_exp;
-  logic [SIG_W-1:0]           s5b_final_sig;
-  logic [kronos_pkg::FP_D_EXP_W-1:0]      s5b_exp_field_d;
-  logic [kronos_pkg::FP_S_EXP_W-1:0]      s5b_exp_field_s;
-  // Tininess-after-rounding scratch ("_n" here = "narrow" per file convention).
-  logic [SIG_W-1:0]           s5b_raw_sig_n;
-  logic                       s5b_guard_n, s5b_round_n, s5b_sticky_n;
-  logic                       s5b_round_up_n;
-  logic                       s5b_carry_n;
-  logic [SUM_W-1:0]           s5b_pre_mag_n;
-  int unsigned                s5b_normal_shift_local;
-  int unsigned                s5b_lzc_i;
-
-  // ---------------------------------------------------------------------------
-  // Stage 1 multiply (combinational, output of S2b operand registers)
   // ---------------------------------------------------------------------------
   always_comb begin
     s2_product_comb = s2b_a_sig * s2b_b_sig;

--- a/rtl/stage5/kronos_dcache.sv
+++ b/rtl/stage5/kronos_dcache.sv
@@ -72,19 +72,7 @@ module kronos_dcache
   assign tag_in   = addr_i[PHYS_ADDR_W-1 : SET_IDX_W + OFFSET_W];
   assign beat_idx = addr_i[OFFSET_W-1 : 3];
 
-  // ---- Hit logic ------------------------------------------------------------
-  logic [NUM_WAYS-1:0] hit_way_oh;
-  logic                hit;
-  always_comb begin
-    for (int w = 0; w < NUM_WAYS; w++) begin
-      hit_way_oh[w] = req_i & valid_q[set_idx][w] & (tag_q[set_idx][w] == tag_in);
-    end
-    hit = |hit_way_oh;
-  end
-
-  // ---- State machine --------------------------------------------------------
-  // Subsequent tasks will add WB_AW, WB_W, AMO_RMW states.  For Task 2 we
-  // only have IDLE / REFILL_AR / REFILL_R.
+  // ---- State machine encoding ----------------------------------------------
   typedef enum logic [3:0] {
     DC_IDLE       = 4'b0000,
     DC_REFILL_AR  = 4'b0001,
@@ -97,14 +85,86 @@ module kronos_dcache
     DC_FLUSH_W    = 4'b1000
   } dcache_state_e;
 
+  // ---- State registers ------------------------------------------------------
   dcache_state_e state_q;
+  logic          miss_pulse_q;
 
-  logic miss_pulse_q;
-  logic miss_event;
-  assign miss_event = req_i & ~hit & (state_q == DC_IDLE);
+  // Miss / refill bookkeeping
+  logic [SET_IDX_W-1:0]            miss_set_q;
+  logic [TAG_W-1:0]                miss_tag_q;
+  logic [BEAT_IDX_W-1:0]           miss_beat_q;
+  logic [$clog2(NUM_WAYS)-1:0]     victim_q;
+  logic [3:0]                      beat_cnt_q;
+  logic                            bypass_valid_q;
+  logic [63:0]                     bypass_data_q;
+  logic                            miss_was_store_q;
+  logic [63:0]                     miss_store_data_q;
+  logic [7:0]                      miss_store_strobes_q;
+  logic [2:0]                      miss_store_off_q;
+  logic                            store_done_q;
+  logic [3:0]                      wb_beat_cnt_q;
+  logic [TAG_W-1:0]                evict_tag_q;
 
+  // AMO state registers
+  logic        amo_pending_q;
+  logic [4:0]  amo_op_q;
+  logic [63:0] amo_src_q;
+  logic [63:0] amo_old_val_q;
+  logic        amo_done_q;
+  logic        amo_is_word_q;     // size_i == 3'd2
+  logic [2:0]  amo_addr_off_q;    // addr_i[2:0] captured at AMO issue
+
+  // LR/SC reservation registers
+  logic [PHYS_ADDR_W-1:0] rsrv_addr_q;
+  logic                   rsrv_valid_q;
+  logic                   sc_success_q;
+
+  // Flush state (FENCE.I full writeback + invalidate walk)
+  logic [SET_IDX_W-1:0]              flush_set_q;
+  logic [$clog2(NUM_WAYS)-1:0]       flush_way_q;
+  logic                              flush_done_q;
+
+  // ---- Combinational signals ------------------------------------------------
+  // Hit logic
+  logic [NUM_WAYS-1:0]         hit_way_oh;
+  logic                        hit;
+  logic                        miss_event;
   // Tree-PLRU victim selection (same as I$).
   logic [$clog2(NUM_WAYS)-1:0] victim_pick;
+  // Per-cycle store strobes / aligned store data (hoisted so byte loops can
+  // index them — Vivado rejects bit-selects on function-call returns).
+  logic [ 7:0]                 store_strobes_in;
+  logic [63:0]                 store_data_aligned_in;
+  // dirty_pending_o helper: 1 if any (set, way) has valid && dirty.
+  logic                        dirty_pending;
+  // AMO intermediate signals for DC_AMO_RMW
+  logic [63:0]                 amo_cur_beat;
+  logic [63:0]                 amo_result;
+  logic [7:0]                  amo_be;
+  logic [63:0]                 amo_aligned;
+  // hit_way_idx: binary encoding of hit way for AMO/SC use
+  logic [$clog2(NUM_WAYS)-1:0] hit_way_idx;
+  // hit_beat: full 64-bit beat from the hit way (consumed by the AMO RMW
+  // capture inside the always_ff block below). Declared here so synthesis
+  // sees it before its first use (Synth 8-6901).
+  logic [63:0]                 hit_beat;
+  // Load data path
+  logic [63:0]                 beat_for_load;
+  logic [63:0]                 load_data_full;
+  // Lint sink
+  logic                        _unused;
+
+  // ---- Hit logic ------------------------------------------------------------
+  always_comb begin
+    for (int w = 0; w < NUM_WAYS; w++) begin
+      hit_way_oh[w] = req_i & valid_q[set_idx][w] & (tag_q[set_idx][w] == tag_in);
+    end
+    hit = |hit_way_oh;
+  end
+
+  assign miss_event = req_i & ~hit & (state_q == DC_IDLE);
+
+  // ---- Tree-PLRU victim selection -------------------------------------------
   always_comb begin
     unique case (plru_q[set_idx][2])
       1'b0: victim_pick = plru_q[set_idx][1] ? 2'd1 : 2'd0;
@@ -185,48 +245,11 @@ module kronos_dcache
   // Vivado synthesis (IEEE 1800 grammar) rejects bit-selects on function-call
   // returns — e.g. `store_strobes(...)[b]`. Hoist the per-cycle results into
   // combinational nets so the per-byte loops can index into them directly.
-  logic [ 7:0] store_strobes_in;
-  logic [63:0] store_data_aligned_in;
   assign store_strobes_in      = store_strobes(size_i, addr_i[2:0]);
   assign store_data_aligned_in = store_data_aligned(size_i, addr_i[2:0], wdata_i);
 
-  logic [SET_IDX_W-1:0]            miss_set_q;
-  logic [TAG_W-1:0]                miss_tag_q;
-  logic [BEAT_IDX_W-1:0]           miss_beat_q;
-  logic [$clog2(NUM_WAYS)-1:0]     victim_q;
-  logic [3:0]                      beat_cnt_q;
-  logic                            bypass_valid_q;
-  logic [63:0]                     bypass_data_q;
-  logic                            miss_was_store_q;
-  logic [63:0]                     miss_store_data_q;
-  logic [7:0]                      miss_store_strobes_q;
-  logic [2:0]                      miss_store_off_q;
-  logic                            store_done_q;
-  logic [3:0]                      wb_beat_cnt_q;
-  logic [TAG_W-1:0]                evict_tag_q;
-
-  // AMO state registers
-  logic        amo_pending_q;
-  logic [4:0]  amo_op_q;
-  logic [63:0] amo_src_q;
-  logic [63:0] amo_old_val_q;
-  logic        amo_done_q;
-  logic        amo_is_word_q;     // size_i == 3'd2
-  logic [2:0]  amo_addr_off_q;    // addr_i[2:0] captured at AMO issue
-
-  // LR/SC reservation registers
-  logic [PHYS_ADDR_W-1:0] rsrv_addr_q;
-  logic                   rsrv_valid_q;
-  logic                   sc_success_q;
-
-  // Flush state (FENCE.I full writeback + invalidate walk)
-  logic [SET_IDX_W-1:0]              flush_set_q;
-  logic [$clog2(NUM_WAYS)-1:0]       flush_way_q;
-  logic                              flush_done_q;
-
   // dirty_pending_o: 1 if any (set, way) has valid && dirty.  Used by the
   // top to short-circuit FENCE.I when no writeback is required.
-  logic dirty_pending;
   always_comb begin
     dirty_pending = 1'b0;
     for (int s = 0; s < NUM_SETS; s++)
@@ -236,14 +259,7 @@ module kronos_dcache
   assign dirty_pending_o = dirty_pending;
   assign flush_done_o    = flush_done_q;
 
-  // AMO intermediate signals for DC_AMO_RMW
-  logic [63:0] amo_cur_beat;
-  logic [63:0] amo_result;
-  logic [7:0]  amo_be;
-  logic [63:0] amo_aligned;
-
   // hit_way_idx: binary encoding of hit way for AMO/SC use
-  logic [$clog2(NUM_WAYS)-1:0] hit_way_idx;
   always_comb begin
     hit_way_idx = {$clog2(NUM_WAYS){1'b0}};
     for (int w = 0; w < NUM_WAYS; w++) begin
@@ -252,9 +268,7 @@ module kronos_dcache
   end
 
   // hit_beat: full 64-bit beat from the hit way (consumed by the AMO RMW
-  // capture inside the always_ff block below). Declared here so synthesis
-  // sees it before its first use (Synth 8-6901).
-  logic [63:0] hit_beat;
+  // capture inside the always_ff block below).
   always_comb begin
     hit_beat = 64'h0;
     for (int w = 0; w < NUM_WAYS; w++) begin
@@ -663,11 +677,9 @@ module kronos_dcache
   // hit_beat is built earlier (top of the file) so the AMO RMW capture path
   // can read it; here we just pick between the cached value and the
   // critical-word-first bypass register on a refill.
-  logic [63:0] beat_for_load;
   assign beat_for_load = bypass_valid_q ? bypass_data_q : hit_beat;
 
   // ---- Size/sign extension on loads ----------------------------------------
-  logic [63:0] load_data_full;
   always_comb begin
     load_data_full = beat_for_load;
     unique case (size_i)
@@ -708,7 +720,6 @@ module kronos_dcache
   assign stall_o      = (state_q != DC_IDLE);
   assign miss_pulse_o = miss_pulse_q;
 
-  logic _unused;
   assign _unused = ^{miss_store_off_q};
 
 endmodule

--- a/rtl/stage5/kronos_top.sv
+++ b/rtl/stage5/kronos_top.sv
@@ -326,6 +326,26 @@ module kronos_top
   // -------------------------------------------------------------------------
   logic [31:0] pc_d                              /* verilator public_flat_rd */;
 
+  // -------------------------------------------------------------------------
+  // Boot-vector load latch (pc_q reset semantics)
+  // -------------------------------------------------------------------------
+  logic boot_loaded_q;
+
+  // -------------------------------------------------------------------------
+  // FENCE.I trap suppression while D-cache is dirty
+  // -------------------------------------------------------------------------
+  logic fence_i_dirty_block;
+
+  // -------------------------------------------------------------------------
+  // Retire/event-bus advance gate
+  // -------------------------------------------------------------------------
+  logic retire_advance;
+
+  // -------------------------------------------------------------------------
+  // Lint-tie aggregator for unused stage-6a IRQ / predecode signals
+  // -------------------------------------------------------------------------
+  logic _unused_irq;
+
   // =========================================================================
   // Submodule instantiations
   // =========================================================================
@@ -949,7 +969,6 @@ module kronos_top
   //   - On the first post-reset cycle, sync-load `boot_addr_i` so a non-zero
   //     boot vector still works. boot_addr_i is captured before the load to
   //     avoid synth seeing it as part of the async reset value.
-  logic boot_loaded_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       pc_q          <= 32'b0;
@@ -1218,7 +1237,6 @@ module kronos_top
   // flush completes.  Once dcache_flush_done pulses (or there were no dirty
   // lines), the redirect resumes and the trap handler advances MEPC past
   // the FENCE.I — by which time AXI memory has the up-to-date bytes.
-  logic fence_i_dirty_block;
   assign fence_i_dirty_block = id_ex_q.valid &
                                 (id_ex_q.instr[6:0]   == 7'b0001111) &
                                 (id_ex_q.instr[14:12] == 3'b001) &
@@ -1380,7 +1398,6 @@ module kronos_top
   // should filter by csr_funct3 if they need to distinguish read-only CSR
   // accesses from read-modify-write ones.
   // =========================================================================
-  logic retire_advance;
   assign retire_advance = mem_wb_q.valid & ~combined_stall;
 
   // ---- Performance-counter event bus ----------------------------------------
@@ -1472,7 +1489,6 @@ module kronos_top
   // Stage-6a IRQ ports declared above are not consumed by the stage-5 CSR
   // file; tie them into a dummy XOR to keep the linter quiet.  Stage 5 also
   // does not use the predecode cross-page-fault output (no translation).
-  logic _unused_irq;
   assign _unused_irq = ^{irq_msi_i, irq_mei_i, irq_ssi_i, irq_sti_i,
                          irq_sei_i, cross_page_fault, align_stall,
                          align_need_upper, align_needs_fetch,

--- a/tb/gls/axi_mem_model.sv
+++ b/tb/gls/axi_mem_model.sv
@@ -74,6 +74,45 @@ module axi_mem_model #(
 
   logic [31:0] mem [0:MEM_WORDS-1];
 
+  // ── Instruction read state ───────────────────────────────────────────
+  logic            i_pending_q;
+  logic [63:0]     i_base_q;
+  logic [ 7:0]     i_len_q;
+  logic [ 1:0]     i_burst_q;
+  logic [ 7:0]     i_beat_q;
+  logic [31:0]     i_lat_q;
+
+  logic [63:0]     i_addr;
+  logic [WI_W-1:0] i_word_lo;
+  logic [WI_W-1:0] i_word_hi;
+
+  // ── Data read state ──────────────────────────────────────────────────
+  logic            d_pending_q;
+  logic [63:0]     d_base_q;
+  logic [ 7:0]     d_len_q;
+  logic [ 1:0]     d_burst_q;
+  logic [ 7:0]     d_beat_q;
+  logic [31:0]     d_lat_q;
+
+  logic [63:0]     d_addr;
+  logic [WI_W-1:0] d_word_lo;
+  logic [WI_W-1:0] d_word_hi;
+
+  // ── Data write state ─────────────────────────────────────────────────
+  logic            d_aw_done_q;
+  logic            d_b_pending_q;
+  logic [63:0]     d_w_base_q;
+  logic [ 7:0]     d_w_beat_q;
+  logic            halt_q;
+  logic [31:0]     halt_code_q;
+
+  logic [63:0]     waddr_c;
+  logic [31:0]     waddr32_c;
+  logic [WI_W-1:0] w_lo_c;
+  logic [WI_W-1:0] w_hi_c;
+  logic [31:0]     wmask_lo_c;
+  logic [31:0]     wmask_hi_c;
+
   initial begin
     foreach (mem[i]) mem[i] = 32'h0;
     if (HEX_FILE != "") $readmemh(HEX_FILE, mem);
@@ -105,17 +144,7 @@ module axi_mem_model #(
     end
   endfunction
 
-  // ── Instruction read state ───────────────────────────────────────────
-  logic            i_pending_q;
-  logic [63:0]     i_base_q;
-  logic [ 7:0]     i_len_q;
-  logic [ 1:0]     i_burst_q;
-  logic [ 7:0]     i_beat_q;
-  logic [31:0]     i_lat_q;
-
-  logic [63:0]     i_addr;
-  logic [WI_W-1:0] i_word_lo;
-  logic [WI_W-1:0] i_word_hi;
+  // ── Instruction read datapath ────────────────────────────────────────
   assign i_addr    = beat_addr(i_base_q, i_len_q, i_burst_q, i_beat_q);
   assign i_word_lo = i_addr[WI_W+1:2];
   assign i_word_hi = i_word_lo + 1;
@@ -156,17 +185,7 @@ module axi_mem_model #(
     end
   end
 
-  // ── Data read state ──────────────────────────────────────────────────
-  logic            d_pending_q;
-  logic [63:0]     d_base_q;
-  logic [ 7:0]     d_len_q;
-  logic [ 1:0]     d_burst_q;
-  logic [ 7:0]     d_beat_q;
-  logic [31:0]     d_lat_q;
-
-  logic [63:0]     d_addr;
-  logic [WI_W-1:0] d_word_lo;
-  logic [WI_W-1:0] d_word_hi;
+  // ── Data read datapath ───────────────────────────────────────────────
   assign d_addr    = beat_addr(d_base_q, d_len_q, d_burst_q, d_beat_q);
   assign d_word_lo = d_addr[WI_W+1:2];
   assign d_word_hi = d_word_lo + 1;
@@ -207,14 +226,7 @@ module axi_mem_model #(
     end
   end
 
-  // ── Data write state ─────────────────────────────────────────────────
-  logic            d_aw_done_q;
-  logic            d_b_pending_q;
-  logic [63:0]     d_w_base_q;
-  logic [ 7:0]     d_w_beat_q;
-  logic            halt_q;
-  logic [31:0]     halt_code_q;
-
+  // ── Data write datapath ──────────────────────────────────────────────
   assign data_aw_ready_o = !d_aw_done_q;
   assign data_w_ready_o  = d_aw_done_q;
   assign data_b_valid_o  = d_b_pending_q;
@@ -230,12 +242,6 @@ module axi_mem_model #(
     return {{8{strb[7]}}, {8{strb[6]}}, {8{strb[5]}}, {8{strb[4]}}};
   endfunction
 
-  logic [63:0]     waddr_c;
-  logic [31:0]     waddr32_c;
-  logic [WI_W-1:0] w_lo_c;
-  logic [WI_W-1:0] w_hi_c;
-  logic [31:0]     wmask_lo_c;
-  logic [31:0]     wmask_hi_c;
   always_comb begin
     waddr_c    = d_w_base_q + (64'(d_w_beat_q) << 3);
     waddr32_c  = waddr_c[31:0];

--- a/tb/gls/tb_gls_top.sv
+++ b/tb/gls/tb_gls_top.sv
@@ -278,6 +278,17 @@ module tb_gls_top;
   logic        halted;
   logic [31:0] halt_code;
 
+  // ── Retire ring buffer (16 deep) ──────────────────────────────────────
+  localparam int RING_DEPTH = 16;
+  logic [63:0] ring_pc    [RING_DEPTH];
+  logic [31:0] ring_instr [RING_DEPTH];
+  // Declaration-init avoids xelab's "multiple procedural drivers" error
+  // that fires when an `initial` block + an `always_ff` both write the var.
+  int          ring_wp = 0;
+
+  // ── Cycle counter ─────────────────────────────────────────────────────
+  longint cycle = 0;
+
   always_ff @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       halt_retire      <= 1'b0;
@@ -292,14 +303,7 @@ module tb_gls_top;
   assign halted    = halt_axi | halt_retire;
   assign halt_code = halt_axi ? halt_code_axi : halt_code_retire;
 
-  // ── Retire ring buffer (16 deep) ──────────────────────────────────────
-  localparam int RING_DEPTH = 16;
-  logic [63:0] ring_pc    [RING_DEPTH];
-  logic [31:0] ring_instr [RING_DEPTH];
-  // Declaration-init avoids xelab's "multiple procedural drivers" error
-  // that fires when an `initial` block + an `always_ff` both write the var.
-  int          ring_wp = 0;
-
+  // ── Retire ring buffer write ──────────────────────────────────────────
   always_ff @(posedge clk) begin
     if (rst_n && retire_valid) begin
       ring_pc   [ring_wp] <= retire_pc;
@@ -333,7 +337,6 @@ module tb_gls_top;
   end
 
   // ── Cycle counter, timeout, finish ────────────────────────────────────
-  longint cycle = 0;
   always_ff @(posedge clk) cycle <= cycle + 1;
 
   task automatic dump_ring();

--- a/tb/stage5/tb_core_fp_basic.sv
+++ b/tb/stage5/tb_core_fp_basic.sv
@@ -90,6 +90,27 @@ module tb_core_fp_basic;
   int          data_w_wi_lo;
   int          data_w_wi_hi;
 
+  // -----------------------------------------------------------------------
+  // AXI slave — data port (multi-beat read + write, dcache issues 8-beat bursts)
+  // -----------------------------------------------------------------------
+  // Read channel
+  logic        data_r_pend;
+  logic [63:0] data_ar_addr_q;
+  logic [7:0]  data_ar_len_q;
+  logic [7:0]  data_r_beat;
+  // Write channel
+  logic        data_aw_pend;
+  logic [63:0] data_aw_addr_q;
+  logic [7:0]  data_aw_len_q;
+  logic [7:0]  data_w_beat;
+  logic        data_b_pend;
+  logic [31:0] halted;
+
+  // -----------------------------------------------------------------------
+  // Test body
+  // -----------------------------------------------------------------------
+  int errors;
+
   always_comb begin
     instr_rsp          = '{default: '0};
     instr_rsp.ar_ready = ~instr_r_pend;
@@ -121,22 +142,6 @@ module tb_core_fp_basic;
       end
     end
   end
-
-  // -----------------------------------------------------------------------
-  // AXI slave — data port (multi-beat read + write, dcache issues 8-beat bursts)
-  // -----------------------------------------------------------------------
-  // Read channel
-  logic        data_r_pend;
-  logic [63:0] data_ar_addr_q;
-  logic [7:0]  data_ar_len_q;
-  logic [7:0]  data_r_beat;
-  // Write channel
-  logic        data_aw_pend;
-  logic [63:0] data_aw_addr_q;
-  logic [7:0]  data_aw_len_q;
-  logic [7:0]  data_w_beat;
-  logic        data_b_pend;
-  logic [31:0] halted;
 
   always_comb begin
     data_rsp          = '{default: '0};
@@ -235,8 +240,6 @@ module tb_core_fp_basic;
   // -----------------------------------------------------------------------
   // Test body
   // -----------------------------------------------------------------------
-  int errors;
-
   initial begin
     // Fill with NOP
     for (int i = 0; i < 64; i++) mem[i] = 32'h0000_0013; // ADDI x0, x0, 0

--- a/tb/stage5/tb_core_fp_forwarding.sv
+++ b/tb/stage5/tb_core_fp_forwarding.sv
@@ -94,6 +94,25 @@ module tb_core_fp_forwarding;
   int          data_w_wi_lo;
   int          data_w_wi_hi;
 
+  // -----------------------------------------------------------------------
+  // AXI slave — data port (multi-beat read + write, dcache issues 8-beat bursts)
+  // -----------------------------------------------------------------------
+  // Read channel
+  logic        data_r_pend;
+  logic [63:0] data_ar_addr_q;
+  logic [7:0]  data_ar_len_q;
+  logic [7:0]  data_r_beat;
+  // Write channel
+  logic        data_aw_pend;
+  logic [63:0] data_aw_addr_q;
+  logic [7:0]  data_aw_len_q;
+  logic [7:0]  data_w_beat;
+  logic        data_b_pend;
+  logic [31:0] halted;
+
+  // Test body
+  int errors;
+
   always_comb begin
     instr_rsp          = '{default: '0};
     instr_rsp.ar_ready = ~instr_r_pend;
@@ -125,22 +144,6 @@ module tb_core_fp_forwarding;
       end
     end
   end
-
-  // -----------------------------------------------------------------------
-  // AXI slave — data port (multi-beat read + write, dcache issues 8-beat bursts)
-  // -----------------------------------------------------------------------
-  // Read channel
-  logic        data_r_pend;
-  logic [63:0] data_ar_addr_q;
-  logic [7:0]  data_ar_len_q;
-  logic [7:0]  data_r_beat;
-  // Write channel
-  logic        data_aw_pend;
-  logic [63:0] data_aw_addr_q;
-  logic [7:0]  data_aw_len_q;
-  logic [7:0]  data_w_beat;
-  logic        data_b_pend;
-  logic [31:0] halted;
 
   always_comb begin
     data_rsp          = '{default: '0};
@@ -236,8 +239,6 @@ module tb_core_fp_forwarding;
   // -----------------------------------------------------------------------
   // Test body
   // -----------------------------------------------------------------------
-  int errors;
-
   initial begin
     for (int i = 0; i < 64; i++) mem[i] = 32'h0000_0013; // NOP
 

--- a/tb/stage5/tb_crv_cov.sv
+++ b/tb/stage5/tb_crv_cov.sv
@@ -170,6 +170,146 @@ module tb_crv_cov;
     end
   endfunction
 
+  // -------------------------------------------------------------------------
+  // AXI data port — declarations (driven below, after instr-port always blocks)
+  // -------------------------------------------------------------------------
+  // Read channel
+  logic        data_r_pend;
+  logic [63:0] data_ar_addr_q;
+  logic [ 7:0] data_ar_len_q;
+  logic [ 1:0] data_ar_burst_q;
+  logic [ 7:0] data_r_beat;
+  logic [63:0] data_r_data_q;
+  // TB beat-tracking helpers (promoted from `automatic` block-locals; see R2).
+  logic [ 7:0] data_nb;
+  logic [63:0] data_na;
+  logic [63:0] data_waddr;
+  int          data_wi_lo;
+  int          data_wi_hi;
+  // Mem-coverage helpers (promoted from `automatic` block-locals; see R2).
+  logic [1:0]  cov_msize;
+  logic [2:0]  cov_maddr3;
+  int          cov_align_bucket;
+  // Write channel
+  logic        data_aw_pend;
+  logic [63:0] data_aw_addr_q;
+  logic [ 7:0] data_aw_len_q;
+  logic [ 7:0] data_w_beat;
+  logic        data_b_pend;
+  logic [31:0] halted;
+  int          irq_countdown;  // cycles remaining for irq_timer assertion
+
+  // -------------------------------------------------------------------------
+  // Functional coverage bit arrays (driven by always_ff blocks below)
+  // -------------------------------------------------------------------------
+  // cg_instr_class (21 bins) — instruction opcode
+  bit cov_op_lui;
+  bit cov_op_auipc;
+  bit cov_op_jal;
+  bit cov_op_jalr;
+  bit cov_op_branch;
+  bit cov_op_load;
+  bit cov_op_store;
+  bit cov_op_imm;
+  bit cov_op_reg;
+  bit cov_op_imm32;
+  bit cov_op_reg32;
+  bit cov_op_fence;
+  bit cov_op_system;
+  bit cov_op_amo;
+  bit cov_op_load_fp;
+  bit cov_op_store_fp;
+  bit cov_op_fmadd;
+  bit cov_op_fmsub;
+  bit cov_op_fnmsub;
+  bit cov_op_fnmadd;
+  bit cov_op_fp;
+
+  // cg_alu_sign (16 bins) — ALU op × result sign cross
+  // 8 funct3 bins × 2 sign bins = 16
+  bit cov_alu_add_sub_pos;   bit cov_alu_add_sub_neg;
+  bit cov_alu_sll_pos;       bit cov_alu_sll_neg;
+  bit cov_alu_slt_pos;       bit cov_alu_slt_neg;
+  bit cov_alu_sltu_pos;      bit cov_alu_sltu_neg;
+  bit cov_alu_xor_pos;       bit cov_alu_xor_neg;
+  bit cov_alu_srl_sra_pos;   bit cov_alu_srl_sra_neg;
+  bit cov_alu_or_pos;        bit cov_alu_or_neg;
+  bit cov_alu_and_pos;       bit cov_alu_and_neg;
+
+  // cg_branch (6 bins) — branch type
+  bit cov_br_beq;
+  bit cov_br_bne;
+  bit cov_br_blt;
+  bit cov_br_bge;
+  bit cov_br_bltu;
+  bit cov_br_bgeu;
+
+  // cg_mem (16 bins) — size × alignment cross
+  // 4 size bins × 4 align bins = 16
+  bit cov_mem_byte_aligned;    bit cov_mem_byte_off4;
+  bit cov_mem_byte_off2;       bit cov_mem_byte_odd;
+  bit cov_mem_half_aligned;    bit cov_mem_half_off4;
+  bit cov_mem_half_off2;       bit cov_mem_half_odd;
+  bit cov_mem_word_aligned;    bit cov_mem_word_off4;
+  bit cov_mem_word_off2;       bit cov_mem_word_odd;
+  bit cov_mem_double_aligned;  bit cov_mem_double_off4;
+  bit cov_mem_double_off2;     bit cov_mem_double_odd;
+
+  // cg_amo (11 bins) — AMO type
+  bit cov_amo_lr;
+  bit cov_amo_sc;
+  bit cov_amo_swap;
+  bit cov_amo_add;
+  bit cov_amo_xor;
+  bit cov_amo_and;
+  bit cov_amo_or;
+  bit cov_amo_min;
+  bit cov_amo_max;
+  bit cov_amo_minu;
+  bit cov_amo_maxu;
+
+  // cg_fp_rm (6 bins) — FP rounding mode
+  bit cov_rm_rne;
+  bit cov_rm_rtz;
+  bit cov_rm_rdn;
+  bit cov_rm_rup;
+  bit cov_rm_rmm;
+  bit cov_rm_dyn;
+
+  // cg_trap (6 bins) — trap mcause via CSR write to mcause (0x342)
+  bit cov_trap_illegal;
+  bit cov_trap_ecall_m;
+  bit cov_trap_ebreak;
+  bit cov_trap_ld_misalign;
+  bit cov_trap_st_misalign;
+  bit cov_trap_irq_timer;
+
+  // cg_icache (2 bins) — Stage 5e I-cache miss path exercise
+  // Tracks whether the I$ miss event (miss_pulse_o from kronos_icache,
+  // mapped to event_bus[16] via icache_miss_pulse in kronos_top) was ever
+  // asserted and whether at least one hit cycle was observed.
+  bit cov_icache_miss_seen;    // at least one I$ miss occurred
+  bit cov_icache_no_miss_seen; // at least one cycle with no miss (normal fetch)
+
+  // cg_dcache (2 bins) — Stage 5f D-cache miss path exercise (Stage 5f)
+  // Tracks whether the D$ miss event (miss_pulse_o from kronos_dcache,
+  // mapped to event_bus[17] via dcache_miss_pulse in kronos_top) was ever
+  // asserted and whether at least one hit cycle was observed.
+  bit cov_dcache_miss_seen;    // at least one D$ miss occurred
+  bit cov_dcache_no_miss_seen; // at least one D$ hit (no miss)
+
+  // Sampling logic — combinational helpers
+  logic is_alu_op;
+  logic is_branch;
+  logic is_mem_op;
+  logic is_amo;
+  logic is_fp_op;
+
+  // Test driver state (used in the initial block)
+  int          cycle_count;
+  string       vmem_path;
+  string       covout_path;
+
   always_comb begin
     instr_rsp          = '0;
     instr_rsp.ar_ready = !instr_r_pend;
@@ -221,32 +361,6 @@ module tb_crv_cov;
   // AXI data port — multi-beat read + write (dcache issues 8-beat WRAP/INCR)
   // Halt is detected via retire_mem_wen (store to 0x4000_0000 sentinel).
   // -------------------------------------------------------------------------
-  // Read channel
-  logic        data_r_pend;
-  logic [63:0] data_ar_addr_q;
-  logic [ 7:0] data_ar_len_q;
-  logic [ 1:0] data_ar_burst_q;
-  logic [ 7:0] data_r_beat;
-  logic [63:0] data_r_data_q;
-  // TB beat-tracking helpers (promoted from `automatic` block-locals; see R2).
-  logic [ 7:0] data_nb;
-  logic [63:0] data_na;
-  logic [63:0] data_waddr;
-  int          data_wi_lo;
-  int          data_wi_hi;
-  // Mem-coverage helpers (promoted from `automatic` block-locals; see R2).
-  logic [1:0]  cov_msize;
-  logic [2:0]  cov_maddr3;
-  int          cov_align_bucket;
-  // Write channel
-  logic        data_aw_pend;
-  logic [63:0] data_aw_addr_q;
-  logic [ 7:0] data_aw_len_q;
-  logic [ 7:0] data_w_beat;
-  logic        data_b_pend;
-  logic [31:0] halted;
-  int          irq_countdown;  // cycles remaining for irq_timer assertion
-
   always_comb begin
     data_rsp          = '0;
     data_rsp.ar_ready = ~data_r_pend;
@@ -364,129 +478,6 @@ module tb_crv_cov;
   // =========================================================================
   // Functional coverage — manual bit arrays (Verilator 5.046 COVERIGN)
   // =========================================================================
-
-  // -------------------------------------------------------------------------
-  // cg_instr_class (21 bins) — instruction opcode
-  // -------------------------------------------------------------------------
-  bit cov_op_lui;
-  bit cov_op_auipc;
-  bit cov_op_jal;
-  bit cov_op_jalr;
-  bit cov_op_branch;
-  bit cov_op_load;
-  bit cov_op_store;
-  bit cov_op_imm;
-  bit cov_op_reg;
-  bit cov_op_imm32;
-  bit cov_op_reg32;
-  bit cov_op_fence;
-  bit cov_op_system;
-  bit cov_op_amo;
-  bit cov_op_load_fp;
-  bit cov_op_store_fp;
-  bit cov_op_fmadd;
-  bit cov_op_fmsub;
-  bit cov_op_fnmsub;
-  bit cov_op_fnmadd;
-  bit cov_op_fp;
-
-  // -------------------------------------------------------------------------
-  // cg_alu_sign (16 bins) — ALU op × result sign cross
-  // -------------------------------------------------------------------------
-  // 8 funct3 bins × 2 sign bins = 16
-  bit cov_alu_add_sub_pos;   bit cov_alu_add_sub_neg;
-  bit cov_alu_sll_pos;       bit cov_alu_sll_neg;
-  bit cov_alu_slt_pos;       bit cov_alu_slt_neg;
-  bit cov_alu_sltu_pos;      bit cov_alu_sltu_neg;
-  bit cov_alu_xor_pos;       bit cov_alu_xor_neg;
-  bit cov_alu_srl_sra_pos;   bit cov_alu_srl_sra_neg;
-  bit cov_alu_or_pos;        bit cov_alu_or_neg;
-  bit cov_alu_and_pos;       bit cov_alu_and_neg;
-
-  // -------------------------------------------------------------------------
-  // cg_branch (6 bins) — branch type
-  // -------------------------------------------------------------------------
-  bit cov_br_beq;
-  bit cov_br_bne;
-  bit cov_br_blt;
-  bit cov_br_bge;
-  bit cov_br_bltu;
-  bit cov_br_bgeu;
-
-  // -------------------------------------------------------------------------
-  // cg_mem (16 bins) — size × alignment cross
-  // -------------------------------------------------------------------------
-  // 4 size bins × 4 align bins = 16
-  bit cov_mem_byte_aligned;    bit cov_mem_byte_off4;
-  bit cov_mem_byte_off2;       bit cov_mem_byte_odd;
-  bit cov_mem_half_aligned;    bit cov_mem_half_off4;
-  bit cov_mem_half_off2;       bit cov_mem_half_odd;
-  bit cov_mem_word_aligned;    bit cov_mem_word_off4;
-  bit cov_mem_word_off2;       bit cov_mem_word_odd;
-  bit cov_mem_double_aligned;  bit cov_mem_double_off4;
-  bit cov_mem_double_off2;     bit cov_mem_double_odd;
-
-  // -------------------------------------------------------------------------
-  // cg_amo (11 bins) — AMO type
-  // -------------------------------------------------------------------------
-  bit cov_amo_lr;
-  bit cov_amo_sc;
-  bit cov_amo_swap;
-  bit cov_amo_add;
-  bit cov_amo_xor;
-  bit cov_amo_and;
-  bit cov_amo_or;
-  bit cov_amo_min;
-  bit cov_amo_max;
-  bit cov_amo_minu;
-  bit cov_amo_maxu;
-
-  // -------------------------------------------------------------------------
-  // cg_fp_rm (6 bins) — FP rounding mode
-  // -------------------------------------------------------------------------
-  bit cov_rm_rne;
-  bit cov_rm_rtz;
-  bit cov_rm_rdn;
-  bit cov_rm_rup;
-  bit cov_rm_rmm;
-  bit cov_rm_dyn;
-
-  // -------------------------------------------------------------------------
-  // cg_trap (6 bins) — trap mcause via CSR write to mcause (0x342)
-  // -------------------------------------------------------------------------
-  bit cov_trap_illegal;
-  bit cov_trap_ecall_m;
-  bit cov_trap_ebreak;
-  bit cov_trap_ld_misalign;
-  bit cov_trap_st_misalign;
-  bit cov_trap_irq_timer;
-
-  // -------------------------------------------------------------------------
-  // cg_icache (2 bins) — Stage 5e I-cache miss path exercise
-  // Tracks whether the I$ miss event (miss_pulse_o from kronos_icache,
-  // mapped to event_bus[16] via icache_miss_pulse in kronos_top) was ever
-  // asserted and whether at least one hit cycle was observed.
-  // -------------------------------------------------------------------------
-  bit cov_icache_miss_seen;    // at least one I$ miss occurred
-  bit cov_icache_no_miss_seen; // at least one cycle with no miss (normal fetch)
-
-  // -------------------------------------------------------------------------
-  // cg_dcache (2 bins) — Stage 5f D-cache miss path exercise (Stage 5f)
-  // Tracks whether the D$ miss event (miss_pulse_o from kronos_dcache,
-  // mapped to event_bus[17] via dcache_miss_pulse in kronos_top) was ever
-  // asserted and whether at least one hit cycle was observed.
-  // -------------------------------------------------------------------------
-  bit cov_dcache_miss_seen;    // at least one D$ miss occurred
-  bit cov_dcache_no_miss_seen; // at least one D$ hit (no miss)
-
-  // -------------------------------------------------------------------------
-  // Sampling logic — combinational helpers
-  // -------------------------------------------------------------------------
-  logic is_alu_op;
-  logic is_branch;
-  logic is_mem_op;
-  logic is_amo;
-  logic is_fp_op;
 
   assign is_alu_op = retire_valid &&
                      (opcode == 7'b0110011 || opcode == 7'b0010011 ||
@@ -804,10 +795,6 @@ module tb_crv_cov;
   // =========================================================================
   // Test driver
   // =========================================================================
-  int          cycle_count;
-  string       vmem_path;
-  string       covout_path;
-
   initial begin
     // Required: +vmem=<path>
     if (!$value$plusargs("vmem=%s", vmem_path)) begin

--- a/tb/stage5/tb_icache.sv
+++ b/tb/stage5/tb_icache.sv
@@ -62,6 +62,10 @@ module tb_icache;
   logic [14:0] line_base;    // 64-byte line base in 32-bit word units
   logic [15:0] word_lo_idx;
   logic [15:0] word_hi_idx;
+
+  // Tree-PLRU stimulus addresses (used inside an unlabeled begin block below).
+  bit [63:0] plru_addr0;
+  bit [63:0] plru_addr1;
   assign wrap_off64  = burst_addr_q[5:3] + burst_beat_q[2:0];
   assign line_base   = burst_addr_q[17:6] * 16;  // 64 bytes / 4 = 16 words per line
   assign word_lo_idx = {1'b0, line_base} + {12'b0, wrap_off64, 1'b0};
@@ -145,8 +149,6 @@ module tb_icache;
     // away from recently-used way 0).  Re-accessing addr0 must be a hit.
     // With hardcoded way-0 victim, addr1 would overwrite addr0 → re-access miss.
     begin
-      bit [63:0] plru_addr0;
-      bit [63:0] plru_addr1;
       plru_addr0 = 64'h1_0000;   // tag 4, set 0
       plru_addr1 = 64'h2_0000;   // tag 8, set 0
 

--- a/tb/stage6/tb_alu_s6.sv
+++ b/tb/stage6/tb_alu_s6.sv
@@ -12,6 +12,11 @@ module tb_alu_s6;
   alu_op_e     op;
   logic        word_op;
 
+  // Random-vector phase locals (hoisted to module scope; no `automatic`).
+  alu_op_e     rop;
+  logic [63:0] ra, rb;
+  logic        rw;
+
   kronos_alu dut (
     .op_i        (op),
     .a_i         (a),
@@ -173,11 +178,11 @@ module tb_alu_s6;
     // Random vectors: 1k iterations per op, cross-check `result_o`
     // -------------------------------------------------------------------
     for (int op_idx = 0; op_idx < 11; op_idx++) begin
-      automatic alu_op_e rop = alu_op_e'(op_idx);
+      rop = alu_op_e'(op_idx);
       for (int it = 0; it < 1000; it++) begin
-        automatic logic [63:0] ra = {$urandom(), $urandom()};
-        automatic logic [63:0] rb = {$urandom(), $urandom()};
-        automatic logic        rw = $urandom_range(0, 1) != 0;
+        ra = {$urandom(), $urandom()};
+        rb = {$urandom(), $urandom()};
+        rw = $urandom_range(0, 1) != 0;
         // SLT/SLTU have no W variant — force word_op=0 for them
         if (rop == ALU_SLT || rop == ALU_SLTU) rw = 1'b0;
         a = ra; b = rb; op = rop; word_op = rw; #1;


### PR DESCRIPTION
## Summary
- Hoists every in-process `logic`/`int`/`bit`/struct/enum declaration flagged by `scripts/check_rtl_rules.py` (R1/R3) into a single module-scope decl block at the top of each module, ordered per CLAUDE.md "Signal Declaration Order" (localparams → imported types → state registers → combinational signals → submodule interface signals).
- Touches `rtl/common/fpu/kronos_fpu_fma.sv`, `rtl/stage5/kronos_dcache.sv`, `rtl/stage5/kronos_top.sv`, and seven testbenches (`tb_crv_cov`, `axi_mem_model`, `tb_core_fp_basic`, `tb_core_fp_forwarding`, `tb_alu_s6`, `tb_gls_top`, `tb_icache`).
- Pure refactor — no logic, behavioural, or control-flow changes.
- Full-tree `python3 scripts/check_rtl_rules.py` now reports **0 violations** (down from 381).
- Drops the now-obsolete "Known full-scan offenders" paragraph from `CLAUDE.md`.

Closes item 4 of #90.

## Test plan
- [x] Full-tree R1 scan: `python3 scripts/check_rtl_rules.py` → 0 violations
- [x] `make ci-local` PASS (lint-rtl-all, sim-cosim-smoke, sim-crv-smoke-s6, sim-dcache-s6-stress, sim-s6, ACT4-s6 305/305)
- [x] FMA unit TB: 8052/8052 checks PASS
- [x] All seven stages of `make lint-rtl-s*` clean

## Per-file violation deltas
| File | Before | After |
|---|--:|--:|
| `rtl/common/fpu/kronos_fpu_fma.sv` | 187 | 0 |
| `tb/stage5/tb_crv_cov.sv` | 97 | 0 |
| `rtl/stage5/kronos_dcache.sv` | 42 | 0 |
| `tb/gls/axi_mem_model.sv` | 21 | 0 |
| `tb/stage5/tb_core_fp_basic.sv` | 11 | 0 |
| `tb/stage5/tb_core_fp_forwarding.sv` | 11 | 0 |
| `rtl/stage5/kronos_top.sv` | 4 | 0 |
| `tb/stage6/tb_alu_s6.sv` | 3 | 0 |
| `tb/gls/tb_gls_top.sv` | 3 | 0 |
| `tb/stage5/tb_icache.sv` | 2 | 0 |
| **Total** | **381** | **0** |