### PR TITLE
test(sim): gate ungated sim-* targets in CI matrix groups

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -378,7 +378,7 @@ sim-crv-assists: build-s5 sim-crv-cov-build
 	 done
 	@echo "[crv-assists] done"
 
-sim-group-crv-smoke: sim-crv-coverage sim-crv-assists
+sim-group-crv-smoke: sim-crv-coverage sim-crv-assists sim-crv-smoke
 
 .DEFAULT_GOAL := help
 
@@ -795,7 +795,7 @@ SIM_GROUP_S5_INT  := sim-alu-s5 sim-muldiv-s5 sim-decode-s5 sim-csr-perf-s5 sim-
                      sim-icache
 
 SIM_GROUP_S6_INT  := sim-alu-s6 sim-muldiv-s6 sim-decode-s6 sim-priv-csr sim-pmp sim-tlb sim-ptw \
-                     sim-kronos-ram
+                     sim-kronos-ram sim-dcache-pma-s6 sim-fetch-buffer sim-cosim-putdec
 
 $(OBJ_DIR):
 	mkdir -p $@
@@ -1401,7 +1401,10 @@ sim-arch-test-s6-priv: gen-arch-tests-s6-priv
 	    work/kronos-rv64imafdc-priv/elfs/
 
 # ── Stage 6 unit-TB stubs (T16 fills these in with real TBs) ───────────────
-sim-muldiv-s6 sim-decode-s6 sim-csr-perf-s6 sim-trigger-s6:
+# sim-decode-s6 is no longer a stub — it points at the real 104k-check
+# tb_decode_s6 testbench below.  The remaining three stay as TODO
+# placeholders so SIM_GROUP_S6_INT keeps a stable list.
+sim-muldiv-s6 sim-csr-perf-s6 sim-trigger-s6:
 	@echo "(stub) $@"
 
 # ── Stage 6 ALU unit TB ───────────────────────────────────────────────────
@@ -1426,7 +1429,7 @@ TB_DECODE_S6_FILES := $(AXI_PKG_SV) \
                       $(RTL_DIR)/stage6/kronos_decode.sv \
                       $(TB_DIR)/stage6/kronos_decode_legacy.sv \
                       $(TB_DIR)/stage6/tb_decode_s6.sv
-sim-decode-s6-tb:
+sim-decode-s6:
 	$(VERILATOR) $(WAIVER) --binary -Wall --Wno-UNUSED --Wno-TIMESCALEMOD --Wno-WIDTHEXPAND \
 	  --Wno-VARHIDDEN \
 	  --top-module tb_decode_s6 $(TB_DECODE_S6_FILES) \


### PR DESCRIPTION
## Summary
Audits recipes that exist in \`sim/Makefile\` but aren't reached by any \`sim-group-*\` matrix entry — same pattern that left \`sim-icache\` silently broken on main until #93 / PR #94. None of the five audited targets were rotted; all built and ran cleanly. Gating them so the gap can't recur:

| Target | New gate | What it tests |
|---|---|---|
| \`sim-dcache-pma-s6\` | \`SIM_GROUP_S6_INT\` | Stage 6 PMA (Physical Memory Attributes) dcache, 14 cases |
| \`sim-fetch-buffer\` | \`SIM_GROUP_S6_INT\` | Fetch buffer unit testbench (BOOM-style frontend dependency) |
| \`sim-cosim-putdec\` | \`SIM_GROUP_S6_INT\` | Cosim \`putdec_stack\` scenario |
| \`sim-crv-smoke\` | \`sim-group-crv-smoke\` | Stage 5 CRV smoke scenarios |

### Plus a separate fix
\`sim-decode-s6\` was registered in \`SIM_GROUP_S6_INT\` but resolved to the stage-6 unit-TB-stub recipe at \`sim/Makefile:1404\`, so CI's \`sim-s6-int\` matrix job was running an \`@echo "(stub) sim-decode-s6"\` non-test. Meanwhile the real 104236-check stage-6 decode testbench sat ungated under the awkward name \`sim-decode-s6-tb\`. This PR renames the real recipe to \`sim-decode-s6\` and drops the stub of the same name. The other three stubs (\`sim-muldiv-s6\`, \`sim-csr-perf-s6\`, \`sim-trigger-s6\`) stay as TODO placeholders pending real testbenches — these are tracked under the original "T16" comment.

Closes #95.

## Test plan
- [x] \`make sim-group-s6-int\` — all 11 entries green (was 7 effective + 1 stub-replaced + 3 newly added)
- [x] \`make sim-group-crv-smoke\` — 3 CRV scenarios + assists + new \`sim-crv-smoke\` dep
- [x] \`make sim-decode-s6\` — now the real test (104236 checks), was a stub
- [x] \`make ci-local\` PASS