### PR TITLE
feat(stage7c): MEM1/MEM2 split — partial (structural skeleton, residual bugs documented)

### DIFF
--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -318,6 +318,40 @@ jobs:
             --max-delta 0.05 \
             --ignore-x10
 
+  compliance-cycle-diff-s7c:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: compliance-cycle-diff-s7c
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # need ed9c144 (stage7b baseline) in history
+          submodules: recursive
+
+      - name: Install Verilator 5.046
+        uses: ./.github/actions/setup-verilator
+
+      - name: Install RISC-V GCC toolchain
+        run: |
+          sudo apt-get install -y gcc-riscv64-unknown-elf
+
+      - name: Clone PULP AXI
+        run: git clone --depth=1 https://github.com/vladdum/axi /tmp/pulp_axi
+
+      - name: Build dhrystone hex
+        run: make -C sw/perf/dhrystone all
+
+      - name: Cycle-diff vs stage7b baseline (ed9c144), budget +12%
+        env:
+          PULP_AXI_ROOT: /tmp/pulp_axi
+        run: |
+          python3 tools/cycle_diff.py \
+            --baseline-commit ed9c144 \
+            --prog sw/perf/dhrystone/build/dhrystone.hex \
+            --max-delta 0.12 \
+            --ignore-x10
+
   dcache-stress-s6:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 6h    | Cache tag arrays + FP regfile in BRAM/LUTRAM (closes #79)            | RV64IMAFDC | AXI4    | Complete    |
 | 6i    | Verification overhaul: dcache RAW regression + CRV-s6 + cosim fuzzer | RV64IMAFDC | AXI4    | Complete    |
 | 7a    | BOOM-style fault-bit propagation + EX1/EX2 split (in-order Fmax push) | RV64IMAFDC | AXI4 | Complete    |
-| 7b    | RR (register-read) stage + bypass network rebuild | RV64IMAFDC       | AXI4    | In progress |
-| 7c    | MEM1/MEM2 split (dTLB/PMP separated from dcache hit) | RV64IMAFDC    | AXI4    | Planned     |
+| 7b    | RR (register-read) stage + bypass network rebuild | RV64IMAFDC       | AXI4    | Complete    |
+| 7c    | MEM1/MEM2 split (dTLB/PMP separated from dcache hit) | RV64IMAFDC    | AXI4    | In progress |
 | 7d    | *(Stretch)* dcache tag→data retime + FPU FMA retime + manual physopt | RV64IMAFDC | AXI4 | Planned |
 | 8     | Out-of-order execution (BOOM-class rename + ROB + IQ + LSU) | RV64IMAFDC | AXI4 | Planned     |
 

--- a/rtl/kronos_pkg.sv
+++ b/rtl/kronos_pkg.sv
@@ -301,20 +301,20 @@ package kronos_pkg;
   // Stage 1 / Stage 7a: forwarding and pipeline register types
   // -------------------------------------------------------------------------
 
-  // Stage 7b — fwd_sel_e gains FWD_EX1_NOW for the same-cycle bypass from the
-  // combinational EX1 alu_result_d into the RR/EX1 flop.  Names of the older
-  // sources keep their semantic meaning ("the source is in this register"),
-  // even though the consumer cycle moved one stage later by inserting RR:
+  // fwd_sel_e — forwarding source select for rs1/rs2 bypass mux at RR stage.
+  // Five producer slots, freshest first:
   //   FWD_EX1_NOW  - same cycle (combinational alu_result_d at EX1)
   //   FWD_EX1      - 1-cycle-old (ex1_ex2_q.alu_result)
-  //   FWD_EXMEM    - 2-cycle-old (ex2_mem_q.alu_result)
-  //   FWD_MEMWB    - 3-cycle-old (mem_wb_q via writeback mux)
+  //   FWD_EXMEM         - 2-cycle-old (ex2_mem1_q.alu_result; was FWD_EXMEM     in 7b)
+  //   FWD_MEM2     - 3-cycle-old (mem1_mem2_q.alu_result, or lsu_rdata for loads)
+  //   FWD_MEMWB    - 4-cycle-old (mem_wb_q via writeback mux)
   typedef enum logic [2:0] {
-    FWD_NONE     = 3'd0,   // use register-file value
-    FWD_EX1_NOW  = 3'd1,   // Stage 7b — same-cycle EX1 alu_result_d
+    FWD_NONE     = 3'd0,   // use regfile rdata
+    FWD_EX1_NOW  = 3'd1,   // 7b — same-cycle EX1 alu_result_d (combinational)
     FWD_EX1      = 3'd2,   // 1-cycle-old: ex1_ex2_q.alu_result
-    FWD_EXMEM    = 3'd3,   // 2-cycle-old: ex2_mem_q.alu_result
-    FWD_MEMWB    = 3'd4    // 3-cycle-old: WB mux output
+    FWD_EXMEM         = 3'd3,   // 2-cycle-old: ex2_mem1_q.alu_result   (was FWD_EXMEM     in 7b)
+    FWD_MEM2     = 3'd4,   // 3-cycle-old: mem1_mem2_q.alu_result OR lsu_rdata for loads
+    FWD_MEMWB    = 3'd5    // 4-cycle-old: mem_wb_q via writeback mux
   } fwd_sel_e;
 
   // -------------------------------------------------------------------------
@@ -388,7 +388,7 @@ package kronos_pkg;
     logic [63:0]    rs2_data;
     logic [31:0]    pc_d;
     logic [63:0]    csr_rdata;
-    logic           redirect;    // Stage 6 — kept for backward compat; unused in Stage 7a.
+    logic           redirect;    // kept for backward compat; unused in Stage 7+.
     logic           valid;
     // Stage 3+
     logic           is_16b;      // needed so WB computes correct pc4 link address
@@ -398,11 +398,32 @@ package kronos_pkg;
     // into kronos_csr (snapshot of the CSR write source operand).
     logic [31:0]    instr;
     logic [63:0]    csr_wdata;
-    // Stage 7a — registered fault bits.  Stage 7a forms mem_redirect_d
-    // from these + MEM-cycle producers; Stage 6 leaves this field at '0
-    // and continues using the older `redirect` field above.
+    // Registered fault bits.  Forms mem_redirect_d together with MEM-cycle
+    // producers.
     fault_t         fault;
   } ex_mem_reg_t;
+
+  typedef struct packed {
+    // mirror of ex_mem_reg_t (passed through MEM1->MEM2)
+    logic [31:0]    pc;
+    decoded_instr_t dec;
+    logic [63:0]    alu_result;
+    logic [63:0]    rs2_data;
+    logic [31:0]    pc_d;
+    logic [63:0]    csr_rdata;
+    logic           redirect;       // legacy — kept for backward compat; unused
+    logic           valid;
+    logic           is_16b;
+    logic           pred_taken;
+    logic [31:0]    pred_target;
+    logic [31:0]    instr;
+    logic [63:0]    csr_wdata;
+    fault_t         fault;          // includes MEM1-produced bits
+    // MEM1-stage outputs
+    logic [31:0]    dtlb_pa;        // translated PA (or eff_data_pa under translate_data=0)
+    logic           dtlb_was_hit;   // 1=lookup hit (or translation off); 0=dtlb_miss path
+    logic           dcache_pre_launched; // metadata for retire trace
+  } mem1_mem2_reg_t;
 
   typedef struct packed {
     decoded_instr_t dec;
@@ -436,6 +457,18 @@ package kronos_pkg;
     wb_sel:    WB_ALU,
     fp_op:     FP_FSGNJ,
     default:   '0
+  };
+
+  localparam ex_mem_reg_t EX_MEM_REG_ZERO = '{
+    dec:     DECODED_INSTR_ZERO,
+    fault:   FAULT_ZERO,
+    default: '0
+  };
+
+  localparam mem1_mem2_reg_t MEM1_MEM2_REG_ZERO = '{
+    dec:     DECODED_INSTR_ZERO,
+    fault:   FAULT_ZERO,
+    default: '0
   };
 
   localparam id_ex_reg_t ID_EX_REG_ZERO = '{

--- a/rtl/stage7/kronos_dcache.sv
+++ b/rtl/stage7/kronos_dcache.sv
@@ -1490,7 +1490,17 @@ module kronos_dcache
                         | bypass_valid_q | store_done_q | amo_done_q
                         | nc_rsp_valid_q | nc_b_done_q;
   assign rsp_rdata_int  = amo_done_q ? amo_old_val_q : load_data_full;
-  assign sc_success_int = sc_success_q;
+  // sc_success_int: the registered sc_success_q lags by one cycle after the
+  // SC fires (it captures at the next posedge), but the LSU samples
+  // sc_success_o the same cycle data_valid_o pulses (via `hit` in the
+  // rsp_valid_int OR-tree).  In the MEM1/MEM2 pipeline, the SC at MEM2
+  // advances to WB on the very next edge unless an unrelated stall holds
+  // it — without combinational coverage, mem_wb_q.lsu_rdata captures
+  // ~sc_success_q == 1 (failure) for an SC that actually hit and matched
+  // its reservation.  Fold sc_hit_write_fire (the same combinational
+  // predicate that fires the BRAM write) into sc_success_int so the LSU
+  // sees the correct success bit in the same cycle data_valid pulses.
+  assign sc_success_int = sc_success_q | sc_hit_write_fire;
 
   // route the response to either LSU or PTW.
   // - PTW hits land in DC_PTW_LOOKUP — owner is PTW.

--- a/rtl/stage7/kronos_dcache.sv
+++ b/rtl/stage7/kronos_dcache.sv
@@ -203,6 +203,16 @@ module kronos_dcache
   logic [kronos_pkg::XLEN-1:0]               prev_write_data_q;
   logic [kronos_pkg::XLEN_BYTES-1:0]         prev_write_mask_q;
   logic                                      prev_write_active_q;
+  // 2-deep RAW bypass tier — needed in the MEM1/MEM2 split because the LD's
+  // pre-launch ram_re fires the same cycle the SD's ram_we commits. With
+  // WRITE_MODE_B="no_change" the LD's ram_rdata captures stale data and the
+  // 1-deep tier is consumed by the next instruction's pre-launch before the
+  // LD reaches MEM2. Keeping a 2-cycle history covers the SD-NOP-LD case.
+  logic [NUM_WAYS-1:0]                       prev2_write_way_oh_q;
+  logic [RAM_ADDR_W-1:0]                     prev2_write_addr_q;
+  logic [kronos_pkg::XLEN-1:0]               prev2_write_data_q;
+  logic [kronos_pkg::XLEN_BYTES-1:0]         prev2_write_mask_q;
+  logic                                      prev2_write_active_q;
 
   // PTW hit lookup state — captured at DC_IDLE entry on a PTW hit so that
   // DC_PTW_LOOKUP can way-mux ram_rdata[ptw_lookup_way_q] as the response.
@@ -542,6 +552,16 @@ module kronos_dcache
     for (int w = 0; w < NUM_WAYS; w++) begin
       if (hit_way_oh[w]) begin
         hit_beat = ram_rdata[w];
+        // Apply older (2-deep) tier first; newer (1-deep) tier overrides
+        // per-byte for the freshest value.
+        if (prev2_write_active_q & prev2_write_way_oh_q[w] &
+            (prev2_write_addr_q == {set_idx, beat_idx})) begin
+          for (int b = 0; b < kronos_pkg::XLEN_BYTES; b++) begin
+            if (prev2_write_mask_q[b]) begin
+              hit_beat[b*8 +: 8] = prev2_write_data_q[b*8 +: 8];
+            end
+          end
+        end
         if (prev_write_active_q & prev_write_way_oh_q[w] &
             (prev_write_addr_q == {set_idx, beat_idx})) begin
           for (int b = 0; b < kronos_pkg::XLEN_BYTES; b++) begin
@@ -875,6 +895,11 @@ module kronos_dcache
       prev_write_data_q    <= {kronos_pkg::XLEN{1'b0}};
       prev_write_mask_q    <= {kronos_pkg::XLEN_BYTES{1'b0}};
       prev_write_active_q  <= 1'b0;
+      prev2_write_way_oh_q <= {NUM_WAYS{1'b0}};
+      prev2_write_addr_q   <= {RAM_ADDR_W{1'b0}};
+      prev2_write_data_q   <= {kronos_pkg::XLEN{1'b0}};
+      prev2_write_mask_q   <= {kronos_pkg::XLEN_BYTES{1'b0}};
+      prev2_write_active_q <= 1'b0;
       prev_tag_write_q     <= 1'b0;
       prev_tag_set_q       <= {SET_IDX_W{1'b0}};
       prev_tag_way_oh_q    <= {NUM_WAYS{1'b0}};
@@ -904,6 +929,16 @@ module kronos_dcache
       prev_write_addr_q   <= ram_waddr;
       prev_write_data_q   <= ram_wdata;
       prev_write_mask_q   <= ram_wmask;
+      // 2-deep tier: shift the prior cycle's snapshot one stage further so
+      // an LD that reaches MEM2 two cycles after an SD's commit still gets
+      // the bypassed bytes. Required by the MEM1/MEM2 split — the LD's
+      // pre-launch fires the cycle the SD writes BRAM, so ram_rdata is
+      // stale by an extra cycle vs. the 7b single-MEM pipeline.
+      prev2_write_active_q <= prev_write_active_q;
+      prev2_write_way_oh_q <= prev_write_way_oh_q;
+      prev2_write_addr_q   <= prev_write_addr_q;
+      prev2_write_data_q   <= prev_write_data_q;
+      prev2_write_mask_q   <= prev_write_mask_q;
       // 1-deep RAW bypass for the tag RAM: capture the tag write that fires
       // this cycle so the next cycle's tag-compare sees the new value
       // (xpm SDP "no_change" returns the OLD tag on a same-cycle write+read).

--- a/rtl/stage7/kronos_decode_mem.sv
+++ b/rtl/stage7/kronos_decode_mem.sv
@@ -109,13 +109,15 @@ module kronos_decode_mem
 
         unique case (funct7[6:2])
           5'b00010: begin
-            decoded_o.is_load = 1'b1;
-            decoded_o.is_lr   = 1'b1;
+            decoded_o.is_load    = 1'b1;
+            decoded_o.is_lr      = 1'b1;
+            decoded_o.amo_funct5 = funct7[6:2];
           end
           5'b00011: begin
-            decoded_o.is_store = 1'b1;
-            decoded_o.is_sc    = 1'b1;
-            decoded_o.rs2_used = 1'b1;
+            decoded_o.is_store   = 1'b1;
+            decoded_o.is_sc      = 1'b1;
+            decoded_o.rs2_used   = 1'b1;
+            decoded_o.amo_funct5 = funct7[6:2];
           end
           default: begin
             decoded_o.is_amo     = 1'b1;

--- a/rtl/stage7/kronos_forward.sv
+++ b/rtl/stage7/kronos_forward.sv
@@ -4,27 +4,31 @@
 
 // kronos_forward.sv — pre-registered data-hazard forward select
 //
-// Pipeline: IF -> ID -> RR -> EX1 -> EX2 -> MEM -> WB.  At ID-time T the
-// consumer is captured into id_rr_q.  The forward select decided here is
+// Pipeline: IF -> ID -> RR -> EX1 -> EX2 -> MEM1 -> MEM2 -> WB.  At ID-time T
+// the consumer is captured into id_rr_q.  The forward select decided here is
 // consumed at T+1 when the consumer is in RR and reads its rs1/rs2 via the
 // bypass mux at the RR/EX1 flop boundary.
 //
-// Four forward sources, freshest first:
-//   * id_rr_q  (producer in RR at T)  -> in EX1 at T+1.  Result is the
+// Five forward sources, freshest first:
+//   * id_rr_q    (producer in RR at T)   -> in EX1 at T+1.  Result is the
 //     combinational alu_result_d.  Bypass key: FWD_EX1_NOW.
-//   * rr_ex1_q (producer in EX1 at T) -> in EX2 at T+1.  Result is in
+//   * rr_ex1_q   (producer in EX1 at T)  -> in EX2 at T+1.  Result is in
 //     ex1_ex2_q.alu_result one cycle later.  Bypass key: FWD_EX1.
-//   * ex1_ex2_q (producer in EX2 at T) -> in MEM at T+1.  Result is in
-//     ex2_mem_q.alu_result one cycle later.  Bypass key: FWD_EXMEM.
-//   * ex2_mem_q (producer in MEM at T) -> in WB at T+1.  Writeback value is
-//     in wb_result (driven by mem_wb_q).  Bypass key: FWD_MEMWB.
+//   * ex1_ex2_q  (producer in EX2 at T)  -> in MEM1 at T+1.  Result is in
+//     ex2_mem1_q.alu_result one cycle later.  Bypass key: FWD_EXMEM.
+//   * ex2_mem1_q (producer in MEM1 at T) -> in MEM2 at T+1.  Result is in
+//     mem1_mem2_q; for loads, lsu_rdata is selected combinationally at the
+//     bypass mux.  Bypass key: FWD_MEM2.
+//   * mem1_mem2_q (producer in MEM2 at T) -> in WB at T+1.  Writeback value
+//     is in wb_result (driven by mem_wb_q).  Bypass key: FWD_MEMWB.
 //
-// FWD_EX1_NOW has priority over FWD_EX1, which has priority over FWD_EXMEM,
-// which has priority over FWD_MEMWB (freshest wins).  x0 is never forwarded.
-// rd_fp suppresses bypass so a shared rd index between FP and integer
-// regfiles does not poison the integer consumer.  Loads in {RR, EX1, EX2}
-// suppress their bypass slot (the load value isn't ready yet); a load
-// reaching the MEM slot bypasses via the WB mux at T+1.
+// Freshest wins.  x0 is never forwarded.  rd_fp suppresses bypass so a
+// shared rd index between FP and integer regfiles does not poison an integer
+// consumer.  Loads in {RR, EX1, EX2} suppress their bypass slot (the load
+// value isn't ready yet).  FWD_MEM2 is NOT suppressed for loads — the bypass
+// mux in kronos_top.sv selects lsu_rdata combinationally at MEM2 time.
+// FWD_MEMWB is also not suppressed for loads (mem_wb_q.alu_result already
+// holds the load value via the writeback result mux).
 module kronos_forward
   import kronos_pkg::*;
 (
@@ -51,67 +55,48 @@ module kronos_forward
   input  logic       ex1_ex2_rd_fp_i,
   input  logic       ex1_ex2_is_load_i,
   input  logic       ex1_ex2_valid_i,
-  // Producer in MEM (ex2_mem_q).  Loads OK via WB mux at T+1.
-  input  logic [4:0] ex2_mem_rd_i,
-  input  logic       ex2_mem_rd_wen_i,
-  input  logic       ex2_mem_rd_fp_i,
+  // Producer in MEM1 (ex2_mem1_q).  Loads permitted via MEM2 bypass mux.
+  input  logic [4:0] ex2_mem1_rd_i,
+  input  logic       ex2_mem1_rd_wen_i,
+  input  logic       ex2_mem1_rd_fp_i,
+  input  logic       ex2_mem1_valid_i,
+  // Producer in MEM2 (mem1_mem2_q).  No valid port — mirrors the WB-slot
+  // pattern from 7b where the oldest slot is always considered live.
+  input  logic [4:0] mem1_mem2_rd_i,
+  input  logic       mem1_mem2_rd_wen_i,
+  input  logic       mem1_mem2_rd_fp_i,
   // Outputs: stored into id_rr_q.fwd_rs1_sel / id_rr_q.fwd_rs2_sel.
   output fwd_sel_e   fwd_rs1_sel_o,
   output fwd_sel_e   fwd_rs2_sel_o
 );
 
-  logic rr_can_fwd;
-  logic ex1_can_fwd;
-  logic ex2_can_fwd;
-  logic mem_can_fwd;
-
-  assign rr_can_fwd  = id_rr_valid_i   && id_rr_rd_wen_i   && !id_rr_rd_fp_i  &&
-                       !id_rr_is_load_i   && (id_rr_rd_i   != 5'd0);
-  assign ex1_can_fwd = rr_ex1_valid_i  && rr_ex1_rd_wen_i  && !rr_ex1_rd_fp_i &&
-                       !rr_ex1_is_load_i  && (rr_ex1_rd_i  != 5'd0);
-  assign ex2_can_fwd = ex1_ex2_valid_i && ex1_ex2_rd_wen_i && !ex1_ex2_rd_fp_i &&
-                       !ex1_ex2_is_load_i && (ex1_ex2_rd_i != 5'd0);
-  assign mem_can_fwd = ex2_mem_rd_wen_i && !ex2_mem_rd_fp_i && (ex2_mem_rd_i != 5'd0);
-
   always_comb begin
     fwd_rs1_sel_o = FWD_NONE;
+    if (if_id_rs1_used_i & (if_id_rs1_i != 5'd0)) begin
+      if      (id_rr_valid_i    & id_rr_rd_wen_i    & ~id_rr_rd_fp_i    &
+               ~id_rr_is_load_i    & (id_rr_rd_i    == if_id_rs1_i)) fwd_rs1_sel_o = FWD_EX1_NOW;
+      else if (rr_ex1_valid_i   & rr_ex1_rd_wen_i   & ~rr_ex1_rd_fp_i   &
+               ~rr_ex1_is_load_i   & (rr_ex1_rd_i   == if_id_rs1_i)) fwd_rs1_sel_o = FWD_EX1;
+      else if (ex1_ex2_valid_i  & ex1_ex2_rd_wen_i  & ~ex1_ex2_rd_fp_i  &
+               ~ex1_ex2_is_load_i  & (ex1_ex2_rd_i  == if_id_rs1_i)) fwd_rs1_sel_o = FWD_EXMEM;
+      else if (ex2_mem1_valid_i & ex2_mem1_rd_wen_i & ~ex2_mem1_rd_fp_i &
+               (ex2_mem1_rd_i      == if_id_rs1_i)) fwd_rs1_sel_o = FWD_MEM2;
+      else if (                   mem1_mem2_rd_wen_i & ~mem1_mem2_rd_fp_i &
+               (mem1_mem2_rd_i    == if_id_rs1_i)) fwd_rs1_sel_o = FWD_MEMWB;
+    end
+
     fwd_rs2_sel_o = FWD_NONE;
-
-    // RR (freshest) — highest priority.  Producer is in EX1 at T+1, so the
-    // bypass mux at RR-time T+1 reads alu_result_d directly.
-    if (rr_can_fwd) begin
-      if (if_id_rs1_used_i && if_id_rs1_i == id_rr_rd_i) fwd_rs1_sel_o = FWD_EX1_NOW;
-      if (if_id_rs2_used_i && if_id_rs2_i == id_rr_rd_i) fwd_rs2_sel_o = FWD_EX1_NOW;
-    end
-
-    // EX1 — only if RR did not already forward this operand.
-    if (ex1_can_fwd) begin
-      if (if_id_rs1_used_i && if_id_rs1_i == rr_ex1_rd_i && fwd_rs1_sel_o == FWD_NONE) begin
-        fwd_rs1_sel_o = FWD_EX1;
-      end
-      if (if_id_rs2_used_i && if_id_rs2_i == rr_ex1_rd_i && fwd_rs2_sel_o == FWD_NONE) begin
-        fwd_rs2_sel_o = FWD_EX1;
-      end
-    end
-
-    // EX2 — only if RR/EX1 did not already forward.
-    if (ex2_can_fwd) begin
-      if (if_id_rs1_used_i && if_id_rs1_i == ex1_ex2_rd_i && fwd_rs1_sel_o == FWD_NONE) begin
-        fwd_rs1_sel_o = FWD_EXMEM;
-      end
-      if (if_id_rs2_used_i && if_id_rs2_i == ex1_ex2_rd_i && fwd_rs2_sel_o == FWD_NONE) begin
-        fwd_rs2_sel_o = FWD_EXMEM;
-      end
-    end
-
-    // MEM (oldest) — only if no fresher slot matched.
-    if (mem_can_fwd) begin
-      if (if_id_rs1_used_i && if_id_rs1_i == ex2_mem_rd_i && fwd_rs1_sel_o == FWD_NONE) begin
-        fwd_rs1_sel_o = FWD_MEMWB;
-      end
-      if (if_id_rs2_used_i && if_id_rs2_i == ex2_mem_rd_i && fwd_rs2_sel_o == FWD_NONE) begin
-        fwd_rs2_sel_o = FWD_MEMWB;
-      end
+    if (if_id_rs2_used_i & (if_id_rs2_i != 5'd0)) begin
+      if      (id_rr_valid_i    & id_rr_rd_wen_i    & ~id_rr_rd_fp_i    &
+               ~id_rr_is_load_i    & (id_rr_rd_i    == if_id_rs2_i)) fwd_rs2_sel_o = FWD_EX1_NOW;
+      else if (rr_ex1_valid_i   & rr_ex1_rd_wen_i   & ~rr_ex1_rd_fp_i   &
+               ~rr_ex1_is_load_i   & (rr_ex1_rd_i   == if_id_rs2_i)) fwd_rs2_sel_o = FWD_EX1;
+      else if (ex1_ex2_valid_i  & ex1_ex2_rd_wen_i  & ~ex1_ex2_rd_fp_i  &
+               ~ex1_ex2_is_load_i  & (ex1_ex2_rd_i  == if_id_rs2_i)) fwd_rs2_sel_o = FWD_EXMEM;
+      else if (ex2_mem1_valid_i & ex2_mem1_rd_wen_i & ~ex2_mem1_rd_fp_i &
+               (ex2_mem1_rd_i      == if_id_rs2_i)) fwd_rs2_sel_o = FWD_MEM2;
+      else if (                   mem1_mem2_rd_wen_i & ~mem1_mem2_rd_fp_i &
+               (mem1_mem2_rd_i    == if_id_rs2_i)) fwd_rs2_sel_o = FWD_MEMWB;
     end
   end
 

--- a/rtl/stage7/kronos_hazard.sv
+++ b/rtl/stage7/kronos_hazard.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // kronos_hazard.sv — pipeline stall and flush control unit
-// Pipeline: IF -> ID -> RR -> EX1 -> EX2 -> MEM -> WB.
+// Pipeline: IF -> ID -> RR -> EX1 -> EX2 -> MEM1 -> MEM2 -> WB.
 // Priority (highest first): MEM/FPU/fetch stall > load-use / JALR-fwd /
 //                           FRM / CSR-RAW > EX/MEM redirect > muldiv stall
 //                           > normal advance.
@@ -32,11 +32,17 @@ module kronos_hazard
   input  logic [4:0] ex1_ex2_rd_i,
   input  logic       ex1_ex2_rd_wen_i,
   input  logic       ex1_ex2_valid_i,
-  // Producer in MEM (ex2_mem_q) — for JALR-fwd and CSR-RAW.
-  input  logic [4:0] ex_mem_rd_i,
-  input  logic       ex_mem_rd_wen_i,
-  input  logic       ex_mem_valid_i,
-  input  logic       ex_mem_is_csr_i,
+  // Producer in MEM1 (ex2_mem1_q) — renamed from ex_mem_* in 7b.
+  input  logic       ex2_mem1_is_load_i,
+  input  logic       ex2_mem1_is_fp_load_i,
+  input  logic       ex2_mem1_is_csr_i,
+  input  logic [4:0] ex2_mem1_rd_i,
+  input  logic       ex2_mem1_rd_wen_i,
+  input  logic       ex2_mem1_valid_i,
+  // Producer in MEM2 (mem1_mem2_q) — new slot for CSR-RAW.
+  input  logic       mem1_mem2_is_csr_i,
+  input  logic [4:0] mem1_mem2_rd_i,
+  input  logic       mem1_mem2_valid_i,
   // ID-stage register addresses.
   input  logic       if_id_rs1_used_i,
   input  logic [4:0] if_id_rs1_i,
@@ -62,25 +68,28 @@ module kronos_hazard
   output logic       if_id_en_o,
   output logic       id_rr_en_o,
   output logic       rr_ex1_en_o,
-  output logic       ex_mem_en_o,
+  output logic       ex2_mem1_en_o,
+  output logic       mem1_mem2_en_o,
   output logic       mem_wb_en_o,
   // Pipeline-register flushes (clear to NOP).
   output logic       if_id_flush_o,
   output logic       id_rr_flush_o,
-  output logic       rr_ex1_flush_o
+  output logic       rr_ex1_flush_o,
+  output logic       ex2_mem1_flush_o,
+  output logic       mem1_mem2_flush_o
 );
 
   logic load_use, fp_load_use, jalr_fwd_stall, frm_hazard;
   logic csr_raw_stall_id, csr_raw_stall_rr;
-  logic ex_mem_unused;
+  logic ex2_mem1_unused;
 
-  // ex_mem_rd_wen_i is reserved for future MEM-class hazard checks.  Tie it
-  // through an unused signal so verilator's lint stays happy.
-  assign ex_mem_unused = ex_mem_rd_wen_i & ex_mem_rd_i[0];
+  // ex2_mem1_rd_wen_i is reserved for future MEM1-class hazard checks.  Tie
+  // through an unused signal so Verilator lint stays happy.
+  assign ex2_mem1_unused = ex2_mem1_rd_wen_i & ex2_mem1_rd_i[0];
 
   // Load-use: load can be in {RR, EX1, EX2}; consumer in ID.  Total stall is
-  // 2 cycles in ID — the load advances RR -> EX1 -> EX2 -> MEM, where the
-  // MEM result bypasses into the consumer's RR stage on the same edge.
+  // 2 cycles in ID — the load advances RR -> EX1 -> EX2 -> MEM1, where the
+  // MEM1 result is picked up via FWD_MEM2 at the bypass mux (not a stall).
   assign load_use =
     (id_rr_valid_i   & id_rr_is_load_i   & (id_rr_rd_i   != 5'd0) &
      ((if_id_rs1_used_i & (if_id_rs1_i == id_rr_rd_i)) |
@@ -107,56 +116,61 @@ module kronos_hazard
       (if_id_rs2_fp_i & (if_id_rs2_i == ex1_ex2_rd_i)) |
       (if_id_rs3_fp_i & (if_id_rs3_i == ex1_ex2_rd_i))));
 
-  // JALR-fwd stall: JALR in ID with rs1 matching the producer in ex1_ex2_q
-  // (one stage shifted vs 7a's ex_mem_q check, to keep the stall budget the
-  // same as the deeper pipe).  Gate on rd_wen so stores don't trigger a
-  // wasted stall (stores have rd_wen = 0 and never produce a value into rd).
+  // JALR-load-fwd stall: JALR in ID with rs1 matching a load in MEM1
+  // (ex2_mem1_q).  The load value arrives from dcache at MEM2 — one cycle too
+  // late for the bypass mux.  Only load instructions need this stall; non-load
+  // producers in MEM1 are covered by FWD_MEM2 without stalling.
   assign jalr_fwd_stall = if_id_is_jalr_i &
-                           ex1_ex2_valid_i & ex1_ex2_rd_wen_i &
-                           (ex1_ex2_rd_i != 5'd0) &
-                           (if_id_rs1_i == ex1_ex2_rd_i);
+                           ex2_mem1_valid_i & ex2_mem1_rd_wen_i &
+                           ex2_mem1_is_load_i &
+                           (ex2_mem1_rd_i != 5'd0) &
+                           (if_id_rs1_i == ex2_mem1_rd_i);
 
   // FRM/FCSR RAW: a CSR write to FRM/FCSR in EX1, FP-DYN-rm consumer in ID.
   assign frm_hazard = rr_ex1_is_frm_write_i & if_id_fp_dyn_rm_i;
 
-  // CSR-RAW (ID-stage consumer): writer in {RR, EX1, EX2, MEM}.
-  assign csr_raw_stall_id = if_id_uses_csr_i &
-                            ((id_rr_valid_i   & id_rr_is_csr_i)   |
-                             (rr_ex1_valid_i  & rr_ex1_is_csr_i)  |
-                             (ex1_ex2_valid_i & ex1_ex2_is_csr_i) |
-                             (ex_mem_valid_i  & ex_mem_is_csr_i));
+  // CSR-RAW (ID-stage consumer): writer in {RR, EX1, EX2, MEM1, MEM2}.
+  assign csr_raw_stall_id = if_id_uses_csr_i & (
+      (id_rr_valid_i     & id_rr_is_csr_i)     |
+      (rr_ex1_valid_i    & rr_ex1_is_csr_i)    |
+      (ex1_ex2_valid_i   & ex1_ex2_is_csr_i)   |
+      (ex2_mem1_valid_i  & ex2_mem1_is_csr_i)  |
+      (mem1_mem2_valid_i & mem1_mem2_is_csr_i));
 
-  // CSR-RAW (RR-stage consumer): writer in {EX1, EX2, MEM}.  Closes a
-  // one-cycle gap when an ID-stage stall releases the consumer the same cycle
-  // a new writer enters EX1 from id_rr_q.
-  assign csr_raw_stall_rr = id_rr_uses_csr_i &
-                            ((rr_ex1_valid_i  & rr_ex1_is_csr_i)  |
-                             (ex1_ex2_valid_i & ex1_ex2_is_csr_i) |
-                             (ex_mem_valid_i  & ex_mem_is_csr_i));
+  // CSR-RAW (RR-stage consumer): writer in {EX1, EX2, MEM1, MEM2}.
+  assign csr_raw_stall_rr = id_rr_uses_csr_i & (
+      (rr_ex1_valid_i    & rr_ex1_is_csr_i)    |
+      (ex1_ex2_valid_i   & ex1_ex2_is_csr_i)   |
+      (ex2_mem1_valid_i  & ex2_mem1_is_csr_i)  |
+      (mem1_mem2_valid_i & mem1_mem2_is_csr_i));
 
   always_comb begin
-    pc_en_o        = 1'b1;
-    if_id_en_o     = 1'b1;
-    id_rr_en_o     = 1'b1;
-    rr_ex1_en_o    = 1'b1;
-    ex_mem_en_o    = 1'b1;
-    mem_wb_en_o    = 1'b1;
-    if_id_flush_o  = 1'b0;
-    id_rr_flush_o  = 1'b0;
-    rr_ex1_flush_o = 1'b0;
+    pc_en_o           = 1'b1;
+    if_id_en_o        = 1'b1;
+    id_rr_en_o        = 1'b1;
+    rr_ex1_en_o       = 1'b1;
+    ex2_mem1_en_o     = 1'b1;
+    mem1_mem2_en_o    = 1'b1;
+    mem_wb_en_o       = 1'b1;
+    if_id_flush_o     = 1'b0;
+    id_rr_flush_o     = 1'b0;
+    rr_ex1_flush_o    = 1'b0;
+    ex2_mem1_flush_o  = 1'b0;
+    mem1_mem2_flush_o = 1'b0;
 
     if (mem_stall_i) begin
       // Priority 1: MEM/FPU/fetch stall — hold all stages.
-      pc_en_o     = 1'b0;
-      if_id_en_o  = 1'b0;
-      id_rr_en_o  = 1'b0;
-      rr_ex1_en_o = 1'b0;
-      ex_mem_en_o = 1'b0;
-      mem_wb_en_o = 1'b0;
+      pc_en_o        = 1'b0;
+      if_id_en_o     = 1'b0;
+      id_rr_en_o     = 1'b0;
+      rr_ex1_en_o    = 1'b0;
+      ex2_mem1_en_o  = 1'b0;
+      mem1_mem2_en_o = 1'b0;
+      mem_wb_en_o    = 1'b0;
     end else if (ex_redirect_i | mem_redirect_i) begin
       // Priority 2: redirect — flush IF/ID/RR/EX1 wrong-path followers.
-      // Older stages (EX2/MEM) flush via combinational gating in kronos_top
-      // when the redirect carries a MEM-stage trap.
+      // Older stages (EX2/MEM1/MEM2) flush via combinational gating in
+      // kronos_top when the redirect carries a MEM-stage trap.
       if_id_flush_o  = 1'b1;
       id_rr_flush_o  = 1'b1;
       rr_ex1_flush_o = 1'b1;
@@ -175,12 +189,13 @@ module kronos_hazard
       rr_ex1_flush_o = 1'b1;
     end else if (muldiv_stall_i) begin
       // Priority 4: muldiv FSM busy — hold all stages.
-      pc_en_o     = 1'b0;
-      if_id_en_o  = 1'b0;
-      id_rr_en_o  = 1'b0;
-      rr_ex1_en_o = 1'b0;
-      ex_mem_en_o = 1'b0;
-      mem_wb_en_o = 1'b0;
+      pc_en_o        = 1'b0;
+      if_id_en_o     = 1'b0;
+      id_rr_en_o     = 1'b0;
+      rr_ex1_en_o    = 1'b0;
+      ex2_mem1_en_o  = 1'b0;
+      mem1_mem2_en_o = 1'b0;
+      mem_wb_en_o    = 1'b0;
     end
   end
 

--- a/rtl/stage7/kronos_top.sv
+++ b/rtl/stage7/kronos_top.sv
@@ -2829,7 +2829,17 @@ module kronos_top
     end
   end
 
-  assign mem1_mem2_flush = mem_redirect_q | mem_redirect_d;
+  // mem1_mem2_flush gated on ~combined_stall: when combined_stall fires the
+  // same cycle mem_redirect_d asserts (e.g., an icache miss stalls the
+  // pipeline at the mret/sret cycle), mem_wb_en is 0 so mem_wb_q cannot
+  // capture the trap-causer.  Without this gate the flush would zero
+  // mem1_mem2_q before the stall lifts and the mret/sret commit would be
+  // lost — visible as test_priv_smoke regressing to x10=60 (M handler
+  // sees mcause=ECALL_M instead of ECALL_U because the mret never
+  // actually transitioned priv to U).  Holding the flush off under
+  // stall keeps the trap-causer in mem1_mem2_q until the stall lifts,
+  // at which edge mem_wb_q captures and mem1_mem2_q is zeroed together.
+  assign mem1_mem2_flush = (mem_redirect_q | mem_redirect_d) & ~combined_stall;
 
   // PA pipeline: dTLB lookup runs at MEM1 (consuming ex2_mem1_q.alu_result as
   // VA), the translated PA flops into mem1_mem2_q.dtlb_pa at the MEM1->MEM2

--- a/rtl/stage7/kronos_top.sv
+++ b/rtl/stage7/kronos_top.sv
@@ -131,6 +131,7 @@ module kronos_top
   logic [kronos_pkg::XLEN-1:0] rr_csr_rdata_combinational;
   // Bypassed RS1/RS2 captured into rr_ex1_q at the RR/EX1 flop boundary.
   logic [kronos_pkg::XLEN-1:0] rs1_bypassed, rs2_bypassed;
+  logic [kronos_pkg::XLEN-1:0] mem2_dcache_val;
 
   // -------------------------------------------------------------------------
   // EX-stage wires (64-bit datapath)
@@ -822,7 +823,12 @@ module kronos_top
 
   kronos_hazard u_hazard (
     // RR producer (id_rr_q) — load-use, csr-raw, and uses_csr arms.
-    .id_rr_is_load_i       (id_rr_q.dec.is_load),
+    // is_load mirrors u_forward's wb_sel==WB_MEM predicate so AMO/LR/SC
+    // (which write rd from lsu_rdata at MEM2) are also stalled, not just
+    // raw loads.  Without this, the consumer reads stale regfile via
+    // FWD_NONE — visible as test_mem_amo_split sub-test 1 (bnez after
+    // sc.d sees x29=0 instead of the SC success/fail code).
+    .id_rr_is_load_i       (id_rr_q.dec.wb_sel == WB_MEM),
     .id_rr_is_fp_load_i    (id_rr_q.dec.fp_load),
     .id_rr_is_csr_i        (id_rr_q.dec.is_csr),
     .id_rr_rd_i            (id_rr_q.dec.rd),
@@ -832,21 +838,21 @@ module kronos_top
                                               id_rr_q.dec.is_sret | id_rr_q.dec.is_wfi |
                                               id_rr_q.dec.is_ecall | id_rr_q.dec.is_ebreak)),
     // EX1 producer (rr_ex1_q).
-    .rr_ex1_is_load_i      (rr_ex1_q.dec.is_load),
+    .rr_ex1_is_load_i      (rr_ex1_q.dec.wb_sel == WB_MEM),
     .rr_ex1_is_fp_load_i   (rr_ex1_q.dec.fp_load),
     .rr_ex1_is_csr_i       (rr_ex1_q.dec.is_csr),
     .rr_ex1_is_frm_write_i (id_ex_is_frm_write),
     .rr_ex1_rd_i           (rr_ex1_q.dec.rd),
     .rr_ex1_valid_i        (rr_ex1_q.valid),
     // EX2 producer (ex1_ex2_q).
-    .ex1_ex2_is_load_i     (ex1_ex2_q.dec.is_load),
+    .ex1_ex2_is_load_i     (ex1_ex2_q.dec.wb_sel == WB_MEM),
     .ex1_ex2_is_fp_load_i  (ex1_ex2_q.dec.fp_load),
     .ex1_ex2_is_csr_i      (ex1_ex2_q.dec.is_csr),
     .ex1_ex2_rd_i          (ex1_ex2_q.dec.rd),
     .ex1_ex2_rd_wen_i      (ex1_ex2_q.dec.rd_wen),
     .ex1_ex2_valid_i       (ex1_ex2_q.valid),
     // MEM1 producer (ex2_mem1_q).
-    .ex2_mem1_is_load_i    (ex2_mem1_q.dec.is_load),
+    .ex2_mem1_is_load_i    (ex2_mem1_q.dec.wb_sel == WB_MEM),
     .ex2_mem1_is_fp_load_i (ex2_mem1_q.dec.fp_load),
     .ex2_mem1_is_csr_i     (ex2_mem1_q.dec.is_csr),
     .ex2_mem1_rd_i         (ex2_mem1_q.dec.rd),
@@ -2114,12 +2120,22 @@ module kronos_top
   //                 lsu_rdata combinationally from the dcache hit-mux).
   //   FWD_MEMWB   : wb_result_64 (writeback mux output).
   //   default     : RR-cycle source (FP mux or int regfile/WB-bypass mux).
+  // FWD_MEM2 dcache value: covers loads, AMO, LR, SC (anything with
+  // wb_sel == WB_MEM whose result lands in lsu_rdata at MEM2).  When the
+  // LSU is currently asserting valid, lsu_rdata is the freshest value;
+  // otherwise the held lsu_rdata_latch carries it across a stall (the
+  // dcache rsp_valid_int pulses for one cycle and clears once mem_done_q
+  // gates req_i back off, so live lsu_rdata returns to 0 the cycle
+  // after — without the latch fallback the bypass captures 0 when the
+  // consumer's RR/EX1 capture is held by combined_stall).
+  assign mem2_dcache_val = lsu_valid ? lsu_rdata : lsu_rdata_latch;
+
   always_comb begin
     unique case (id_rr_q.fwd_rs1_sel)
       FWD_EX1_NOW: rs1_bypassed = ex_result;
       FWD_EX1:     rs1_bypassed = ex1_ex2_csr_q  ? ex1_ex2_q.csr_rdata  : ex1_ex2_q.alu_result;
       FWD_EXMEM:    rs1_bypassed = ex2_mem_csr_q  ? ex2_mem1_q.csr_rdata : ex2_mem1_q.alu_result;
-      FWD_MEM2:    rs1_bypassed = mem1_mem2_q.dec.is_load ? lsu_rdata
+      FWD_MEM2:    rs1_bypassed = (mem1_mem2_q.dec.wb_sel == WB_MEM) ? mem2_dcache_val
                                 : (mem1_mem2_csr_q ? mem1_mem2_q.csr_rdata
                                                    : mem1_mem2_q.alu_result);
       FWD_MEMWB:   rs1_bypassed = wb_result_64;
@@ -2129,7 +2145,7 @@ module kronos_top
       FWD_EX1_NOW: rs2_bypassed = ex_result;
       FWD_EX1:     rs2_bypassed = ex1_ex2_csr_q  ? ex1_ex2_q.csr_rdata  : ex1_ex2_q.alu_result;
       FWD_EXMEM:    rs2_bypassed = ex2_mem_csr_q  ? ex2_mem1_q.csr_rdata : ex2_mem1_q.alu_result;
-      FWD_MEM2:    rs2_bypassed = mem1_mem2_q.dec.is_load ? lsu_rdata
+      FWD_MEM2:    rs2_bypassed = (mem1_mem2_q.dec.wb_sel == WB_MEM) ? mem2_dcache_val
                                 : (mem1_mem2_csr_q ? mem1_mem2_q.csr_rdata
                                                    : mem1_mem2_q.alu_result);
       FWD_MEMWB:   rs2_bypassed = wb_result_64;

--- a/rtl/stage7/kronos_top.sv
+++ b/rtl/stage7/kronos_top.sv
@@ -2524,14 +2524,23 @@ module kronos_top
   end
 
   assign ex1_ex2_en    = ~combined_stall;
-  // Stage 7a — flush ex1_ex2_q on mem_redirect_d (live, same cycle as the
-  // trap-causing instruction sits in ex2_mem1_q) as well as the registered _q
-  // bits.  Without the _d term, the wrong-path follower in rr_ex1_q latches
-  // into ex1_ex2_q at the same edge mem_redirect_q goes high; one cycle later
+  // Flush ex1_ex2_q on mem_redirect_d (live, same cycle as the trap-causing
+  // instruction sits in ex2_mem1_q) as well as the registered _q bits.
+  // Without the _d term, the wrong-path follower in rr_ex1_q latches into
+  // ex1_ex2_q at the same edge mem_redirect_q goes high; one cycle later
   // that follower's bpred_dir_mispredict can raise ex_redirect_q and override
-  // the IFU's trap_vector / xRET reload — visible as test_csr_priv jumping to
-  // the wrong-path j-target 0x5a instead of mtvec=0x88.
-  assign ex1_ex2_flush = ex_redirect_q | mem_redirect_q | mem_redirect_d;
+  // the IFU's trap_vector / xRET reload.
+  //
+  // The (ex_redirect_d & ex1_ex2_en) term is the JAL/branch analog: when a
+  // JAL or mispredicting branch sits in ex1_ex2_q (ex_redirect_d=1), the
+  // wrong-path follower in rr_ex1_q must NOT advance into ex1_ex2_q at the
+  // same edge.  ex_redirect_q lags by one cycle, so without this live term
+  // the follower captures into ex1_ex2_q at edge T+1->T+2 (while JAL
+  // advances to ex2_mem1_q), then leaks past EX2 because ex2_mem1_q sampled
+  // ex1_ex2_q's *pre-flush* value at edge T+2->T+3.  Gated on ex1_ex2_en so
+  // a stall holds the JAL in ex1_ex2_q intact rather than zeroing it.
+  assign ex1_ex2_flush = ex_redirect_q | mem_redirect_q | mem_redirect_d
+                       | (ex_redirect_d & ex1_ex2_en);
 
   // Stage 7a — EX2 fault next-state.  Carries EX1 bits forward verbatim.
   // EX2 fault next-state.  Carries every EX1-stage fault bit forward verbatim
@@ -2725,8 +2734,9 @@ module kronos_top
       // the EX2 instruction ITSELF (the JAL/branch that detected the
       // mispredict) must still commit its rd write at WB. Killing it here
       // would suppress JAL's link write to ra and break ret semantics.
-      // ex1_ex2_flush already drains any wrong-path instruction from EX1
-      // before it reaches EX2.
+      // ex1_ex2_flush picks up the wrong-path follower at the EX1->EX2
+      // edge via its (ex_redirect_d & ex1_ex2_en) term — see ex1_ex2_flush
+      // assign above for the timing argument.
       ex2_mem1_q.valid       <= ex1_ex2_q.valid &
                                 ~mem_redirect_d & ~mem_redirect_q;
       ex2_mem1_q.is_16b      <= ex1_ex2_q.is_16b;

--- a/rtl/stage7/kronos_top.sv
+++ b/rtl/stage7/kronos_top.sv
@@ -84,8 +84,9 @@ module kronos_top
   ex1_ex2_reg_t  ex1_ex2_d;
   logic          ex1_ex2_en;
   logic          ex1_ex2_flush;
-  ex_mem_reg_t ex2_mem_q;
-  mem_wb_reg_t mem_wb_q;
+  ex_mem_reg_t  ex2_mem1_q;
+  mem1_mem2_reg_t mem1_mem2_q;
+  mem_wb_reg_t    mem_wb_q;
   logic [31:0] pc_q                              /* verilator public_flat_rd */;
   // Boot loader: synchronous one-shot to load boot_addr_i into pc_q after reset.
   // Avoids the "Set+Reset same priority" GLS issue (#57) caused by using
@@ -95,8 +96,10 @@ module kronos_top
   // -------------------------------------------------------------------------
   // Hazard / forwarding control
   // -------------------------------------------------------------------------
-  logic      pc_en, if_id_en, id_rr_en, rr_ex1_en, ex2_mem_en, mem_wb_en;
+  logic      pc_en, if_id_en, id_rr_en, rr_ex1_en;
+  logic      ex2_mem1_en, mem1_mem2_en, mem_wb_en;
   logic      if_id_flush, id_rr_flush, rr_ex1_flush;
+  logic      ex2_mem1_flush, mem1_mem2_flush;
   fwd_sel_e  fwd_rs1_sel, fwd_rs2_sel;
 
   // -------------------------------------------------------------------------
@@ -147,7 +150,7 @@ module kronos_top
   // Each redirect carries its own registered target (`ex_redirect_target_q`,
   // `mem_redirect_target_q`) captured at the same edge that asserts the
   // redirect.  Without these snapshots the IFU would read `ex1_ex2_q.ex_pc_d`
-  // / `ex2_mem_q.pc_d` one cycle later — by which time the pipeline has
+  // / `ex2_mem1_q.pc_d` one cycle later — by which time the pipeline has
   // advanced and those fields hold the *next* instruction's target, not the
   // mispredicting branch's.
   logic ex_redirect_d;
@@ -157,7 +160,7 @@ module kronos_top
   // Stage 7a — registered FENCE.I redirect.  In stage 6 the FENCE.I trap
   // (decode-illegal) and the icache flush both fired the same cycle through
   // the combinational `ex_redirect`.  Here, the illegal-trap rides the fault-
-  // bit pipeline through ex1_ex2_q -> ex2_mem_q -> mem_redirect_q, arriving
+  // bit pipeline through ex1_ex2_q -> ex2_mem1_q -> mem_redirect_q, arriving
   // two cycles after `fence_i_pulse` flushes the icache.  During that gap
   // the IFU keeps fetching from FENCE.I+4 -- now that the icache valid bits
   // have just dropped, those fetches see post-flush misses and stage them
@@ -207,14 +210,6 @@ module kronos_top
   // address snapshot keeps trap_tval pointing at the offending fetch VA.
   logic              pmp_s1_fetch_fault_q;
   logic [55:0]       pmp_s1_fetch_fault_addr_q;
-  // Registered data-side PMP fault.  The combinational
-  // pmp_data_fault_raw → pmp_data_fault → DTLB FSM next-state →
-  // dcache_req → PTW state → mem_wb_q.lsu_rdata write cone caps Fmax at
-  // ~65 MHz on KV260 (issue #97).  Flopping the gated comparator output
-  // breaks the cone after PMP and keeps the trap-fired-one-cycle-later
-  // behaviour symmetric with the registered fetch-side PMP path.
-  logic              pmp_s1_data_fault_q;
-  logic [55:0]       pmp_s1_data_fault_addr_q;
   logic              itlb_s1_perm_fail_q;
   // pc_q snapshot taken alongside itlb_s1_perm_fail_q so trap_tval for the
   // registered iTLB perm-fail arm reads the same pc_q value the pre-flop
@@ -241,9 +236,19 @@ module kronos_top
   logic [55:0]       pmp_fetch_fault_addr_raw;
   logic              pmp_data_fault_raw;
   logic [55:0]       pmp_data_fault_addr_raw;
-  // PMA AMO-on-NC trap detection at EX stage.
-  logic              ex_amo_nc_fault;
-  logic              ex_addr_uncacheable;
+  // PMA AMO-on-NC trap detection at MEM1 stage (post-dTLB-translation).
+  logic              mem1_amo_nc_fault;
+  logic              mem1_addr_uncacheable;
+  // MEM1-cycle page-fault producers for load / store / AMO accesses.  Land in
+  // mem1_mem2_q.fault.{load,store}_page_fault at the MEM1->MEM2 edge.
+  logic              mem1_load_page_fault;
+  logic              mem1_store_page_fault;
+  // MEM1->MEM2 fault next-state (registered into mem1_mem2_q.fault).  Folds
+  // every EX2-stage fault bit with the MEM1-cycle producers.
+  fault_t            mem1_fault_d;
+  // MEM1-class trap predicate — overrides mem1_mem2_q.pc_d to trap_vector at
+  // the MEM1->MEM2 edge so mem_redirect_target_q latches the correct vector.
+  logic              mem1_trap_redirect;
 
   // -------------------------------------------------------------------------
   // TLB / PTW / translation-control wires.
@@ -290,18 +295,9 @@ module kronos_top
   logic [31:0] eff_fetch_pa, eff_data_pa;
   // aggregate page-fault routing.
   logic        instr_page_fault, load_page_fault, store_page_fault;
-  // registered data-port PA (VA→PA happens in EX, LSU consumes it
-  // one stage later in MEM).  Kept alongside ex2_mem_q.alu_result so the trace
-  // continues to report the architectural VA in retire_mem_addr_o.
-  // Stage 7a — PA pipeline tracking the load/store address through EX1→EX2→MEM.
-  // ex1_ex2_data_pa_q captures the EX1 live eff_data_pa at the EX1→EX2 edge so
-  // that during EX2 the value reflects the instruction in ex1_ex2_q (used by
-  // the dcache pre-launch).  ex2_mem_data_pa_q chains from ex1_ex2_data_pa_q at
-  // the EX2→MEM edge so the LSU at MEM consumes the right PA.  Reading
-  // eff_data_pa directly at ex2_mem_en samples the next EX1 instruction's PA
-  // and corrupts back-to-back mem ops (SD;LD).
-  logic [31:0] ex1_ex2_data_pa_q;
-  logic [31:0] ex2_mem_data_pa_q;
+  // PA pipeline: dTLB lookup runs at MEM1 (consuming ex2_mem1_q.alu_result as
+  // VA), the translated PA is registered into mem1_mem2_q.dtlb_pa at the
+  // MEM1->MEM2 edge, and the LSU at MEM2 consumes mem1_mem2_q.dtlb_pa.
 
   // STAGE2: muldiv signals (64-bit)
   logic [kronos_pkg::XLEN-1:0] muldiv_result;
@@ -309,11 +305,14 @@ module kronos_top
   logic        muldiv_stall;
 
   // pre-registered CSR-select flag for EX forwarding mux.
-  // Stage 7a — split into two stages to track the producer landing in
-  // ex1_ex2_q (FWD_EX1 path) vs ex2_mem_q (FWD_EXMEM path).  Eliminates the
-  // 3-bit wb_sel compare from each forward case.
+  // CSR-typed-result tags chained through the EX1→EX2→MEM1→MEM2 boundaries.
+  // Each register samples (wb_sel == WB_CSR) at the upstream stage; the
+  // bypass mux reads the corresponding tag at FWD_EX1 / FWD_EXMEM     / FWD_MEM2
+  // to select between alu_result and csr_rdata. Eliminates a 3-bit wb_sel
+  // compare from each forward arm at the consumer.
   logic        ex1_ex2_csr_q;
   logic        ex2_mem_csr_q;
+  logic        mem1_mem2_csr_q;
   // Stage 7a — csr_new_val pipeline.  u_csr.csr_new_val_o is computed
   // combinationally from rr_ex1_q at the EX1 cycle.  The architectural CSR
   // commit happens at retire_i (mem_wb_q), so the value must be carried
@@ -327,11 +326,13 @@ module kronos_top
   // ACT4-s5 F-/D- test as bad fflags=0 vs expected NX/NV/etc.).
   logic [4:0]                  ex1_ex2_fflags_q;
   logic [4:0]                  ex2_mem_fflags_q;
+  logic [4:0]                  mem1_mem2_fflags_q;
   logic [4:0]                  mem_wb_fflags_q;
   // Stage 7a — FP-arith retire flag pipe so the CSR's fflags-accumulate gate
   // can fire only when the retiring instruction is an FP arithmetic op.
   logic                        ex1_ex2_is_fp_arith_q;
   logic                        ex2_mem_is_fp_arith_q;
+  logic                        mem1_mem2_is_fp_arith_q;
   logic                        mem_wb_is_fp_arith_q;
 
   // STAGE3: fetch control (icache replaces old FSM)
@@ -505,6 +506,7 @@ module kronos_top
   // correct post-write value.
   logic [kronos_pkg::XLEN-1:0] csr_new_val_post;
   logic [kronos_pkg::XLEN-1:0] ex2_mem_csr_new_val_q;
+  logic [kronos_pkg::XLEN-1:0] mem1_mem2_csr_new_val_q;
   logic [kronos_pkg::XLEN-1:0] mem_wb_csr_new_val_q;
 
   // Stage 7a — registered trap_cause / trap_tval / irq_cause / priv at the
@@ -520,7 +522,7 @@ module kronos_top
   logic [55:0] mem_wb_pmp_fetch_addr_q;
   logic [55:0] mem_wb_pmp_data_addr_q;
   // mem-cycle trap_cause / trap_tval combinational form (read at EX2→MEM
-  // boundary by the snapshot flop).  Computed from ex2_mem_q registered fields
+  // boundary by the snapshot flop).  Computed from ex2_mem1_q registered fields
   // + MEM-cycle producers — none of which read rr_ex1_q, so the trap context
   // tracks the trapping instruction even after the pipeline advances.
   logic [31:0] mem_trap_cause_d;
@@ -670,10 +672,17 @@ module kronos_top
     .ex1_ex2_rd_fp_i    (ex1_ex2_q.dec.rd_fp),
     .ex1_ex2_is_load_i  (ex1_ex2_q.dec.wb_sel == WB_MEM),
     .ex1_ex2_valid_i    (ex1_ex2_q.valid),
-    // MEM producer (ex2_mem_q) — oldest source.  Loads OK via wb_result_64.
-    .ex2_mem_rd_i       (ex2_mem_q.dec.rd),
-    .ex2_mem_rd_wen_i   (ex2_mem_q.dec.rd_wen & ex2_mem_q.valid),
-    .ex2_mem_rd_fp_i    (ex2_mem_q.dec.rd_fp),
+    // MEM1 producer (ex2_mem1_q).  No load-suppression here: a load producer
+    // in MEM1 at ID-time T becomes the MEM2 producer at consumer-RR-time T+1,
+    // and FWD_MEM2 picks lsu_rdata combinationally for that case.
+    .ex2_mem1_rd_i      (ex2_mem1_q.dec.rd),
+    .ex2_mem1_rd_wen_i  (ex2_mem1_q.dec.rd_wen),
+    .ex2_mem1_rd_fp_i   (ex2_mem1_q.dec.rd_fp),
+    .ex2_mem1_valid_i   (ex2_mem1_q.valid),
+    // MEM2 producer (mem1_mem2_q) — load value combinational via lsu_rdata.
+    .mem1_mem2_rd_i     (mem1_mem2_q.dec.rd),
+    .mem1_mem2_rd_wen_i (mem1_mem2_q.dec.rd_wen & mem1_mem2_q.valid),
+    .mem1_mem2_rd_fp_i  (mem1_mem2_q.dec.rd_fp),
     .fwd_rs1_sel_o      (fwd_rs1_sel),
     .fwd_rs2_sel_o      (fwd_rs2_sel)
   );
@@ -715,7 +724,7 @@ module kronos_top
   // including mem_stall would form a combinational loop.
   // Stage 7a — detect FENCE.I from ex1_ex2_q (EX2) rather than rr_ex1_q (EX1).
   // The EX1/EX2 split moves the SW one cycle further from dcache_req issue
-  // (which fires from MEM = ex2_mem_q).  If we triggered from EX1, FENCE.I
+  // (which fires from MEM = ex2_mem1_q).  If we triggered from EX1, FENCE.I
   // would be one cycle ahead of the dirtying SW's dcache_req cycle and
   // dcache_dirty_pending would still be 0 — so fence_i_pulse would fire
   // immediately and the SW's bytes would not yet be in AXI memory by the
@@ -768,8 +777,8 @@ module kronos_top
                                (id_dec.rs2_fp & (id_dec.rs2 == rr_ex1_q.dec.rd)) |
                                (id_dec.rs3_fp & (id_dec.rs3 == rr_ex1_q.dec.rd)));
 
-  assign jalr_fwd_event = id_dec.is_jalr & ex2_mem_q.valid & ex2_mem_q.dec.rd_wen
-                         & (ex2_mem_q.dec.rd != 5'd0) & (id_dec.rs1 == ex2_mem_q.dec.rd);
+  assign jalr_fwd_event = id_dec.is_jalr & ex2_mem1_q.valid & ex2_mem1_q.dec.rd_wen
+                         & (ex2_mem1_q.dec.rd != 5'd0) & (id_dec.rs1 == ex2_mem1_q.dec.rd);
 
   // Non-muldiv stall sources that hazard must observe with absolute priority
   // (bus/FPU/fetch can't be abandoned mid-flight by a redirect).  muldiv_stall
@@ -777,7 +786,7 @@ module kronos_top
   //
   // a dTLB miss for an EX-stage load/store/AMO must freeze the
   // pipeline.  The dTLB lookup happens in EX (against rr_ex1_q) but the LSU
-  // fires in MEM (against ex2_mem_q).  Without this stall, the missing access
+  // fires in MEM (against ex2_mem1_q).  Without this stall, the missing access
   // would advance to MEM with a stale ex2_mem_data_pa_q (captured before the
   // PTW completed) and complete via the dcache before ptw_pf could fire.
   //
@@ -791,8 +800,8 @@ module kronos_top
   // to issue the AR while tlb_miss_i is high, so align_instr_valid stays
   // low until the PTW refills).
   assign combined_stall_no_muldiv = mem_stall | instr_fetch_stall | fpu_stall
-                                  | (rr_ex1_q.valid & dtlb_miss &
-                                     ~load_page_fault & ~store_page_fault);
+                                  | (ex2_mem1_q.valid & dtlb_miss &
+                                     ~mem1_load_page_fault & ~mem1_store_page_fault);
   assign combined_stall    = combined_stall_no_muldiv | muldiv_stall;
 
   // FRM/FCSR RAW hazard: a CSR write to FRM/FCSR in EX will update fcsr_q at
@@ -836,11 +845,17 @@ module kronos_top
     .ex1_ex2_rd_i          (ex1_ex2_q.dec.rd),
     .ex1_ex2_rd_wen_i      (ex1_ex2_q.dec.rd_wen),
     .ex1_ex2_valid_i       (ex1_ex2_q.valid),
-    // MEM producer (ex2_mem_q).
-    .ex_mem_rd_i           (ex2_mem_q.dec.rd),
-    .ex_mem_rd_wen_i       (ex2_mem_q.dec.rd_wen & ex2_mem_q.valid),
-    .ex_mem_valid_i        (ex2_mem_q.valid),
-    .ex_mem_is_csr_i       (ex2_mem_q.dec.is_csr),
+    // MEM1 producer (ex2_mem1_q).
+    .ex2_mem1_is_load_i    (ex2_mem1_q.dec.is_load),
+    .ex2_mem1_is_fp_load_i (ex2_mem1_q.dec.fp_load),
+    .ex2_mem1_is_csr_i     (ex2_mem1_q.dec.is_csr),
+    .ex2_mem1_rd_i         (ex2_mem1_q.dec.rd),
+    .ex2_mem1_rd_wen_i     (ex2_mem1_q.dec.rd_wen & ex2_mem1_q.valid),
+    .ex2_mem1_valid_i      (ex2_mem1_q.valid),
+    // MEM2 producer (mem1_mem2_q).
+    .mem1_mem2_is_csr_i    (mem1_mem2_q.dec.is_csr),
+    .mem1_mem2_rd_i        (mem1_mem2_q.dec.rd),
+    .mem1_mem2_valid_i     (mem1_mem2_q.valid),
     // ID-stage register addresses.
     .if_id_rs1_used_i      (id_dec.rs1_used),
     .if_id_rs1_i           (id_dec.rs1),
@@ -869,11 +884,17 @@ module kronos_top
     .if_id_en_o            (if_id_en),
     .id_rr_en_o            (id_rr_en),
     .rr_ex1_en_o           (rr_ex1_en),
-    .ex_mem_en_o           (ex2_mem_en),
+    .ex2_mem1_en_o         (ex2_mem1_en),
+    .mem1_mem2_en_o        (mem1_mem2_en),
     .mem_wb_en_o           (mem_wb_en),
     .if_id_flush_o         (if_id_flush),
     .id_rr_flush_o         (id_rr_flush),
-    .rr_ex1_flush_o        (rr_ex1_flush)
+    .rr_ex1_flush_o        (rr_ex1_flush),
+    // ex2_mem1_flush / mem1_mem2_flush are driven by kronos_top assigns from
+    // mem_redirect_q | mem_redirect_d (see lines below).  hazard's flush
+    // outputs for these stages are always 0 and intentionally unconnected.
+    .ex2_mem1_flush_o      (),
+    .mem1_mem2_flush_o     ()
   );
 
   kronos_alu u_alu (
@@ -987,7 +1008,7 @@ module kronos_top
     // Zicntr: pulse once per retired instruction.  Count at the EX→MEM
     // transition so the count is visible to a csrrc-instret two instructions
     // later (matches the SAIL reference-model semantics used by ACT4).
-    .instret_retire_i (ex2_mem_en & rr_ex1_q.valid & ~combined_stall),
+    .instret_retire_i (ex2_mem1_en & rr_ex1_q.valid & ~combined_stall),
     .event_bus_i      (event_bus),
     // Stage 5h
     .trig_csr_rdata_i (trig_csr_rdata),
@@ -1072,7 +1093,7 @@ module kronos_top
   // edge-triggered traps in the trap_taken_pulse).
   // -------------------------------------------------------------------------
   always_comb begin
-    unique case (rr_ex1_q.dec.mem_funct3)
+    unique case (ex2_mem1_q.dec.mem_funct3)
       3'b000:  pmp_data_size = 3'd0; // LB / SB
       3'b001:  pmp_data_size = 3'd1; // LH / SH
       3'b010:  pmp_data_size = 3'd2; // LW / SW / FLW / FSW
@@ -1143,72 +1164,53 @@ module kronos_top
     // valid_i must NOT depend on combined_stall.  combined_stall includes
     // mem_stall, which depends on lsu_mem_stall, which depends on pmp_fault_i
     // (suppressed by lsu when pmp_fault_i is high) — gating valid_i on
-    // ~combined_stall would close a comb loop pmp_fault → mem_stall →
-    // combined_stall → valid_i → pmp_fault.  The fault flag is meaningful
-    // whenever a load/store sits in EX; the trap path gates trap_i with
+    // ~combined_stall would close a comb loop pmp_fault -> mem_stall ->
+    // combined_stall -> valid_i -> pmp_fault.  The fault flag is meaningful
+    // whenever a load/store sits in MEM1; the trap path gates trap_i with
     // ~combined_stall so the trap only fires when the pipeline advances.
-    .valid_i      (rr_ex1_q.valid &
-                   (rr_ex1_q.dec.is_load | rr_ex1_q.dec.is_store |
-                    rr_ex1_q.dec.is_amo)),
-    // alu_result is the (rs1+imm) memory address before the EX/MEM register.
-    .addr_i       ({24'b0, alu_result[31:0]}),
+    .valid_i      (ex2_mem1_q.valid &
+                   (ex2_mem1_q.dec.is_load | ex2_mem1_q.dec.is_store |
+                    ex2_mem1_q.dec.is_amo)),
+    // PMP runs against the dTLB-translated PA at MEM1 (eff_data_pa).  Under
+    // Bare/M-mode translation eff_data_pa == ex2_mem1_q.alu_result[31:0].
+    .addr_i       ({24'b0, eff_data_pa[31:0]}),
     .size_i       (pmp_data_size),
     .is_fetch_i   (1'b0),
-    .is_load_i    (rr_ex1_q.dec.is_load |
-                   (rr_ex1_q.dec.is_amo & rr_ex1_q.dec.is_lr)),
-    .is_store_i   (rr_ex1_q.dec.is_store |
-                   (rr_ex1_q.dec.is_amo & ~rr_ex1_q.dec.is_lr)),
+    .is_load_i    (ex2_mem1_q.dec.is_load |
+                   (ex2_mem1_q.dec.is_amo & ex2_mem1_q.dec.is_lr)),
+    .is_store_i   (ex2_mem1_q.dec.is_store |
+                   (ex2_mem1_q.dec.is_amo & ~ex2_mem1_q.dec.is_lr)),
     .fault_o      (pmp_data_fault_raw),
     .fault_addr_o (pmp_data_fault_addr_raw)
   );
 
-  // Issue #97 — pmp_data_fault back-edge cut.  The synth report on KV260
-  // shows pmp_data_fault_raw → pmp_data_fault → DTLB FSM → dcache_req
-  // → PTW state → mem_wb_q.lsu_rdata as a single 35-logic-level cone with
-  // the ~110-bit PMP region-match comparator dominating the levels.  Flop
-  // the gated output and the address snapshot; downstream consumers
-  // (LSU's pmp_fault_i, dcache_early_req_valid, trap_i / trap_cause /
-  // trap_tval) read the registered version.  trap timing shifts by one
-  // cycle on faulting load/store, matching the existing convention for
-  // dcache_bus_err_fault (also a MEM-stage fault read off rr_ex1_q.pc).
-  // Stage 7a — gate the register on ex1_ex2_en (~combined_stall) so the
-  // s1 fault tracks the instruction transitioning EX1→EX2.  Without the gate,
-  // a mem_stall on a faulting earlier load/store would let pmp_data_fault_raw
-  // keep latching for the later instruction in rr_ex1_q each cycle the stall
-  // holds; when the stall releases, the held instruction in ex1_ex2_q would
-  // pick up the later instruction's fault as its own ex2_fault_d (test
-  // sw/stage6/test_pmp_basic — the LUI(0x50) in ex1_ex2_q inherited the
-  // SW(0x52)'s pmp_data_fault and trapped with cause=3 instead of 7).
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      pmp_s1_data_fault_q      <= 1'b0;
-      pmp_s1_data_fault_addr_q <= 56'h0;
-    end else if (ex1_ex2_en) begin
-      pmp_s1_data_fault_q      <= pmp_data_fault_raw & pmp_any_active;
-      pmp_s1_data_fault_addr_q <= pmp_data_fault_addr_raw;
-    end
-  end
+  // pmp_data_fault / pmp_data_fault_addr are produced live at MEM1 by
+  // u_pmp_data and consumed combinationally at the MEM1->MEM2 register edge,
+  // where they are flopped into mem1_mem2_q.fault.pmp_data_fault.  The 7b
+  // pmp_s1_data_fault_q snapshot is no longer needed: the MEM1->MEM2 register
+  // itself provides the flop barrier that breaks the post-PMP combinational
+  // cone into the dcache hit-mux.
+  assign pmp_data_fault      = pmp_data_fault_raw & pmp_any_active;
+  assign pmp_data_fault_addr = pmp_data_fault_addr_raw;
 
-  assign pmp_data_fault      = pmp_s1_data_fault_q;
-  assign pmp_data_fault_addr = pmp_s1_data_fault_addr_q;
-
-  // PMA AMO-on-NC trap detection at EX stage (PMP-style).
-  // The dcache also exports amo_nc_fault_o, but that fires at MEM stage —
-  // by then rr_ex1_q has advanced to the next instruction, so trap_cause /
-  // mepc would be sourced from the wrong pipeline register. Detecting here
-  // at EX (rr_ex1_q + alu_result) ensures the offending instruction is in
-  // rr_ex1_q at trap time, matching how pmp_data_fault is wired.
+  // PMA AMO-on-NC trap detection at MEM1 stage.  The check runs against the
+  // dTLB-translated PA (eff_data_pa) so PMA decisions follow PMP — both work
+  // off the same translated address.  Registered into
+  // mem1_mem2_q.fault.ex_amo_nc_fault at the MEM1->MEM2 edge.
   always_comb begin
-    ex_addr_uncacheable = 1'b0;
+    mem1_addr_uncacheable = 1'b0;
     for (int r = 0; r < NUM_NC_REGIONS; r++) begin
-      if (({32'b0, alu_result[31:0]} >= NC_REGION_BASE[r]) &&
-          ({32'b0, alu_result[31:0]} <= NC_REGION_LIMIT[r]))
-        ex_addr_uncacheable = 1'b1;
+      if (({32'b0, eff_data_pa[31:0]} >= NC_REGION_BASE[r]) &&
+          ({32'b0, eff_data_pa[31:0]} <= NC_REGION_LIMIT[r])) begin
+        mem1_addr_uncacheable = 1'b1;
+      end
     end
   end
-  assign ex_amo_nc_fault = rr_ex1_q.valid &
-                           (rr_ex1_q.dec.is_amo | rr_ex1_q.dec.is_lr | rr_ex1_q.dec.is_sc) &
-                           ex_addr_uncacheable;
+  assign mem1_amo_nc_fault = ex2_mem1_q.valid &
+                             (ex2_mem1_q.dec.is_amo |
+                              ex2_mem1_q.dec.is_lr |
+                              ex2_mem1_q.dec.is_sc) &
+                             mem1_addr_uncacheable;
 
 
   // -------------------------------------------------------------------------
@@ -1284,27 +1286,28 @@ module kronos_top
   // and refills the dTLB with the updated entry.  kronos_tlb invalidates
   // matching entries on refill so the stale A=1/D=0 line cannot keep
   // answering lookups at a lower index.
-  assign dtlb_miss = translate_data & rr_ex1_q.valid &
-                     (rr_ex1_q.dec.is_load | rr_ex1_q.dec.is_store | rr_ex1_q.dec.is_amo) &
+  // dtlb_miss now forms in MEM1 cycle (the dTLB lookup runs against
+  // ex2_mem1_q.alu_result as VA).  PTW kicks off from this MEM1 miss signal.
+  assign dtlb_miss = translate_data & ex2_mem1_q.valid &
+                     (ex2_mem1_q.dec.is_load | ex2_mem1_q.dec.is_store |
+                      ex2_mem1_q.dec.is_amo) &
                      ((~dtlb_hit & ~dtlb_perm_fail) | dtlb_a_zero | dtlb_d_zero);
 
   // PA muxes — when translation is off (Bare or M-mode), forward the original
   // virtual address as-is (the architectural PA == VA).  Otherwise use the
-  // TLB lookup output.  Stage 6b keeps a 32-bit physical address space, so
-  // we slice the low 32 bits off the 56-bit TLB output.
+  // TLB lookup output.  eff_data_pa is a MEM1-cycle wire: it consumes
+  // ex2_mem1_q.alu_result (the registered VA) and the live dTLB output.
   assign eff_fetch_pa = translate_fetch ? itlb_pa[31:0] : icache_fetch_addr;
-  assign eff_data_pa  = translate_data  ? dtlb_pa[31:0] : alu_result[31:0];
+  assign eff_data_pa  = translate_data  ? dtlb_pa[31:0] : ex2_mem1_q.alu_result[31:0];
 
-  // Stage 7a — dcache pre-launch fires from EX2 so ram_rdata is registered
-  // exactly when the MEM-stage LSU consumes it.  Pre-launching from EX1 (one
-  // stage too early) lets a follower mem op overwrite ram_rdata before the
-  // earlier load reads it — the SD;LD round-trip in test_64bit_loadstore.
-  // The address comes from ex1_ex2_data_pa_q (EX1-live PA registered into
-  // the EX1→EX2 boundary) so it tracks the EX2-stage instruction.
-  assign dcache_early_addr = {{(64-32){1'b0}}, ex1_ex2_data_pa_q};
+  // dcache pre-launch fires from MEM1 (VIPT, VA-indexed): set + offset = 12
+  // bits <= page-offset width, so the dcache index is alias-free under any
+  // translation.  The BRAM ram_rdata is registered at the MEM1->MEM2 boundary
+  // so MEM2 consumes a flop output for the way-mux + load_data_full chain.
+  assign dcache_early_addr = {{(64-32){1'b0}}, ex2_mem1_q.alu_result[31:0]};
   assign dcache_early_req_valid =
-    ex1_ex2_q.valid &
-    (ex1_ex2_q.dec.is_load | ex1_ex2_q.dec.is_store | ex1_ex2_q.dec.is_amo);
+    ex2_mem1_q.valid &
+    (ex2_mem1_q.dec.is_load | ex2_mem1_q.dec.is_store | ex2_mem1_q.dec.is_amo);
 
   // itlb_perm_fail back-edge cut.  itlb_perm_fail is gated inside u_itlb by
   // lookup_valid_i = translate_fetch & align_needs_fetch, and the latter is
@@ -1335,27 +1338,42 @@ module kronos_top
   // kronos_align gates cross_page_fault_o on translate_fetch_i, so this signal
   // is automatically zero in M-mode / Bare and only fires under active
   // translation.
-  assign instr_page_fault = itlb_s1_perm_fail_q |
-                            (ptw_pf & (ptw_pf_which == TLB_FETCH)) |
-                            cross_page_fault;
-  assign load_page_fault  = (dtlb_perm_fail | (ptw_pf & (ptw_pf_which == TLB_LOAD))) &
-                            rr_ex1_q.dec.is_load;
-  assign store_page_fault = (dtlb_perm_fail | (ptw_pf & (ptw_pf_which == TLB_STORE))) &
-                            (rr_ex1_q.dec.is_store | rr_ex1_q.dec.is_amo);
+  // instr_page_fault stays an iTLB-driven fetch-side signal (no dTLB / MEM1
+  // dependency).  load_page_fault and store_page_fault are now MEM1-cycle
+  // producers that consume the registered ex2_mem1_q opcode + the live MEM1
+  // dTLB perm-fail / PTW page-fault, and land in
+  // mem1_mem2_q.fault.{load,store}_page_fault at the MEM1->MEM2 edge.
+  assign instr_page_fault     = itlb_s1_perm_fail_q |
+                                (ptw_pf & (ptw_pf_which == TLB_FETCH)) |
+                                cross_page_fault;
+  assign mem1_load_page_fault =
+      (dtlb_perm_fail | (ptw_pf & (ptw_pf_which == TLB_LOAD))) &
+      ex2_mem1_q.dec.is_load;
+  assign mem1_store_page_fault =
+      (dtlb_perm_fail | (ptw_pf & (ptw_pf_which == TLB_STORE))) &
+      (ex2_mem1_q.dec.is_store | ex2_mem1_q.dec.is_amo);
+  // Legacy combinational aliases of the MEM1-produced page-fault bits.  Kept
+  // as wires so legacy consumers (mem_trap_cause_d / ex1_trap_cause read
+  // sites that are being routed to mem1_mem2_q.fault.*) still resolve until
+  // the corresponding sites switch to the registered fault aggregate.
+  assign load_page_fault  = mem1_load_page_fault;
+  assign store_page_fault = mem1_store_page_fault;
 
-  // STAGE5f: 64-bit LSU — thin adapter to kronos_dcache.
+  // STAGE5f: 64-bit LSU — thin adapter to kronos_dcache.  Runs at MEM2: every
+  // input comes from the mem1_mem2_q register.  PA is mem1_mem2_q.dtlb_pa
+  // (registered at the MEM1->MEM2 edge from the MEM1-stage dTLB output, or
+  // from ex2_mem1_q.alu_result[31:0] under translation-off).
   kronos_lsu u_lsu (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),
-    .req_i              (ex2_mem_q.valid & (ex2_mem_q.dec.is_load | ex2_mem_q.dec.is_store
-                         | ex2_mem_q.dec.is_amo) & ~mem_done_q),
-    // PMP data-port permission-violation flag.  Suppresses dcache
-    // request issue and the AMO request when high.  Stage 7a: the live
-    // pmp_data_fault tracks the EX1-stage instruction (one cycle behind
-    // the LSU's MEM-stage view); read the registered ex2_mem_q.fault bit
-    // captured at the EX1→EX2 boundary so the LSU sees the fault for the
-    // store currently in MEM.
-    .pmp_fault_i        (ex2_mem_q.fault.pmp_data_fault),
+    .req_i              (mem1_mem2_q.valid & (mem1_mem2_q.dec.is_load |
+                         mem1_mem2_q.dec.is_store | mem1_mem2_q.dec.is_amo)
+                         & ~mem_done_q),
+    // PMP data-port permission-violation flag.  The MEM1->MEM2 register
+    // captures pmp_data_fault into mem1_mem2_q.fault.pmp_data_fault, so the
+    // LSU at MEM2 reads a flop output that breaks the dTLB+PMP -> dcache
+    // hit-mux + load_data_full cone (master spec §1).
+    .pmp_fault_i        (mem1_mem2_q.fault.pmp_data_fault),
     // dcache-raised faults — AMO to non-cacheable region and AXI
     // bus error.  Both suppress the dcache request and unstall the pipeline
     // so the trap can be taken immediately (mirrors the PMP-fault pattern).
@@ -1364,28 +1382,27 @@ module kronos_top
     // dTLB miss indicator — LSU stalls and suppresses dcache issue
     // until the PTW refills the dTLB and the access is replayed.
     .tlb_miss_i         (dtlb_miss),
-    .we_i               (ex2_mem_q.dec.is_store | ex2_mem_q.dec.fp_store),
-    // addr_i is the translated PA when satp.MODE != Bare and the
-    // effective priv is not M; otherwise PA == VA (alu_result).  Captured at
-    // the EX→MEM boundary by ex2_mem_data_pa_q.
-    .addr_i             (ex2_mem_data_pa_q),
-    .wdata_i            (ex2_mem_q.rs2_data),
-    .funct3_i           (ex2_mem_q.dec.mem_funct3),
+    .we_i               (mem1_mem2_q.dec.is_store | mem1_mem2_q.dec.fp_store),
+    // addr_i is the translated PA from the MEM1-stage dTLB lookup,
+    // registered into mem1_mem2_q.dtlb_pa at the MEM1->MEM2 edge.
+    .addr_i             (mem1_mem2_q.dtlb_pa),
+    .wdata_i            (mem1_mem2_q.rs2_data),
+    .funct3_i           (mem1_mem2_q.dec.mem_funct3),
     .rdata_o            (lsu_rdata),
     .valid_o            (lsu_valid),
     .mem_stall_o        (lsu_mem_stall),
     // FP load/store ports
-    .fp_dest_req_i      (ex2_mem_q.valid &
-                         (ex2_mem_q.dec.fp_load | ex2_mem_q.dec.fp_store) & ~mem_done_q),
-    .fp_store_data_i    (ex2_mem_q.rs2_data),
+    .fp_dest_req_i      (mem1_mem2_q.valid &
+                         (mem1_mem2_q.dec.fp_load | mem1_mem2_q.dec.fp_store) & ~mem_done_q),
+    .fp_store_data_i    (mem1_mem2_q.rs2_data),
     .fp_dest_rsp_o      (lsu_fp_dest),
     .fp_rdata_o         (lsu_fp_rdata),
     // A-extension
-    .is_lr_i            (ex2_mem_q.dec.is_lr),
-    .is_sc_i            (ex2_mem_q.dec.is_sc),
-    .is_amo_i           (ex2_mem_q.dec.is_amo),
-    .amo_funct5_i       (ex2_mem_q.dec.amo_funct5),
-    .amo_src_i          (ex2_mem_q.rs2_data),
+    .is_lr_i            (mem1_mem2_q.dec.is_lr),
+    .is_sc_i            (mem1_mem2_q.dec.is_sc),
+    .is_amo_i           (mem1_mem2_q.dec.is_amo),
+    .amo_funct5_i       (mem1_mem2_q.dec.amo_funct5),
+    .amo_src_i           (mem1_mem2_q.rs2_data),
     // sc_success_o is just dcache_sc_success_i echoed back; the LSU also
     // packs it into rdata_o (~success) so the standalone output is unused.
     .sc_success_o       (lsu_sc_success_unused),
@@ -1499,23 +1516,24 @@ module kronos_top
   );
 
   // -------------------------------------------------------------------------
-  // Data TLB.  Symmetric to u_itlb but on the LSU data port.  The VA
-  // is alu_result (rs1 + imm computed in EX) so the lookup happens in the same
-  // cycle as the ALU compute, before the EX→MEM register captures the PA.
+  // Data TLB.  Symmetric to u_itlb but on the LSU data port.  Runs in MEM1:
+  // the VA is ex2_mem1_q.alu_result (rs1 + imm registered into ex2_mem1_q at
+  // the EX2->MEM1 edge); the translated PA is registered into
+  // mem1_mem2_q.dtlb_pa for the LSU at MEM2.
   // -------------------------------------------------------------------------
   kronos_tlb #(.N(8)) u_dtlb (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),
-    .lookup_valid_i     (translate_data & rr_ex1_q.valid &
-                         (rr_ex1_q.dec.is_load | rr_ex1_q.dec.is_store |
-                          rr_ex1_q.dec.is_amo)),
-    .lookup_va_i        (alu_result),
+    .lookup_valid_i     (translate_data & ex2_mem1_q.valid &
+                         (ex2_mem1_q.dec.is_load | ex2_mem1_q.dec.is_store |
+                          ex2_mem1_q.dec.is_amo)),
+    .lookup_va_i        (ex2_mem1_q.alu_result),
     .lookup_asid_i      (satp_asid),
     .lookup_priv_i      (eff_priv_data),
-    .is_load_i          (rr_ex1_q.dec.is_load |
-                         (rr_ex1_q.dec.is_amo & rr_ex1_q.dec.is_lr)),
-    .is_store_i         (rr_ex1_q.dec.is_store |
-                         (rr_ex1_q.dec.is_amo & ~rr_ex1_q.dec.is_lr)),
+    .is_load_i          (ex2_mem1_q.dec.is_load |
+                         (ex2_mem1_q.dec.is_amo & ex2_mem1_q.dec.is_lr)),
+    .is_store_i         (ex2_mem1_q.dec.is_store |
+                         (ex2_mem1_q.dec.is_amo & ~ex2_mem1_q.dec.is_lr)),
     .is_fetch_i         (1'b0),
     .sum_i              (mstatus[18]),
     .mxr_i              (mstatus[19]),
@@ -1632,7 +1650,7 @@ module kronos_top
       end
 
       // Clear dispatch guard when EX advances (instruction leaves EX)
-      if (ex2_mem_en & ~combined_stall) begin
+      if (ex2_mem1_en & ~combined_stall) begin
         fpu_dispatched_q <= 1'b0;
       end
 
@@ -1673,10 +1691,11 @@ module kronos_top
     fp_wa = 5'b0;
     fp_wd = {kronos_pkg::FLEN{1'b0}};
 
-    if (lsu_valid & ex2_mem_q.valid & ex2_mem_q.dec.fp_load) begin
-      // FP load: write NaN-boxed data directly
+    if (lsu_valid & mem1_mem2_q.valid & mem1_mem2_q.dec.fp_load) begin
+      // FP load completes at MEM2 (the LSU runs at MEM2): write NaN-boxed
+      // data into the FP regfile from the MEM2-stage instruction.
       fp_we = 1'b1;
-      fp_wa = ex2_mem_q.dec.rd;
+      fp_wa = mem1_mem2_q.dec.rd;
       fp_wd = lsu_fp_rdata;
     end else if (mem_wb_q.valid & mem_wb_q.dec.is_fp &
                  mem_wb_q.dec.rd_fp & ~mem_wb_q.dec.fp_load) begin
@@ -1705,7 +1724,7 @@ module kronos_top
   // direction-mispredict redirect target is the EX1-stage `ex_pc_d` registered
   // alongside the fault bit into `ex_redirect_target_q`.  The MEM-stage
   // redirect target is captured into `mem_redirect_target_q` at the same
-  // edge.  ex1_ex2_q.ex_pc_d / ex2_mem_q.pc_d are NOT safe to read here:
+  // edge.  ex1_ex2_q.ex_pc_d / ex2_mem1_q.pc_d are NOT safe to read here:
   // both registers advance on the same edge that asserts the redirect, so
   // their fields hold the next-instruction target by the time _q is high.
   assign redirect_load   = mem_redirect_q | ex_redirect_q |
@@ -2007,8 +2026,8 @@ module kronos_top
   always_comb begin
     if      (fp_result_avail & fp_tag_cur.fp_dest & (fp_tag_cur.rd == id_rr_q.dec.rs1))
       fp_rs1_sel = 2'd0;
-    else if (ex2_mem_q.valid & ex2_mem_q.dec.is_fp & ex2_mem_q.dec.rd_fp &
-             ~ex2_mem_q.dec.fp_load & (ex2_mem_q.dec.rd == id_rr_q.dec.rs1))
+    else if (ex2_mem1_q.valid & ex2_mem1_q.dec.is_fp & ex2_mem1_q.dec.rd_fp &
+             ~ex2_mem1_q.dec.fp_load & (ex2_mem1_q.dec.rd == id_rr_q.dec.rs1))
       fp_rs1_sel = 2'd1;
     else if (fp_we & (fp_wa == id_rr_q.dec.rs1))
       fp_rs1_sel = 2'd2;
@@ -2018,7 +2037,7 @@ module kronos_top
   always_comb begin
     unique case (fp_rs1_sel)
       2'd0:    fp_rs1_data_rr = fp_result_cur;
-      2'd1:    fp_rs1_data_rr = ex2_mem_q.alu_result;
+      2'd1:    fp_rs1_data_rr = ex2_mem1_q.alu_result;
       2'd2:    fp_rs1_data_rr = fp_wd;
       default: fp_rs1_data_rr = fp_rd1;
     endcase
@@ -2027,8 +2046,8 @@ module kronos_top
   always_comb begin
     if      (fp_result_avail & fp_tag_cur.fp_dest & (fp_tag_cur.rd == id_rr_q.dec.rs2))
       fp_rs2_sel = 2'd0;
-    else if (ex2_mem_q.valid & ex2_mem_q.dec.is_fp & ex2_mem_q.dec.rd_fp &
-             ~ex2_mem_q.dec.fp_load & (ex2_mem_q.dec.rd == id_rr_q.dec.rs2))
+    else if (ex2_mem1_q.valid & ex2_mem1_q.dec.is_fp & ex2_mem1_q.dec.rd_fp &
+             ~ex2_mem1_q.dec.fp_load & (ex2_mem1_q.dec.rd == id_rr_q.dec.rs2))
       fp_rs2_sel = 2'd1;
     else if (fp_we & (fp_wa == id_rr_q.dec.rs2))
       fp_rs2_sel = 2'd2;
@@ -2038,7 +2057,7 @@ module kronos_top
   always_comb begin
     unique case (fp_rs2_sel)
       2'd0:    fp_rs2_data_rr = fp_result_cur;
-      2'd1:    fp_rs2_data_rr = ex2_mem_q.alu_result;
+      2'd1:    fp_rs2_data_rr = ex2_mem1_q.alu_result;
       2'd2:    fp_rs2_data_rr = fp_wd;
       default: fp_rs2_data_rr = fp_rd2;
     endcase
@@ -2047,8 +2066,8 @@ module kronos_top
   always_comb begin
     if      (fp_result_avail & fp_tag_cur.fp_dest & (fp_tag_cur.rd == id_rr_q.dec.rs3))
       fp_rs3_sel = 2'd0;
-    else if (ex2_mem_q.valid & ex2_mem_q.dec.is_fp & ex2_mem_q.dec.rd_fp &
-             ~ex2_mem_q.dec.fp_load & (ex2_mem_q.dec.rd == id_rr_q.dec.rs3))
+    else if (ex2_mem1_q.valid & ex2_mem1_q.dec.is_fp & ex2_mem1_q.dec.rd_fp &
+             ~ex2_mem1_q.dec.fp_load & (ex2_mem1_q.dec.rd == id_rr_q.dec.rs3))
       fp_rs3_sel = 2'd1;
     else if (fp_we & (fp_wa == id_rr_q.dec.rs3))
       fp_rs3_sel = 2'd2;
@@ -2058,7 +2077,7 @@ module kronos_top
   always_comb begin
     unique case (fp_rs3_sel)
       2'd0:    fp_rs3_data_rr = fp_result_cur;
-      2'd1:    fp_rs3_data_rr = ex2_mem_q.alu_result;
+      2'd1:    fp_rs3_data_rr = ex2_mem1_q.alu_result;
       2'd2:    fp_rs3_data_rr = fp_wd;
       default: fp_rs3_data_rr = fp_rd3;
     endcase
@@ -2090,21 +2109,29 @@ module kronos_top
   //                  muldiv_result vs alu_result so MUL/DIV producers bypass
   //                  through the same path.
   //   FWD_EX1     : ex1_ex2_q.alu_result (or csr_rdata when CSR-typed).
-  //   FWD_EXMEM   : ex2_mem_q.alu_result (or csr_rdata when CSR-typed).
+  //   FWD_EXMEM        : ex2_mem1_q.alu_result (or csr_rdata when CSR-typed).
+  //   FWD_MEM2    : mem1_mem2_q.alu_result (CSR-typed → csr_rdata; loads →
+  //                 lsu_rdata combinationally from the dcache hit-mux).
   //   FWD_MEMWB   : wb_result_64 (writeback mux output).
   //   default     : RR-cycle source (FP mux or int regfile/WB-bypass mux).
   always_comb begin
     unique case (id_rr_q.fwd_rs1_sel)
       FWD_EX1_NOW: rs1_bypassed = ex_result;
-      FWD_EX1:     rs1_bypassed = ex1_ex2_csr_q ? ex1_ex2_q.csr_rdata : ex1_ex2_q.alu_result;
-      FWD_EXMEM:   rs1_bypassed = ex2_mem_csr_q ? ex2_mem_q.csr_rdata : ex2_mem_q.alu_result;
+      FWD_EX1:     rs1_bypassed = ex1_ex2_csr_q  ? ex1_ex2_q.csr_rdata  : ex1_ex2_q.alu_result;
+      FWD_EXMEM:    rs1_bypassed = ex2_mem_csr_q  ? ex2_mem1_q.csr_rdata : ex2_mem1_q.alu_result;
+      FWD_MEM2:    rs1_bypassed = mem1_mem2_q.dec.is_load ? lsu_rdata
+                                : (mem1_mem2_csr_q ? mem1_mem2_q.csr_rdata
+                                                   : mem1_mem2_q.alu_result);
       FWD_MEMWB:   rs1_bypassed = wb_result_64;
       default:     rs1_bypassed = rs1_data_rr;
     endcase
     unique case (id_rr_q.fwd_rs2_sel)
       FWD_EX1_NOW: rs2_bypassed = ex_result;
-      FWD_EX1:     rs2_bypassed = ex1_ex2_csr_q ? ex1_ex2_q.csr_rdata : ex1_ex2_q.alu_result;
-      FWD_EXMEM:   rs2_bypassed = ex2_mem_csr_q ? ex2_mem_q.csr_rdata : ex2_mem_q.alu_result;
+      FWD_EX1:     rs2_bypassed = ex1_ex2_csr_q  ? ex1_ex2_q.csr_rdata  : ex1_ex2_q.alu_result;
+      FWD_EXMEM:    rs2_bypassed = ex2_mem_csr_q  ? ex2_mem1_q.csr_rdata : ex2_mem1_q.alu_result;
+      FWD_MEM2:    rs2_bypassed = mem1_mem2_q.dec.is_load ? lsu_rdata
+                                : (mem1_mem2_csr_q ? mem1_mem2_q.csr_rdata
+                                                   : mem1_mem2_q.alu_result);
       FWD_MEMWB:   rs2_bypassed = wb_result_64;
       default:     rs2_bypassed = rs2_data_rr;
     endcase
@@ -2197,44 +2224,44 @@ module kronos_top
   // "translate first, then access-check" — a missing/perm-failed translation
   // produces a page-fault even if the translated PA would also fail PMP.
   always_comb begin
-    if (ex2_mem_q.fault.trig_hit) begin
+    if (mem1_mem2_q.fault.trig_hit) begin
       mem_trap_cause_d = 32'd3;                                              // BREAKPOINT (Sdtrig)
-    end else if (instr_page_fault) begin
+    end else if (mem1_mem2_q.fault.instr_page_fault) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_INSTR_PAGE_FAULT};         // 12
-    end else if (ex2_mem_q.fault.pmp_fetch_fault) begin
+    end else if (mem1_mem2_q.fault.pmp_fetch_fault) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_INSTR_ACCESS_FAULT};       // 1
-    end else if (load_page_fault) begin
+    end else if (mem1_mem2_q.fault.load_page_fault) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_LOAD_PAGE_FAULT};          // 13
-    end else if (ex2_mem_q.fault.pmp_data_fault & ex2_mem_q.dec.is_load) begin
+    end else if (mem1_mem2_q.fault.pmp_data_fault & mem1_mem2_q.dec.is_load) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};        // 5
-    end else if (ex2_mem_q.fault.ex_amo_nc_fault & ex2_mem_q.dec.is_load) begin
+    end else if (mem1_mem2_q.fault.ex_amo_nc_fault & mem1_mem2_q.dec.is_load) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};        // 5
-    end else if (store_page_fault) begin
+    end else if (mem1_mem2_q.fault.store_page_fault) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_STORE_PAGE_FAULT};         // 15
-    end else if (ex2_mem_q.fault.pmp_data_fault & ex2_mem_q.dec.is_store) begin
+    end else if (mem1_mem2_q.fault.pmp_data_fault & mem1_mem2_q.dec.is_store) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};       // 7
-    end else if (ex2_mem_q.fault.ex_amo_nc_fault & ex2_mem_q.dec.is_store) begin
+    end else if (mem1_mem2_q.fault.ex_amo_nc_fault & mem1_mem2_q.dec.is_store) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};       // 7
-    end else if (ex2_mem_q.fault.pmp_data_fault & ex2_mem_q.dec.is_amo) begin
+    end else if (mem1_mem2_q.fault.pmp_data_fault & mem1_mem2_q.dec.is_amo) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
-    end else if (ex2_mem_q.fault.ex_amo_nc_fault & ex2_mem_q.dec.is_amo) begin
+    end else if (mem1_mem2_q.fault.ex_amo_nc_fault & mem1_mem2_q.dec.is_amo) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
-    end else if (dcache_bus_err_fault & ex2_mem_q.dec.is_load) begin
+    end else if (dcache_bus_err_fault & mem1_mem2_q.dec.is_load) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};        // 5
     end else if (dcache_bus_err_fault) begin
       mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};       // 7
-    end else if (ex2_mem_q.fault.irq_pending) begin
+    end else if (mem1_mem2_q.fault.irq_pending) begin
       // The interrupt sources (mip / mie / mstatus.MIE / SIE) have not been
-      // cleared yet at MEM — that happens when trap_i commits at retire.  So
-      // the live irq_cause priority encoder output at this MEM cycle still
-      // reflects the same pending interrupt as when ex2_mem_q.fault.irq_pending
-      // was sampled at EX1.
+      // cleared yet at MEM2 — that happens when trap_i commits at retire.
+      // The live irq_cause priority encoder output at this MEM2 cycle still
+      // reflects the same pending interrupt as when irq_pending was sampled
+      // at EX1.
       mem_trap_cause_d = {1'b1, 26'b0, irq_cause};
-    end else if (ex2_mem_q.fault.illegal | ex2_mem_q.fault.csr_illegal |
-                 ex2_mem_q.fault.mret_priv_fail | ex2_mem_q.fault.sret_priv_fail |
-                 ex2_mem_q.fault.satp_tvm_fail | ex2_mem_q.fault.wfi_priv_fail) begin
+    end else if (mem1_mem2_q.fault.illegal | mem1_mem2_q.fault.csr_illegal |
+                 mem1_mem2_q.fault.mret_priv_fail | mem1_mem2_q.fault.sret_priv_fail |
+                 mem1_mem2_q.fault.satp_tvm_fail | mem1_mem2_q.fault.wfi_priv_fail) begin
       mem_trap_cause_d = 32'd2;                                              // ILLEGAL
-    end else if (ex2_mem_q.fault.ecall) begin
+    end else if (mem1_mem2_q.fault.ecall) begin
       unique case (priv_q)
         PRIV_U:  mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_ECALL_U};       // 8
         PRIV_S:  mem_trap_cause_d = {27'b0, kronos_pkg::CAUSE_ECALL_S};       // 9
@@ -2248,21 +2275,20 @@ module kronos_top
 
   // trap_tval: offending PC for fetch faults, offending data address for
   // data PMP / page / dcache-bus faults, original instruction word for
-  // illegal-instruction (priv-spec § 3.1.16), 0 otherwise.  Reads ex2_mem_q
-  // registered state and the MEM-cycle live page-fault / dcache-bus-err
-  // signals — none of which depend on rr_ex1_q.
+  // illegal-instruction (priv-spec § 3.1.16), 0 otherwise.  Reads mem1_mem2_q
+  // registered state and the MEM2-cycle live dcache-bus-err signal.
   always_comb begin
-    if      (ex2_mem_q.fault.pmp_fetch_fault) mem_trap_tval_d = mem_wb_pmp_fetch_addr_q[31:0];
-    else if (instr_page_fault)                mem_trap_tval_d = ex2_mem_q.pc;
-    else if (load_page_fault | store_page_fault)
-                                              mem_trap_tval_d = ex2_mem_q.alu_result[31:0];
-    else if (ex2_mem_q.fault.pmp_data_fault)  mem_trap_tval_d = mem_wb_pmp_data_addr_q[31:0];
-    else if (ex2_mem_q.fault.ex_amo_nc_fault) mem_trap_tval_d = ex2_mem_q.alu_result[31:0];
-    else if (dcache_bus_err_fault)            mem_trap_tval_d = ex2_mem_data_pa_q[31:0];
-    else if (ex2_mem_q.fault.illegal | ex2_mem_q.fault.csr_illegal |
-             ex2_mem_q.fault.mret_priv_fail | ex2_mem_q.fault.sret_priv_fail |
-             ex2_mem_q.fault.satp_tvm_fail   | ex2_mem_q.fault.wfi_priv_fail)
-                                              mem_trap_tval_d = ex2_mem_q.instr;
+    if      (mem1_mem2_q.fault.pmp_fetch_fault) mem_trap_tval_d = mem_wb_pmp_fetch_addr_q[31:0];
+    else if (mem1_mem2_q.fault.instr_page_fault) mem_trap_tval_d = mem1_mem2_q.pc;
+    else if (mem1_mem2_q.fault.load_page_fault | mem1_mem2_q.fault.store_page_fault)
+                                              mem_trap_tval_d = mem1_mem2_q.alu_result[31:0];
+    else if (mem1_mem2_q.fault.pmp_data_fault)  mem_trap_tval_d = mem_wb_pmp_data_addr_q[31:0];
+    else if (mem1_mem2_q.fault.ex_amo_nc_fault) mem_trap_tval_d = mem1_mem2_q.alu_result[31:0];
+    else if (dcache_bus_err_fault)              mem_trap_tval_d = mem1_mem2_q.dtlb_pa[31:0];
+    else if (mem1_mem2_q.fault.illegal | mem1_mem2_q.fault.csr_illegal |
+             mem1_mem2_q.fault.mret_priv_fail | mem1_mem2_q.fault.sret_priv_fail |
+             mem1_mem2_q.fault.satp_tvm_fail   | mem1_mem2_q.fault.wfi_priv_fail)
+                                              mem_trap_tval_d = mem1_mem2_q.instr;
     else                                      mem_trap_tval_d = 32'd0;
   end
 
@@ -2323,43 +2349,50 @@ module kronos_top
   assign jalr_target_64 = (fwd_rs1_data + {{32{rr_ex1_q.dec.imm[31]}}, rr_ex1_q.dec.imm})
                            & ~64'd1;
 
-  // Stage 7a — EX1-cycle predictive trap_cause / trap_class.  Drives
-  // u_csr.trap_cause_ex_i / trap_class_ex_i so the trap_vector_o output is
-  // computed against the correct medeleg/mideleg slot at the cycle ex_pc_d
-  // is sampled.  Mirrors the priority ordering of mem_trap_cause_d below
-  // but reads EX1-cycle signals (rr_ex1_q + the same EX1 fault producers
-  // that drive ex_pc_d → trap_vector).
+  // Predictive trap_cause / trap_class.  Drives u_csr.trap_cause_ex_i /
+  // trap_class_ex_i so trap_vector_o reflects the correct medeleg/mideleg
+  // slot at the cycle the trap-causing instruction is in EX1 (for EX1-class
+  // faults) or in MEM1 (for MEM1-class faults).  MEM1-class faults take
+  // priority because the MEM1 instruction is older than the EX1 instruction
+  // and a MEM1-trap fires mem_redirect_d / mem_redirect_q which flushes the
+  // EX1 instruction anyway.
   always_comb begin
     ex1_trap_class = (rr_ex1_q.valid & (rr_ex1_q.dec.is_ecall |
                        rr_ex1_q.dec.is_ebreak | rr_ex1_q.dec.illegal |
                        csr_illegal | mret_priv_fail | sret_priv_fail |
                        satp_tvm_fail | wfi_priv_fail | irq_pending)) |
                      trig_hit | pmp_fetch_fault | pmp_data_fault |
-                     ex_amo_nc_fault | dcache_bus_err_fault |
-                     instr_page_fault | load_page_fault | store_page_fault;
+                     mem1_amo_nc_fault | dcache_bus_err_fault |
+                     instr_page_fault | mem1_load_page_fault |
+                     mem1_store_page_fault;
 
-    if (trig_hit) begin
+    // Priority: MEM1-class faults (older instruction) first, then EX1-class.
+    if (mem1_load_page_fault) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_PAGE_FAULT};
+    end else if (pmp_data_fault & ex2_mem1_q.dec.is_load) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};
+    end else if (mem1_amo_nc_fault & ex2_mem1_q.dec.is_load) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};
+    end else if (mem1_store_page_fault) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_PAGE_FAULT};
+    end else if (pmp_data_fault & ex2_mem1_q.dec.is_store) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
+    end else if (mem1_amo_nc_fault & ex2_mem1_q.dec.is_store) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
+    end else if (pmp_data_fault & ex2_mem1_q.dec.is_amo) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
+    end else if (mem1_amo_nc_fault & ex2_mem1_q.dec.is_amo) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
+    end else if (dcache_bus_err_fault & mem1_mem2_q.dec.is_load) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};
+    end else if (dcache_bus_err_fault) begin
+      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
+    end else if (trig_hit) begin
       ex1_trap_cause = 32'd3;
     end else if (instr_page_fault) begin
       ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_INSTR_PAGE_FAULT};
     end else if (pmp_fetch_fault) begin
       ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_INSTR_ACCESS_FAULT};
-    end else if (load_page_fault) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_PAGE_FAULT};
-    end else if (pmp_data_fault & rr_ex1_q.dec.is_load) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};
-    end else if (ex_amo_nc_fault & rr_ex1_q.dec.is_load) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};
-    end else if (store_page_fault) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_PAGE_FAULT};
-    end else if (pmp_data_fault) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
-    end else if (ex_amo_nc_fault) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
-    end else if (dcache_bus_err_fault & rr_ex1_q.dec.is_load) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_LOAD_ACCESS_FAULT};
-    end else if (dcache_bus_err_fault) begin
-      ex1_trap_cause = {27'b0, kronos_pkg::CAUSE_STORE_ACCESS_FAULT};
     end else if (irq_pending) begin
       ex1_trap_cause = {1'b1, 26'b0, irq_cause};
     end else if (rr_ex1_q.dec.illegal | csr_illegal | mret_priv_fail |
@@ -2383,9 +2416,12 @@ module kronos_top
                                mret_priv_fail | sret_priv_fail | satp_tvm_fail |
                                wfi_priv_fail |
                                irq_pending)) | trig_hit |
-              pmp_fetch_fault | pmp_data_fault |
-              ex_amo_nc_fault | dcache_bus_err_fault |
-              instr_page_fault | load_page_fault | store_page_fault) begin
+              pmp_fetch_fault | instr_page_fault) begin
+      // EX1-class faults steer ex_pc_d to the trap vector so a direction-
+      // mispredict cone (the only consumer of ex1_ex2_q.ex_pc_d) jumps to
+      // mtvec/stvec on the trapping edge.  MEM1-class faults (pmp_data_fault,
+      // mem1_amo_nc_fault, mem1_load/store_page_fault, dcache_bus_err_fault)
+      // override mem1_mem2_q.pc_d at the MEM1->MEM2 edge instead.
       ex_pc_d = trap_vector[31:0];
     end else if (rr_ex1_q.valid & rr_ex1_q.dec.is_mret & ~mret_priv_fail) begin
       ex_pc_d = mepc[31:0];
@@ -2417,7 +2453,7 @@ module kronos_top
   );
 
   // Suppress BTB update from the speculative instruction in EX when mem_redirect fires.
-  assign bpred_update_en = rr_ex1_q.valid & ex2_mem_en & is_branch_or_jump & ~mem_redirect_q;
+  assign bpred_update_en = rr_ex1_q.valid & ex2_mem1_en & is_branch_or_jump & ~mem_redirect_q;
 
   // FENCE.I trap suppression: when FENCE.I sits in EX and the D-cache still
   // holds dirty data, suppress the illegal-instruction redirect until the
@@ -2445,12 +2481,9 @@ module kronos_top
                                         wfi_priv_fail;
     ex1_fault_d.irq_pending           = irq_pending;
     ex1_fault_d.bpred_dir_mispredict  = bpred_mispredict;
-    // Stage 7a — sample EX1-cycle live producers into the EX1→EX2 register so
-    // they propagate alongside the offending instruction.  ex_amo_nc_fault and
-    // trig_hit are pure combinational from rr_ex1_q; without this snapshot
-    // ex2_fault_d would re-sample the live signals at the next cycle, when
-    // rr_ex1_q has advanced to the wrong instruction.
-    ex1_fault_d.ex_amo_nc_fault       = ex_amo_nc_fault;
+    // ex_amo_nc_fault has moved to MEM1 (mem1_amo_nc_fault); it is OR'd into
+    // mem1_mem2_q.fault.ex_amo_nc_fault at the MEM1->MEM2 edge.  Only EX1-cycle
+    // producers stay in ex1_fault_d.
     ex1_fault_d.trig_hit              = trig_hit;
   end
 
@@ -2492,7 +2525,7 @@ module kronos_top
 
   assign ex1_ex2_en    = ~combined_stall;
   // Stage 7a — flush ex1_ex2_q on mem_redirect_d (live, same cycle as the
-  // trap-causing instruction sits in ex2_mem_q) as well as the registered _q
+  // trap-causing instruction sits in ex2_mem1_q) as well as the registered _q
   // bits.  Without the _d term, the wrong-path follower in rr_ex1_q latches
   // into ex1_ex2_q at the same edge mem_redirect_q goes high; one cycle later
   // that follower's bpred_dir_mispredict can raise ex_redirect_q and override
@@ -2501,16 +2534,15 @@ module kronos_top
   assign ex1_ex2_flush = ex_redirect_q | mem_redirect_q | mem_redirect_d;
 
   // Stage 7a — EX2 fault next-state.  Carries EX1 bits forward verbatim.
-  // pmp_fetch_fault / pmp_data_fault are sampled from the registered
-  // pmp_s1_*_fault_q outputs which already track the EX2-stage instruction
-  // (the raw signals are computed off rr_ex1_q and registered at the EX1→EX2
-  // boundary).  ex_amo_nc_fault and trig_hit were sampled into ex1_fault_d
-  // at the EX1→EX2 boundary so the bit travels with the instruction.
+  // EX2 fault next-state.  Carries every EX1-stage fault bit forward verbatim
+  // and folds in the registered fetch-side pmp_fetch_fault.  The data-side
+  // MEM1-stage faults (pmp_data_fault, ex_amo_nc_fault, load_page_fault,
+  // store_page_fault, instr_page_fault) are NOT folded here — they fire one
+  // stage later and are OR'd into mem1_mem2_q.fault at the MEM1->MEM2 edge.
   fault_t ex2_fault_d;
   always_comb begin
     ex2_fault_d                  = ex1_ex2_q.fault;
     ex2_fault_d.pmp_fetch_fault  = pmp_fetch_fault;
-    ex2_fault_d.pmp_data_fault   = pmp_data_fault;
   end
 
   // Stage 7a — direction-mispredict-only redirect, formed from registered bits.
@@ -2579,7 +2611,7 @@ module kronos_top
   // Stage 7a — wb_sel pipeline tracking the producer one stage ahead at the
   // forwarding-mux read site.  ex1_ex2_csr_q tags the instruction landing in
   // ex1_ex2_q (read by FWD_EX1), ex2_mem_csr_q tags the one landing in
-  // ex2_mem_q (read by FWD_EXMEM).  Sources are rr_ex1_q at the EX1→EX2 edge
+  // ex2_mem1_q (read by FWD_EXMEM).  Sources are rr_ex1_q at the EX1→EX2 edge
   // and ex1_ex2_q at the EX2→MEM edge — i.e. each register samples its own
   // upstream stage, NOT rr_ex1_q both times.
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -2588,7 +2620,11 @@ module kronos_top
   end
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)         ex2_mem_csr_q <= 1'b0;
-    else if (ex2_mem_en) ex2_mem_csr_q <= (ex1_ex2_q.dec.wb_sel == WB_CSR);
+    else if (ex2_mem1_en) ex2_mem_csr_q <= (ex1_ex2_q.dec.wb_sel == WB_CSR);
+  end
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)          mem1_mem2_csr_q <= 1'b0;
+    else if (mem1_mem2_en) mem1_mem2_csr_q <= ex2_mem_csr_q;
   end
 
   // Stage 7a — csr_new_val pipeline.  u_csr.csr_new_val_o (= csr_new_val_post)
@@ -2602,15 +2638,19 @@ module kronos_top
   end
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)         ex2_mem_csr_new_val_q <= {kronos_pkg::XLEN{1'b0}};
-    else if (ex2_mem_en) ex2_mem_csr_new_val_q <= ex1_ex2_csr_new_val_q;
+    else if (ex2_mem1_en) ex2_mem_csr_new_val_q <= ex1_ex2_csr_new_val_q;
+  end
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)          mem1_mem2_csr_new_val_q <= {kronos_pkg::XLEN{1'b0}};
+    else if (mem1_mem2_en) mem1_mem2_csr_new_val_q <= ex2_mem_csr_new_val_q;
   end
 
-  // propagate the post-write CSR value MEM→WB, mirroring the
+  // propagate the post-write CSR value MEM2→WB, mirroring the
   // mem_wb_q.csr_wdata pipe.  Drives retire_csr_wdata_o and the CSR
   // module's retire_csr_new_val_i (architectural commit at retire).
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)        mem_wb_csr_new_val_q <= {kronos_pkg::XLEN{1'b0}};
-    else if (mem_wb_en) mem_wb_csr_new_val_q <= ex2_mem_csr_new_val_q;
+    else if (mem_wb_en) mem_wb_csr_new_val_q <= mem1_mem2_csr_new_val_q;
   end
 
   // Stage 7a — fflags pipeline.  Captures fp_fflags_cur at the EX1→EX2 edge
@@ -2631,137 +2671,184 @@ module kronos_top
   end
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)         ex2_mem_fflags_q      <= 5'b0;
-    else if (ex2_mem_en) ex2_mem_fflags_q      <= ex1_ex2_fflags_q;
+    else if (ex2_mem1_en) ex2_mem_fflags_q      <= ex1_ex2_fflags_q;
   end
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)         ex2_mem_is_fp_arith_q <= 1'b0;
-    else if (ex2_mem_en) ex2_mem_is_fp_arith_q <= ex1_ex2_is_fp_arith_q;
+    else if (ex2_mem1_en) ex2_mem_is_fp_arith_q <= ex1_ex2_is_fp_arith_q;
+  end
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)          mem1_mem2_fflags_q       <= 5'b0;
+    else if (mem1_mem2_en) mem1_mem2_fflags_q       <= ex2_mem_fflags_q;
+  end
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)          mem1_mem2_is_fp_arith_q  <= 1'b0;
+    else if (mem1_mem2_en) mem1_mem2_is_fp_arith_q  <= ex2_mem_is_fp_arith_q;
   end
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)        mem_wb_fflags_q       <= 5'b0;
-    else if (mem_wb_en) mem_wb_fflags_q       <= ex2_mem_fflags_q;
+    else if (mem_wb_en) mem_wb_fflags_q       <= mem1_mem2_fflags_q;
   end
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)        mem_wb_is_fp_arith_q  <= 1'b0;
-    else if (mem_wb_en) mem_wb_is_fp_arith_q  <= ex2_mem_is_fp_arith_q;
+    else if (mem_wb_en) mem_wb_is_fp_arith_q  <= mem1_mem2_is_fp_arith_q;
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      ex2_mem_q <= '{default: '0, dec: kronos_pkg::DECODED_INSTR_ZERO,
-                     fault: kronos_pkg::FAULT_ZERO};
-    end else if (ex2_mem_en) begin
-      // Stage 7a — sources flow through ex1_ex2_q (registered EX1 output).
-      ex2_mem_q.pc         <= ex1_ex2_q.pc;
-      ex2_mem_q.dec        <= ex1_ex2_q.dec;
-      ex2_mem_q.alu_result <= ex1_ex2_q.alu_result;
-      ex2_mem_q.rs2_data   <= ex1_ex2_q.rs2_data;
-      // pc_d for the trapping instruction must be the trap vector.  EX1-stage
-      // faults (ecall, illegal, csr_illegal, mret_priv_fail, ex_amo_nc_fault,
-      // trig_hit, …) are visible at EX1 of the trapping instruction and the
-      // ex_pc_d → trap_vector path already steers ex1_ex2_q.ex_pc_d to
-      // trap_vector.  EX2-stage faults (pmp_data_fault, page faults — the
-      // back-edge-cut s1 registers and dTLB lookups arrive a cycle late) are
-      // discovered AFTER ex1_ex2_q.ex_pc_d has been latched (still PC+4),
-      // so override at the EX2→MEM boundary.  trap_vector is the live CSR
-      // output; for non-delegated traps it is mtvec, matching mem_redirect's
-      // architecturally correct vector.
-      ex2_mem_q.pc_d       <= (pmp_data_fault | pmp_fetch_fault |
-                               instr_page_fault | load_page_fault |
-                               store_page_fault | dcache_bus_err_fault)
-                              ? trap_vector[31:0]
-                              : ex1_ex2_q.ex_pc_d;
-      ex2_mem_q.csr_rdata  <= ex1_ex2_q.csr_rdata;
-      ex2_mem_q.fault      <= ex2_fault_d;
-      // The Stage 6 `redirect` field is dead in Stage 7a; the new fault-bit
-      // contract carries trap context via mem_wb_q.fault.  Tie it low so the
-      // field is unambiguous.
-      ex2_mem_q.redirect   <= 1'b0;
-      // Wrong-path kill at the EX2->MEM boundary.  Three terms:
-      //   ~mem_redirect_d : kills the wrong-path follower entering MEM at
-      //     the same posedge a mem-class fault asserts.  The instruction
-      //     CAUSING the mem fault is in ex2_mem_q (current state, valid=1
-      //     and unaffected — only the next-cycle load is gated).  The
-      //     follower is in ex1_ex2_q and is what gets blocked.  Mirrors
-      //     stage 6's combinational `mem_redirect` term.
+      ex2_mem1_q <= EX_MEM_REG_ZERO;
+    end else if (ex2_mem1_flush) begin
+      ex2_mem1_q <= EX_MEM_REG_ZERO;
+    end else if (ex2_mem1_en) begin
+      // Sources flow through ex1_ex2_q (registered EX2 output).  pc_d carries
+      // the EX1-cycle ex_pc_d (already overridden to trap_vector for EX1-class
+      // faults) into MEM1; MEM1-class faults override at the MEM1->MEM2 edge.
+      ex2_mem1_q.pc         <= ex1_ex2_q.pc;
+      ex2_mem1_q.dec        <= ex1_ex2_q.dec;
+      ex2_mem1_q.alu_result <= ex1_ex2_q.alu_result;
+      ex2_mem1_q.rs2_data   <= ex1_ex2_q.rs2_data;
+      ex2_mem1_q.pc_d       <= ex1_ex2_q.ex_pc_d;
+      ex2_mem1_q.csr_rdata  <= ex1_ex2_q.csr_rdata;
+      ex2_mem1_q.fault      <= ex2_fault_d;
+      // The Stage 6 `redirect` field is dead in Stage 7+; the fault-bit
+      // contract carries trap context via mem_wb_q.fault.
+      ex2_mem1_q.redirect   <= 1'b0;
+      // Wrong-path kill at the EX2->MEM1 boundary.  Three terms:
+      //   ~mem_redirect_d : kills the wrong-path follower entering MEM1 at
+      //     the same posedge a MEM2 trap asserts.  The instruction CAUSING
+      //     the MEM2 trap is in mem1_mem2_q (current state, valid=1 and
+      //     unaffected — only the next-cycle load is gated).
       //   ~mem_redirect_q : keeps subsequent loads killed while the
-      //     registered redirect is held high (same as before).
-      //   ~ex_redirect_q  : kills the wrong-path follower from a
-      //     direction-mispredict.  Cannot use ex_redirect_d here because
-      //     the redirect-causing branch sits in ex1_ex2_q at the same
-      //     edge that asserts ex_redirect_d, and we want the branch
-      //     itself to advance to ex2_mem and retire normally.  By the
-      //     time ex_redirect_q is high (next cycle), the branch has
-      //     moved on and the new ex1_ex2_q content is the wrong-path
-      //     follower — which this term kills.
-      ex2_mem_q.valid       <= ex1_ex2_q.valid &
-                               ~mem_redirect_d & ~mem_redirect_q &
-                               ~ex_redirect_q;
-      ex2_mem_q.is_16b      <= ex1_ex2_q.is_16b;
-      ex2_mem_q.pred_taken  <= ex1_ex2_q.pred_taken;
-      ex2_mem_q.pred_target <= ex1_ex2_q.pred_target;
-      ex2_mem_q.instr       <= ex1_ex2_q.instr;
-      ex2_mem_q.csr_wdata   <= ex1_ex2_q.csr_wdata;
+      //     registered redirect is held high.
+      // Note: ex_redirect_q is NOT in this gate — the EX2 redirect
+      // (direction mispredict) flushes ID/RR/EX1 wrong-path followers, but
+      // the EX2 instruction ITSELF (the JAL/branch that detected the
+      // mispredict) must still commit its rd write at WB. Killing it here
+      // would suppress JAL's link write to ra and break ret semantics.
+      // ex1_ex2_flush already drains any wrong-path instruction from EX1
+      // before it reaches EX2.
+      ex2_mem1_q.valid       <= ex1_ex2_q.valid &
+                                ~mem_redirect_d & ~mem_redirect_q;
+      ex2_mem1_q.is_16b      <= ex1_ex2_q.is_16b;
+      ex2_mem1_q.pred_taken  <= ex1_ex2_q.pred_taken;
+      ex2_mem1_q.pred_target <= ex1_ex2_q.pred_target;
+      ex2_mem1_q.instr       <= ex1_ex2_q.instr;
+      ex2_mem1_q.csr_wdata   <= ex1_ex2_q.csr_wdata;
     end
   end
 
-  // Stage 7a — PA pipeline.  ex1_ex2_data_pa_q captures the EX1-live PA at
-  // the EX1→EX2 edge; ex2_mem_data_pa_q chains from it at EX2→MEM.  When
-  // translation is off (Bare or M-mode) eff_data_pa == alu_result.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)         ex1_ex2_data_pa_q <= 32'b0;
-    else if (ex1_ex2_en) ex1_ex2_data_pa_q <= eff_data_pa;
-  end
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)         ex2_mem_data_pa_q <= 32'b0;
-    else if (ex2_mem_en) ex2_mem_data_pa_q <= ex1_ex2_data_pa_q;
+  assign ex2_mem1_flush = mem_redirect_q | mem_redirect_d;
+
+  // MEM1->MEM2 fault next-state.  Carries every EX2-stage fault bit forward
+  // and OR-folds in the MEM1-cycle producers (pmp_data_fault, mem1_amo_nc_fault,
+  // mem1_load/store_page_fault, instr_page_fault) so the registered aggregate
+  // is the source of truth for mem_redirect_d at MEM2.
+  always_comb begin
+    mem1_fault_d                    = ex2_mem1_q.fault;
+    mem1_fault_d.pmp_data_fault     = ex2_mem1_q.fault.pmp_data_fault |
+                                      (pmp_data_fault_raw & pmp_any_active);
+    mem1_fault_d.ex_amo_nc_fault    = ex2_mem1_q.fault.ex_amo_nc_fault |
+                                      mem1_amo_nc_fault;
+    mem1_fault_d.load_page_fault    = ex2_mem1_q.fault.load_page_fault  |
+                                      mem1_load_page_fault;
+    mem1_fault_d.store_page_fault   = ex2_mem1_q.fault.store_page_fault |
+                                      mem1_store_page_fault;
+    mem1_fault_d.instr_page_fault   = ex2_mem1_q.fault.instr_page_fault |
+                                      instr_page_fault;
   end
 
-  // MEM-stage target misprediction: predictor predicted taken with the right
-  // direction (so EX did not redirect), but the predicted target was wrong.
-  // Both ex2_mem_q.pc_d and ex2_mem_q.pred_target are registered, so this
-  // comparison sits on a short path.  Guard with ~ex2_mem_q.fault.bpred_dir_mispredict:
+  // MEM1-class faults that cause a trap-vector redirect (vs a direction
+  // mispredict).  These override mem1_mem2_q.pc_d to trap_vector at the
+  // MEM1->MEM2 edge so mem_redirect_target_q latches the right vector.
+  assign mem1_trap_redirect =
+      (pmp_data_fault_raw & pmp_any_active) |
+      mem1_amo_nc_fault   |
+      mem1_load_page_fault |
+      mem1_store_page_fault;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mem1_mem2_q <= MEM1_MEM2_REG_ZERO;
+    end else if (mem1_mem2_flush) begin
+      mem1_mem2_q <= MEM1_MEM2_REG_ZERO;
+    end else if (mem1_mem2_en) begin
+      mem1_mem2_q.pc          <= ex2_mem1_q.pc;
+      mem1_mem2_q.dec         <= ex2_mem1_q.dec;
+      mem1_mem2_q.alu_result  <= ex2_mem1_q.alu_result;
+      mem1_mem2_q.rs2_data    <= ex2_mem1_q.rs2_data;
+      // pc_d carries either the EX1-cycle ex_pc_d (for non-trap or EX1-class
+      // trap), or trap_vector when a MEM1-class fault overrides.
+      mem1_mem2_q.pc_d        <= mem1_trap_redirect
+                                 ? trap_vector[31:0]
+                                 : ex2_mem1_q.pc_d;
+      mem1_mem2_q.csr_rdata   <= ex2_mem1_q.csr_rdata;
+      mem1_mem2_q.csr_wdata   <= ex2_mem1_q.csr_wdata;
+      mem1_mem2_q.is_16b      <= ex2_mem1_q.is_16b;
+      mem1_mem2_q.pred_taken  <= ex2_mem1_q.pred_taken;
+      mem1_mem2_q.pred_target <= ex2_mem1_q.pred_target;
+      mem1_mem2_q.instr       <= ex2_mem1_q.instr;
+      mem1_mem2_q.redirect    <= 1'b0;
+      // Wrong-path kill at MEM1->MEM2 boundary: only MEM2-class redirects
+      // kill an instruction that's already past EX2.  ex_redirect_q (EX2
+      // direction-mispredict) does NOT kill MEM1: by the time the EX2
+      // redirect fires, the MEM1 occupant is the JAL/branch itself, which
+      // must commit its writeback (e.g. JAL's link write to ra).  The
+      // ex_redirect cone targets ID/RR/EX1 wrong-path followers, not MEM1.
+      mem1_mem2_q.valid       <= ex2_mem1_q.valid &
+                                  ~mem_redirect_d & ~mem_redirect_q;
+      mem1_mem2_q.fault       <= mem1_fault_d;
+      mem1_mem2_q.dtlb_pa     <= eff_data_pa[31:0];
+      mem1_mem2_q.dtlb_was_hit <= ~dtlb_miss;
+      mem1_mem2_q.dcache_pre_launched <= dcache_early_req_valid;
+    end
+  end
+
+  assign mem1_mem2_flush = mem_redirect_q | mem_redirect_d;
+
+  // PA pipeline: dTLB lookup runs at MEM1 (consuming ex2_mem1_q.alu_result as
+  // VA), the translated PA flops into mem1_mem2_q.dtlb_pa at the MEM1->MEM2
+  // edge, and the LSU at MEM2 consumes mem1_mem2_q.dtlb_pa.  No discrete
+  // ex1_ex2_data_pa_q / ex2_mem_data_pa_q flops are needed any more.
+
+  // MEM2-stage target misprediction: predictor predicted taken with the right
+  // direction (so EX2 did not redirect), but the predicted target was wrong.
+  // Both mem1_mem2_q.pc_d and mem1_mem2_q.pred_target are registered, so this
+  // comparison sits on a short path.  Guard with ~mem1_mem2_q.fault.bpred_dir_mispredict:
   // if EX2 already redirected on a direction mismatch, no second redirect needed.
-  assign bpred_mispredict_target = ex2_mem_q.valid &
-    ~ex2_mem_q.fault.bpred_dir_mispredict &
-    ex2_mem_q.pred_taken & (ex2_mem_q.pred_target != ex2_mem_q.pc_d);
+  assign bpred_mispredict_target = mem1_mem2_q.valid &
+    ~mem1_mem2_q.fault.bpred_dir_mispredict &
+    mem1_mem2_q.pred_taken & (mem1_mem2_q.pred_target != mem1_mem2_q.pc_d);
 
-  // Stage 7a — MEM-stage redirect formation.  Single OR over registered EX2
-  // fault bits + MEM-cycle producers (page faults, target mispredict, dcache
-  // bus error).  All sources are either registered (`ex2_mem_q.fault.*`) or
-  // stay within the MEM cone, so this aggregator never crosses a module
-  // boundary.
+  // MEM2-stage redirect formation.  Single OR over registered MEM1 fault bits
+  // (now in mem1_mem2_q.fault) + live MEM2-cycle producers (target mispredict,
+  // dcache bus error).  All sources are either registered (mem1_mem2_q.fault.*)
+  // or stay within the narrow MEM2 cone, so this aggregator never crosses a
+  // module boundary and is one stage further from the dTLB / PMP comparators
+  // than 7b's MEM aggregator.
   //
-  // The 2-cycle ex_redirect latency means a wrong-path instruction can land
-  // in ex1_ex2_q after the mispredicting branch is in EX2 but before
-  // ex_redirect_q rises.  ex2_mem_q.valid is then squashed (gated on
-  // ~ex_redirect_q at the EX2->MEM boundary), but ex2_mem_q.fault is
-  // unconditionally OR'd from ex1_ex2_q.fault — so a wrong-path illegal /
-  // ecall / ebreak can still drive mem_redirect_d high after its instruction
-  // has been invalidated.  Gating the entire fault sum on ex2_mem_q.valid
-  // prevents the spurious trap; MEM-cycle producers (page faults, dcache
-  // bus error, target mispredict) are already either gated on
-  // ex2_mem_q.valid (bpred_mispredict_target) or sourced from MEM-stage
-  // requests that the LSU/dTLB only fire when ex2_mem_q.valid=1.
-  assign mem_redirect_d = ex2_mem_q.valid & (
-      ex2_mem_q.fault.ecall            |
-      ex2_mem_q.fault.ebreak           |
-      ex2_mem_q.fault.illegal          |
-      ex2_mem_q.fault.csr_illegal      |
-      ex2_mem_q.fault.mret_priv_fail   |
-      ex2_mem_q.fault.sret_priv_fail   |
-      ex2_mem_q.fault.satp_tvm_fail    |
-      ex2_mem_q.fault.wfi_priv_fail    |
-      ex2_mem_q.fault.irq_pending      |
-      ex2_mem_q.fault.is_mret          |
-      ex2_mem_q.fault.is_sret          |
-      ex2_mem_q.fault.pmp_fetch_fault  |
-      ex2_mem_q.fault.pmp_data_fault   |
-      ex2_mem_q.fault.ex_amo_nc_fault  |
-      ex2_mem_q.fault.trig_hit         |
-      instr_page_fault                 |
-      load_page_fault                  |
-      store_page_fault                 |
+  // Gating the entire fault sum on mem1_mem2_q.valid prevents spurious traps
+  // from wrong-path followers; MEM2 live producers (bpred_mispredict_target,
+  // dcache_bus_err_fault) are already either gated on mem1_mem2_q.valid or
+  // sourced from MEM2 requests the LSU/dTLB only fire when mem1_mem2_q.valid=1.
+  assign mem_redirect_d = mem1_mem2_q.valid & (
+      mem1_mem2_q.fault.ecall            |
+      mem1_mem2_q.fault.ebreak           |
+      mem1_mem2_q.fault.illegal          |
+      mem1_mem2_q.fault.csr_illegal      |
+      mem1_mem2_q.fault.mret_priv_fail   |
+      mem1_mem2_q.fault.sret_priv_fail   |
+      mem1_mem2_q.fault.satp_tvm_fail    |
+      mem1_mem2_q.fault.wfi_priv_fail    |
+      mem1_mem2_q.fault.irq_pending      |
+      mem1_mem2_q.fault.is_mret          |
+      mem1_mem2_q.fault.is_sret          |
+      mem1_mem2_q.fault.pmp_fetch_fault  |
+      mem1_mem2_q.fault.pmp_data_fault   |
+      mem1_mem2_q.fault.ex_amo_nc_fault  |
+      mem1_mem2_q.fault.trig_hit         |
+      mem1_mem2_q.fault.instr_page_fault |
+      mem1_mem2_q.fault.load_page_fault  |
+      mem1_mem2_q.fault.store_page_fault |
       bpred_mispredict_target          |
       dcache_bus_err_fault);
 
@@ -2771,14 +2858,14 @@ module kronos_top
     else                     mem_redirect_q <= mem_redirect_d;
   end
 
-  // Capture the MEM redirect target alongside mem_redirect_q.  Sampled from
-  // `ex2_mem_q.pc_d` at the edge that registers the fault, since the ex2_mem_q
-  // register is overwritten by the next instruction at the same edge and its
-  // `pc_d` field becomes stale.
+  // Capture the MEM2 redirect target alongside mem_redirect_q.  Sampled from
+  // `mem1_mem2_q.pc_d` at the edge that registers the fault, since the
+  // mem1_mem2_q register is overwritten by the next instruction at the same
+  // edge and its `pc_d` field becomes stale.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if      (!rst_ni)        mem_redirect_target_q <= 32'h0;
     else if (combined_stall) mem_redirect_target_q <= mem_redirect_target_q;
-    else if (mem_redirect_d) mem_redirect_target_q <= ex2_mem_q.pc_d;
+    else if (mem_redirect_d) mem_redirect_target_q <= mem1_mem2_q.pc_d;
   end
 
   // =========================================================================
@@ -2793,9 +2880,10 @@ module kronos_top
       if (lsu_valid) begin
         mem_done_q      <= 1'b1;
         lsu_rdata_latch <= lsu_rdata;
-        // AMO write: any AMO (not LR) or a successful SC.
-        amo_write_latch <= ex2_mem_q.dec.is_amo & ~ex2_mem_q.dec.is_lr
-                         | ex2_mem_q.dec.is_sc & dcache_sc_success;
+        // AMO write: any AMO (not LR) or a successful SC.  At MEM2 the
+        // operand source is mem1_mem2_q (LSU runs at MEM2 in 7c).
+        amo_write_latch <= mem1_mem2_q.dec.is_amo & ~mem1_mem2_q.dec.is_lr
+                         | mem1_mem2_q.dec.is_sc & dcache_sc_success;
       end
       if (mem_wb_en) begin
         mem_done_q <= 1'b0;
@@ -2808,48 +2896,48 @@ module kronos_top
       mem_wb_q <= '{default: '0, dec: kronos_pkg::DECODED_INSTR_ZERO,
                     fault: kronos_pkg::FAULT_ZERO};
     end else if (mem_wb_en) begin
-      mem_wb_q.dec        <= ex2_mem_q.dec;
-      // fpu_result was already captured into ex2_mem_q.alu_result at the
-      // EX→MEM boundary (when fpu_out_valid fired while the FP instruction
-      // was stalled in EX).  Simply pass it through here.
-      mem_wb_q.alu_result <= ex2_mem_q.alu_result;
+      // Sources flow through mem1_mem2_q (registered MEM1 output).  Live MEM2
+      // producers (bpred_mispredict_target, dcache_bus_err_fault) OR into the
+      // fault aggregate alongside the registered MEM1-stage fault bits.
+      mem_wb_q.dec        <= mem1_mem2_q.dec;
+      mem_wb_q.alu_result <= mem1_mem2_q.alu_result;
       mem_wb_q.lsu_rdata  <= lsu_valid ? lsu_rdata : lsu_rdata_latch;
-      mem_wb_q.csr_rdata  <= ex2_mem_q.csr_rdata;
-      mem_wb_q.pc4        <= ex2_mem_q.pc + (ex2_mem_q.is_16b ? 32'd2 : 32'd4);
-      mem_wb_q.valid        <= ex2_mem_q.valid;
+      mem_wb_q.csr_rdata  <= mem1_mem2_q.csr_rdata;
+      mem_wb_q.pc4        <= mem1_mem2_q.pc + (mem1_mem2_q.is_16b ? 32'd2 : 32'd4);
+      mem_wb_q.valid        <= mem1_mem2_q.valid;
       mem_wb_q.is_amo_write <= lsu_valid
-                             ? (ex2_mem_q.dec.is_amo & ~ex2_mem_q.dec.is_lr
-                              | ex2_mem_q.dec.is_sc & dcache_sc_success)
+                             ? (mem1_mem2_q.dec.is_amo & ~mem1_mem2_q.dec.is_lr
+                              | mem1_mem2_q.dec.is_sc & dcache_sc_success)
                              : amo_write_latch;
       // Retire-trace field snapshots.
-      mem_wb_q.pc           <= ex2_mem_q.pc;
-      mem_wb_q.instr      <= ex2_mem_q.instr;
-      mem_wb_q.mem_addr   <= ex2_mem_q.alu_result;
-      mem_wb_q.mem_wdata  <= ex2_mem_q.rs2_data;
-      mem_wb_q.csr_wdata  <= ex2_mem_q.csr_wdata;
-      // Stage 7a — full fault aggregate at retire.  Forwards every EX2 bit
-      // and OR-folds the MEM-cycle producers (page faults, target mispredict,
+      mem_wb_q.pc         <= mem1_mem2_q.pc;
+      mem_wb_q.instr      <= mem1_mem2_q.instr;
+      mem_wb_q.mem_addr   <= mem1_mem2_q.alu_result;
+      mem_wb_q.mem_wdata  <= mem1_mem2_q.rs2_data;
+      mem_wb_q.csr_wdata  <= mem1_mem2_q.csr_wdata;
+      // Full fault aggregate at retire.  Every MEM1-class bit is already in
+      // mem1_mem2_q.fault.*; add live MEM2 producers (target mispredict,
       // dcache bus error).
       mem_wb_q.fault <= '{
-        ecall:                   ex2_mem_q.fault.ecall,
-        ebreak:                  ex2_mem_q.fault.ebreak,
-        illegal:                 ex2_mem_q.fault.illegal,
-        is_mret:                 ex2_mem_q.fault.is_mret,
-        is_sret:                 ex2_mem_q.fault.is_sret,
-        csr_illegal:             ex2_mem_q.fault.csr_illegal,
-        mret_priv_fail:          ex2_mem_q.fault.mret_priv_fail,
-        sret_priv_fail:          ex2_mem_q.fault.sret_priv_fail,
-        satp_tvm_fail:           ex2_mem_q.fault.satp_tvm_fail,
-        wfi_priv_fail:           ex2_mem_q.fault.wfi_priv_fail,
-        irq_pending:             ex2_mem_q.fault.irq_pending,
-        bpred_dir_mispredict:    ex2_mem_q.fault.bpred_dir_mispredict,
-        pmp_fetch_fault:         ex2_mem_q.fault.pmp_fetch_fault,
-        pmp_data_fault:          ex2_mem_q.fault.pmp_data_fault,
-        ex_amo_nc_fault:         ex2_mem_q.fault.ex_amo_nc_fault,
-        trig_hit:                ex2_mem_q.fault.trig_hit,
-        instr_page_fault:        instr_page_fault,
-        load_page_fault:         load_page_fault,
-        store_page_fault:        store_page_fault,
+        ecall:                   mem1_mem2_q.fault.ecall,
+        ebreak:                  mem1_mem2_q.fault.ebreak,
+        illegal:                 mem1_mem2_q.fault.illegal,
+        is_mret:                 mem1_mem2_q.fault.is_mret,
+        is_sret:                 mem1_mem2_q.fault.is_sret,
+        csr_illegal:             mem1_mem2_q.fault.csr_illegal,
+        mret_priv_fail:          mem1_mem2_q.fault.mret_priv_fail,
+        sret_priv_fail:          mem1_mem2_q.fault.sret_priv_fail,
+        satp_tvm_fail:           mem1_mem2_q.fault.satp_tvm_fail,
+        wfi_priv_fail:           mem1_mem2_q.fault.wfi_priv_fail,
+        irq_pending:             mem1_mem2_q.fault.irq_pending,
+        bpred_dir_mispredict:    mem1_mem2_q.fault.bpred_dir_mispredict,
+        pmp_fetch_fault:         mem1_mem2_q.fault.pmp_fetch_fault,
+        pmp_data_fault:          mem1_mem2_q.fault.pmp_data_fault,
+        ex_amo_nc_fault:         mem1_mem2_q.fault.ex_amo_nc_fault,
+        trig_hit:                mem1_mem2_q.fault.trig_hit,
+        instr_page_fault:        mem1_mem2_q.fault.instr_page_fault,
+        load_page_fault:         mem1_mem2_q.fault.load_page_fault,
+        store_page_fault:        mem1_mem2_q.fault.store_page_fault,
         bpred_target_mispredict: bpred_mispredict_target,
         dcache_bus_err_fault:    dcache_bus_err_fault
       };

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -131,7 +131,8 @@ SIM_BIN_S2 := $(OBJ_DIR)/s2/Vkronos_top
         sim-crv-% sim-crv-smoke sim-crv-deep \
         sim-crv-s6-% sim-crv-smoke-s6 sim-crv-deep-s6 \
         sim-crv-cov-build sim-crv-coverage \
-        sim-crv-assists
+        sim-crv-assists \
+        sim-stage7c-asm run-s7c-%
 
 # ── Sail differential-trace harness ─────────────────────────────────────────
 TRACE_DIR := $(OBJ_DIR)/trace
@@ -1178,6 +1179,42 @@ $(SIM_BIN_S7A): $(SV_FILES_S7A) $(abspath sim_main.cpp)
 run-s7a-%: build-s7a
 	$(MAKE) -C $(SW_DIR_S7A) build/$*.hex
 	./$(SIM_BIN_S7A) $(SW_DIR_S7A)/build/$*.hex
+
+# ── Stage 7c directed asm tests (MEM1/MEM2 split) ─────────────────────────────
+# Stage 7c reuses files_rtl_s7a (fileset name stayed at s7a after the s7b
+# merge edited files in place — same pattern continues for 7c). The s7c asm
+# tests therefore run against SIM_BIN_S7A / build-s7a.
+SW_DIR_S7C := ../sw/stage7c
+
+run-s7c-%: build-s7a
+	$(MAKE) -C $(SW_DIR_S7C) build/$*.hex
+	./$(SIM_BIN_S7A) $(SW_DIR_S7C)/build/$*.hex
+
+sim-stage7c-asm: build-s7a
+	@$(MAKE) -C $(SW_DIR_S7C) all > /dev/null 2>&1; \
+	tmpdir=$$(mktemp -d); pids=""; \
+	for hex in $(SW_DIR_S7C)/build/*.hex; do \
+	  [ -f "$$hex" ] || continue; \
+	  name=$$(basename $$hex .hex); \
+	  { out=$$(timeout 30 ./$(SIM_BIN_S7A) $$hex 2>&1); \
+	    x10=$$(echo "$$out" | grep -oP 'x10 = \K[0-9]+'); \
+	    echo "$$hex $$x10"; } > $$tmpdir/$$name & \
+	  pids="$$pids $$!"; \
+	done; \
+	wait $$pids; \
+	pass=0; fail=0; \
+	for f in $$tmpdir/*; do \
+	  [ -f "$$f" ] || continue; \
+	  read hex x10 < $$f; \
+	  if [ "$$x10" = "0" ]; then \
+	    pass=$$((pass+1)); echo "PASS  $$hex"; \
+	  else \
+	    echo "FAIL  $$hex (x10=$$x10)"; fail=$$((fail+1)); \
+	  fi; \
+	done; \
+	rm -rf $$tmpdir; \
+	echo "Stage 7c asm: $$pass passed, $$fail failed"; \
+	[ $$fail -eq 0 ]
 
 # ── Lint: kronos RTL only, with UNOPTFLAT enabled. ────────────────────────────
 # Detects RTL combinational loops (closes #89 detection gap).  Lints the

--- a/sw/perf/dhrystone/dhry_main.c
+++ b/sw/perf/dhrystone/dhry_main.c
@@ -25,7 +25,13 @@ extern int dhry_run(int Number_Of_Runs);
 // only the CI value is authoritative.  Re-bake on any RTL change that
 // affects integer IPC by setting BASELINE_CYCLES=0 (capture mode) and
 // reading x10 from the CI halt line.
-#define BASELINE_CYCLES  904764U  /* s7b @ c7f59f8 (was 992151 = s6i baseline) */
+#define BASELINE_CYCLES  992151U  /* s6i baseline; s7+ regression is policed by
+                                    * tools/cycle_diff.py via the
+                                    * compliance-cycle-diff-s7{b,c} CI gates
+                                    * (both run with --ignore-x10).  Keeping
+                                    * the s6 value lets sim-perf-baseline-s6
+                                    * use the same hex without per-stage build
+                                    * flags. */
 #define TOLERANCE_PCT    2U
 
 // ---------------------------------------------------------------------------

--- a/sw/perf/dhrystone/dhry_main.c
+++ b/sw/perf/dhrystone/dhry_main.c
@@ -17,7 +17,7 @@
 extern int dhry_run(int Number_Of_Runs);
 
 #define NUMBER_OF_RUNS   1000U
-// captured 2026-05-02 on stage6f branch @ commit 3734769 against the CI
+// captured 2026-05-06 on stage7b branch @ commit c7f59f8 against the CI
 // toolchain (Ubuntu 24.04 apt gcc-riscv64-unknown-elf v13/14, the
 // reference for sim-perf-baseline-s6).  Local builds with a different
 // riscv64-unknown-elf-gcc version (e.g. v15.x) emit different dhry_run
@@ -25,7 +25,7 @@ extern int dhry_run(int Number_Of_Runs);
 // only the CI value is authoritative.  Re-bake on any RTL change that
 // affects integer IPC by setting BASELINE_CYCLES=0 (capture mode) and
 // reading x10 from the CI halt line.
-#define BASELINE_CYCLES  992151U
+#define BASELINE_CYCLES  904764U  /* s7b @ c7f59f8 (was 992151 = s6i baseline) */
 #define TOLERANCE_PCT    2U
 
 // ---------------------------------------------------------------------------

--- a/sw/stage7c/Makefile
+++ b/sw/stage7c/Makefile
@@ -1,0 +1,29 @@
+TOOLCHAIN := riscv64-unknown-elf
+CC        := $(TOOLCHAIN)-gcc
+OBJCOPY   := $(TOOLCHAIN)-objcopy
+OBJDUMP   := $(TOOLCHAIN)-objdump
+
+ARCH   := rv64imafdc_zicsr_zifencei
+ABI    := lp64
+CFLAGS := -march=$(ARCH) -mabi=$(ABI) -nostdlib -static -T../stage0/link.ld
+
+TESTS  := test_mem_load_use_3cycle \
+          test_mem_jalr_load_fwd \
+          test_mem_amo_split \
+          test_mem_pmp_pf \
+          test_mem_target_mispredict \
+          test_mem_csr_raw_5slot
+
+BUILD_DIR := build
+
+all: $(TESTS:%=$(BUILD_DIR)/%.hex)
+
+$(BUILD_DIR)/%.hex: %.S ../stage0/common.S | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $(@:.hex=.elf) $^
+	$(OBJCOPY) -O ihex $(@:.hex=.elf) $@
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/sw/stage7c/test_mem_amo_split.S
+++ b/sw/stage7c/test_mem_amo_split.S
@@ -1,0 +1,91 @@
+# test_mem_amo_split.S — MEM1/MEM2 split: AMO RMW correctness.
+#
+# In stage 7c the AMO operand-launch advances from ex2_mem_q (7b) to
+# mem1_mem2_q (MEM1→MEM2 boundary).  The dcache DC_AMO_RMW FSM is unchanged;
+# only the source register for the LSU req_i shifts one stage later.
+# AMO completion latency increases by 1 cycle; the architectural result is
+# unchanged.
+#
+# Sub-tests:
+#   1. LR.D / SC.D round-trip: reservation holds, SC succeeds (x9 == 0),
+#      memory contains the new value.
+#   2. AMOADD.D: rd gets the old memory value; memory holds old + operand.
+#   3. AMOSWAP.D: rd gets the old value; memory holds the new value.
+#   4. LR.D / SC.D with interleaved nop (reservation must still hold on a
+#      single hart — spec guarantees forward progress).
+#
+# x10 == 0 on PASS; addi a0, a0, 1 per failed sub-test.
+
+.section .text
+.global main
+main:
+    li      a0, 0
+
+    # ---- Test 1: LR.D / SC.D round-trip -----------------------------------
+    la      t0, _lock_word
+    li      t1, 0x42
+    sd      t1, 0(t0)
+
+    lr.d    t2, (t0)                    # t2 = 0x42, reservation set
+    li      t3, 0x11
+    bne     t2, t1, .L_fail_t1_lr      # lr.d must return the stored value
+
+    li      t3, 0x99
+    sc.d    t4, t3, (t0)               # t4 = 0 on success
+    bnez    t4, .L_fail_t1_sc
+
+    ld      t5, 0(t0)
+    bne     t5, t3, .L_fail_t1_mem     # memory must hold 0x99
+
+    # ---- Test 2: AMOADD.D -------------------------------------------------
+    li      t1, 0x10
+    sd      t1, 0(t0)
+    li      t2, 0x20
+    amoadd.d t3, t2, (t0)             # t3 = old (0x10), mem ← 0x30
+    bne     t3, t1, .L_fail_t2_rd
+
+    ld      t4, 0(t0)
+    li      t5, 0x30
+    bne     t4, t5, .L_fail_t2_mem
+
+    # ---- Test 3: AMOSWAP.D ------------------------------------------------
+    li      t1, 0xAA
+    sd      t1, 0(t0)
+    li      t2, 0xBB
+    amoswap.d t3, t2, (t0)            # t3 = 0xAA, mem ← 0xBB
+    bne     t3, t1, .L_fail_t3_rd
+
+    ld      t4, 0(t0)
+    bne     t4, t2, .L_fail_t3_mem
+
+    # ---- Test 4: LR.D / SC.D with nop between ----------------------------
+    li      t1, 0x55
+    sd      t1, 0(t0)
+    lr.d    t2, (t0)
+    bne     t2, t1, .L_fail_t4_lr
+    nop
+    nop
+    li      t3, 0x66
+    sc.d    t4, t3, (t0)
+    bnez    t4, .L_fail_t4_sc
+
+    ld      t5, 0(t0)
+    bne     t5, t3, .L_fail_t4_mem
+
+    ret
+
+.L_fail_t1_lr:  addi a0, a0, 1; ret
+.L_fail_t1_sc:  addi a0, a0, 1; ret
+.L_fail_t1_mem: addi a0, a0, 1; ret
+.L_fail_t2_rd:  addi a0, a0, 1; ret
+.L_fail_t2_mem: addi a0, a0, 1; ret
+.L_fail_t3_rd:  addi a0, a0, 1; ret
+.L_fail_t3_mem: addi a0, a0, 1; ret
+.L_fail_t4_lr:  addi a0, a0, 1; ret
+.L_fail_t4_sc:  addi a0, a0, 1; ret
+.L_fail_t4_mem: addi a0, a0, 1; ret
+
+.section .data
+.balign 8
+_lock_word:
+    .dword  0

--- a/sw/stage7c/test_mem_csr_raw_5slot.S
+++ b/sw/stage7c/test_mem_csr_raw_5slot.S
@@ -1,0 +1,84 @@
+# test_mem_csr_raw_5slot.S — MEM1/MEM2 split: CSR-RAW stall for 5-slot writer.
+#
+# In stage 7c the CSR-RAW hazard window extends from 4 (7b: RR, EX1, EX2,
+# MEM1) to 5 positions ({RR, EX1, EX2, MEM1, MEM2}).  A CSR read immediately
+# following a chain of up to 5 back-to-back CSR writes to the same address
+# must stall until the last writer has committed, then return the final value.
+#
+# mscratch (0x340) is used as the test CSR — M-mode accessible, no side
+# effects, safe to clobber.
+#
+# Sub-tests:
+#   1. Single csrrw + immediate csrr — basic RAW stall.
+#   2. Two consecutive csrrw to same CSR + csrr — 2-slot RAW.
+#   3. Five consecutive csrrw + csrr — exercises the full 5-slot window.
+#   4. Five csrrw to same CSR; intermediate csrr after each write verifies
+#      that each stall delivers the correct in-flight value.
+#
+# x10 == 0 on PASS; addi a0, a0, 1 per failed sub-test.
+
+.equ CSR_MSCRATCH, 0x340
+
+.section .text
+.global main
+main:
+    li      a0, 0
+
+    # ---- Test 1: single csrrw + csrr -------------------------------------
+    li      t0, 0x11
+    csrrw   x0, CSR_MSCRATCH, t0
+    csrr    t1, CSR_MSCRATCH
+    li      t2, 0x11
+    bne     t1, t2, .L_fail_t1
+
+    # ---- Test 2: two csrrw + csrr ----------------------------------------
+    li      t0, 0x22
+    csrrw   x0, CSR_MSCRATCH, t0
+    li      t0, 0x33
+    csrrw   x0, CSR_MSCRATCH, t0
+    csrr    t1, CSR_MSCRATCH
+    li      t2, 0x33
+    bne     t1, t2, .L_fail_t2
+
+    # ---- Test 3: five csrrw + csrr (full 5-slot window) ------------------
+    li      t0, 0x11
+    csrrw   x0, CSR_MSCRATCH, t0
+    li      t0, 0x22
+    csrrw   x0, CSR_MSCRATCH, t0
+    li      t0, 0x33
+    csrrw   x0, CSR_MSCRATCH, t0
+    li      t0, 0x44
+    csrrw   x0, CSR_MSCRATCH, t0
+    li      t0, 0x55
+    csrrw   x0, CSR_MSCRATCH, t0
+    csrr    t1, CSR_MSCRATCH           # must stall until last write retires
+    li      t2, 0x55
+    bne     t1, t2, .L_fail_t3
+
+    # ---- Test 4: csrr after each write delivers the correct value ---------
+    li      t0, 0xAA
+    csrrw   x0, CSR_MSCRATCH, t0
+    csrr    t1, CSR_MSCRATCH
+    li      t2, 0xAA
+    bne     t1, t2, .L_fail_t4a
+
+    li      t0, 0xBB
+    csrrw   x0, CSR_MSCRATCH, t0
+    csrr    t1, CSR_MSCRATCH
+    li      t2, 0xBB
+    bne     t1, t2, .L_fail_t4b
+
+    li      t0, 0xCC
+    csrrw   x0, CSR_MSCRATCH, t0
+    csrr    t1, CSR_MSCRATCH
+    li      t2, 0xCC
+    bne     t1, t2, .L_fail_t4c
+
+    ret
+
+.L_fail_t1:  addi a0, a0, 1; ret
+.L_fail_t2:  addi a0, a0, 1; ret
+.L_fail_t3:  addi a0, a0, 1; ret
+.L_fail_t4a: addi a0, a0, 1; ret
+.L_fail_t4b: addi a0, a0, 1; ret
+.L_fail_t4c: addi a0, a0, 1; ret

--- a/sw/stage7c/test_mem_jalr_load_fwd.S
+++ b/sw/stage7c/test_mem_jalr_load_fwd.S
@@ -1,0 +1,63 @@
+# test_mem_jalr_load_fwd.S — MEM1/MEM2 split: JALR-load-fwd stall correctness.
+#
+# Per spec §2.3: the JALR-fwd stall fires when JALR's rs1 producer is a load
+# currently in ex2_mem1_q (MEM1 stage at ID-issue time of the JALR).  This
+# incurs a 1-cycle stall so the load result (FWD_MEM2) is ready when JALR
+# resolves in EX1.
+#
+# Pattern (pre-set x10 = 1 before the jalr, clear to 0 at target):
+#   ld  rs1, mem       # load target address into rs1
+#   jalr x0, 0(rs1)   # JALR whose rs1 is the fresh load result
+#   # unreachable (would increment x10 on wrong path)
+#   .target: x10 = 0
+#
+# Two variants:
+#   1. JALR immediately after ld (load-use + JALR stall interaction)
+#   2. JALR one instruction after ld (JALR stall fires when ld is in MEM1)
+#
+# x10 == 0 on PASS.
+
+.section .text
+.global main
+main:
+    li      a0, 0
+
+    # ---- Test 1: JALR immediately after ld --------------------------------
+    # Pre-arm: if JALR lands wrongly, x10 will retain the wrong value.
+    la      t0, _addr_t1_target
+    la      t1, _addr_t1_addr
+    sd      t0, 0(t1)                   # store target address in mem
+
+    li      a0, 0x1                     # failure sentinel
+    la      t2, _addr_t1_addr
+    ld      t3, 0(t2)                   # t3 = &_addr_t1_target
+    jalr    x0, 0(t3)                   # jump to _addr_t1_target
+    # unreachable
+    addi    a0, a0, 0x100               # won't execute on correct path
+_addr_t1_target:
+    li      a0, 0                       # clear failure sentinel — landed correctly
+
+    # ---- Test 2: JALR one instr after ld ----------------------------------
+    # Insert one instruction between ld and jalr so the load is in MEM1
+    # when the JALR is in ID.  Stall must still fire to wait for FWD_MEM2.
+    la      t0, _addr_t2_target
+    la      t1, _addr_t2_addr
+    sd      t0, 0(t1)
+
+    li      a0, 0x2                     # failure sentinel
+    la      t2, _addr_t2_addr
+    ld      t3, 0(t2)                   # t3 = &_addr_t2_target
+    nop                                 # one pipeline slot between ld and jalr
+    jalr    x0, 0(t3)                   # jump to _addr_t2_target
+    addi    a0, a0, 0x100               # unreachable on correct path
+_addr_t2_target:
+    li      a0, 0                       # clear sentinel — landed correctly
+
+    ret
+
+.section .data
+.balign 8
+_addr_t1_addr:
+    .dword  0
+_addr_t2_addr:
+    .dword  0

--- a/sw/stage7c/test_mem_load_use_3cycle.S
+++ b/sw/stage7c/test_mem_load_use_3cycle.S
@@ -1,0 +1,71 @@
+# test_mem_load_use_3cycle.S — MEM1/MEM2 split: load-use bypass correctness.
+#
+# With the MEM1/MEM2 split the hazard unit detects a load in {RR, EX1, EX2,
+# MEM1} and stalls 2 cycles in ID (same total as 7b).  When the consuming
+# instruction's RR cycle aligns with the load's MEM2 cycle, FWD_MEM2 selects
+# lsu_rdata combinationally so no extra stall is needed.
+#
+# This test verifies result correctness for back-to-back ld/use patterns —
+# the self-check confirms bypass delivers the right value rather than a
+# stale register value.
+#
+# Sub-tests:
+#   1. Single ld immediately consumed by addi      — FWD_MEM2 path
+#   2. ld followed by two ld-dependent addi chain  — consecutive stalls
+#   3. ld of a negative value, use in arithmetic   — sign extension check
+#   4. Double-word ld consumed by add (two-operand) — FWD_MEM2 on rs2
+#
+# x10 == 0 on PASS; increments by 1 per failed sub-test.
+
+.equ CSR_MSTATUS, 0x300
+
+.section .text
+.global main
+main:
+    li      a0, 0                       # running failure count
+
+    # ---- Test 1: ld immediately consumed by addi -------------------------
+    la      t0, _test_data
+    li      t1, 0x12345678
+    sd      t1, 0(t0)
+    ld      t2, 0(t0)                   # load 0x12345678 → t2
+    addi    t3, t2, 1                   # consume immediately (load-use stall)
+    li      t4, 0x12345679
+    bne     t3, t4, .L_fail_t1
+
+    # ---- Test 2: back-to-back ld; addi; addi chain -----------------------
+    li      t1, 0x100
+    sd      t1, 0(t0)
+    ld      t2, 0(t0)                   # t2 = 0x100
+    addi    t3, t2, 0x10               # t3 = 0x110  (load-use stall)
+    addi    t4, t3, 0x10               # t4 = 0x120
+    li      t5, 0x120
+    bne     t4, t5, .L_fail_t2
+
+    # ---- Test 3: ld negative value, use in arithmetic --------------------
+    li      t1, -1
+    sd      t1, 0(t0)
+    ld      t2, 0(t0)                   # t2 = -1 (sign-extended 0xFFFF...FFFF)
+    addi    t3, t2, 1                   # t3 = 0
+    bnez    t3, .L_fail_t3
+
+    # ---- Test 4: ld consumed on rs2 of add --------------------------------
+    li      t1, 0xABCD
+    sd      t1, 0(t0)
+    ld      t2, 0(t0)                   # t2 = 0xABCD
+    li      t3, 0x1000
+    add     t4, t3, t2                  # consume on rs2 (load-use stall)
+    li      t5, 0xBBCD
+    bne     t4, t5, .L_fail_t4
+
+    ret
+
+.L_fail_t1: addi a0, a0, 1; ret
+.L_fail_t2: addi a0, a0, 1; ret
+.L_fail_t3: addi a0, a0, 1; ret
+.L_fail_t4: addi a0, a0, 1; ret
+
+.section .data
+.balign 8
+_test_data:
+    .dword  0

--- a/sw/stage7c/test_mem_pmp_pf.S
+++ b/sw/stage7c/test_mem_pmp_pf.S
@@ -1,0 +1,128 @@
+# test_mem_pmp_pf.S — MEM1/MEM2 split: PMP data fault and page-fault trapping.
+#
+# In stage 7c the PMP check moves from EX2 to MEM1.  Faults produced at MEM1
+# ride mem1_mem2_q.fault and are delivered via the MEM2 redirect path with a
+# 5-bubble flush (ID + RR + EX1 + EX2 + MEM1).
+#
+# This test exercises PMP data faults, which are the only fault type
+# reachable from M-mode without setting up Sv39 translation.  Page faults
+# require virtual memory (SATP != 0 in S/U mode) which needs OS scaffolding
+# not available here; they are covered by the ACT4-s6-priv Sv suite.
+#
+# Sub-tests:
+#   1. PMP store-access fault (mcause = 7): locked NAPOT region, W=0, M-mode
+#      store → fault traps with correct mcause and mepc.
+#   2. PMP load-access fault (mcause = 5): locked NAPOT region, R=0, M-mode
+#      load → fault traps with correct mcause and mepc.
+#   3. Fault delivers to handler after exactly the right number of NOPs:
+#      mepc matches the instruction that triggered the fault (not +4, not -4).
+#
+# x10 == 0 on PASS; each failed sub-test ORs a unique bit into a0.
+
+.equ CSR_MTVEC,   0x305
+.equ CSR_MEPC,    0x341
+.equ CSR_MCAUSE,  0x342
+.equ CSR_MTVAL,   0x343
+.equ CSR_PMPCFG0, 0x3A0
+.equ CSR_PMPCFG1, 0x3A1
+.equ CSR_PMPADDR0, 0x3B0
+.equ CSR_PMPADDR1, 0x3B1
+
+.macro READ_LAST_MCAUSE rd
+    la      \rd, _last_mcause
+    lw      \rd, 0(\rd)
+.endm
+
+.macro READ_LAST_MEPC rd
+    la      \rd, _last_mepc
+    ld      \rd, 0(\rd)
+.endm
+
+.section .text
+.global main
+main:
+    li      a0, 0
+    la      t0, _mhandler
+    csrw    CSR_MTVEC, t0
+
+    # ---- Test 1: PMP store-access fault (mcause = 7) ---------------------
+    # NAPOT region covering [0x12000, 0x12100): R=1, W=0, X=0, L=1.
+    la      s0, _trap_taken
+    sw      zero, 0(s0)
+    li      t0, 0x481F                  # NAPOT: base=0x12000, size=256B
+    csrw    CSR_PMPADDR0, t0
+    li      t0, 0x99                    # L=1, A=NAPOT, X=0, W=0, R=1
+    csrw    CSR_PMPCFG0, t0
+    # Wait for CSR writes to drain through the pipeline before PMP check.
+    nop; nop; nop; nop
+    li      t1, 0x12000
+.L_t1_store:
+    sw      zero, 0(t1)                 # expect store-access fault (mcause=7)
+    lw      t0, 0(s0)
+    li      t1, 1
+    bne     t0, t1, .L_fail_t1_no_trap
+    READ_LAST_MCAUSE t0
+    li      t1, 7
+    bne     t0, t1, .L_fail_t1_cause
+    # Verify mepc points at the faulting store, not past it.
+    READ_LAST_MEPC t0
+    la      t1, .L_t1_store
+    bne     t0, t1, .L_fail_t1_mepc
+
+    # ---- Test 2: PMP load-access fault (mcause = 5) ----------------------
+    # Region 1: [0x13000, 0x13100) with R=0, W=0, X=0, L=1.
+    sw      zero, 0(s0)
+    li      t0, 0x4C1F                  # NAPOT: base=0x13000, size=256B
+    csrw    CSR_PMPADDR1, t0
+    li      t0, (0x98 << 8) | 0x99     # cfg1: L=1,NAPOT,X=0,W=0,R=0; cfg0 unchanged
+    csrw    CSR_PMPCFG0, t0
+    nop; nop; nop; nop
+    li      t1, 0x13000
+.L_t2_load:
+    lw      t2, 0(t1)                   # expect load-access fault (mcause=5)
+    lw      t0, 0(s0)
+    li      t1, 1
+    bne     t0, t1, .L_fail_t2_no_trap
+    READ_LAST_MCAUSE t0
+    li      t1, 5
+    bne     t0, t1, .L_fail_t2_cause
+    READ_LAST_MEPC t0
+    la      t1, .L_t2_load
+    bne     t0, t1, .L_fail_t2_mepc
+
+    ret
+
+.L_fail_t1_no_trap: ori a0, a0, 0x001; ret
+.L_fail_t1_cause:   ori a0, a0, 0x002; ret
+.L_fail_t1_mepc:    ori a0, a0, 0x004; ret
+.L_fail_t2_no_trap: ori a0, a0, 0x008; ret
+.L_fail_t2_cause:   ori a0, a0, 0x010; ret
+.L_fail_t2_mepc:    ori a0, a0, 0x020; ret
+
+# M-mode trap handler: save mcause/mepc, mark trap_taken, skip faulting instr.
+.balign 4
+_mhandler:
+    csrr    t0, CSR_MCAUSE
+    la      t1, _last_mcause
+    sw      t0, 0(t1)
+    csrr    t0, CSR_MEPC
+    la      t1, _last_mepc
+    sd      t0, 0(t1)
+    la      t1, _trap_taken
+    li      t2, 1
+    sw      t2, 0(t1)
+    # Advance mepc past the faulting instruction (assume 4-byte for simplicity).
+    csrr    t1, CSR_MEPC
+    addi    t1, t1, 4
+    csrw    CSR_MEPC, t1
+    mret
+
+.section .data
+.balign 8
+_trap_taken:
+    .word   0
+_last_mcause:
+    .word   0
+.balign 8
+_last_mepc:
+    .dword  0

--- a/sw/stage7c/test_mem_target_mispredict.S
+++ b/sw/stage7c/test_mem_target_mispredict.S
@@ -1,0 +1,68 @@
+# test_mem_target_mispredict.S — MEM1/MEM2 split: target mispredict flush.
+#
+# In stage 7c a target mispredict (bpred_target_mispredict) is detected at
+# MEM2 and flushes 5 stages (ID + RR + EX1 + EX2 + MEM1), one more than in
+# 7b.  The pipeline must redirect to the correct target and continue cleanly.
+#
+# Test approach: use JALR with a register-loaded target address.  The branch
+# predictor cannot predict the target of a register-indirect JALR before the
+# register is available (at EX1/EX2 at earliest), so the pipeline typically
+# fetches speculatively from PC+4.  When the JALR resolves in EX2/MEM2, the
+# redirect fires, flushing the wrongly-fetched instructions.
+#
+# Additionally, exercise a taken branch whose target was not in the BTB
+# (cold branch), so the predictor speculates not-taken and must redirect.
+#
+# Sub-tests:
+#   1. JALR to a register-loaded address: verify correct landing.
+#      Pattern: pre-set a0=0x1 (fail); clear to 0 at target.
+#   2. Cold backward branch (not in predictor): verify all loop iterations
+#      execute the correct number of times.
+#   3. Forward JALR chain: JALR A → JALR B → JALR C, verify final landing.
+#
+# x10 == 0 on PASS.
+
+.section .text
+.global main
+main:
+    li      a0, 0
+
+    # ---- Test 1: register-indirect JALR target mispredict -----------------
+    li      a0, 0x1                     # failure sentinel
+    la      t0, _t1_target
+    jalr    x0, 0(t0)                   # JALR to address in t0
+    addi    a0, a0, 0x100              # unreachable on correct path
+_t1_target:
+    li      a0, 0                       # clear sentinel — arrived correctly
+
+    # ---- Test 2: cold backward branch (loop) ------------------------------
+    # Count down from 4 to 0; the backward branch is never-seen-before.
+    li      t0, 4                       # loop counter
+    li      t1, 0                       # accumulator
+.L_t2_loop:
+    addi    t1, t1, 1                   # acc++
+    addi    t0, t0, -1                  # counter--
+    bnez    t0, .L_t2_loop             # backward branch — potential mispredict
+    li      t2, 4
+    bne     t1, t2, .L_fail_t2         # must have run exactly 4 times
+
+    # ---- Test 3: forward JALR chain ---------------------------------------
+    # JALR A → JALR B → JALR C → landing; verify we land at the right spot.
+    li      a0, 0x3                     # failure sentinel
+    la      t0, _t3_jmp_b
+    jalr    x0, 0(t0)                   # jump to _t3_jmp_b
+    addi    a0, a0, 0x100              # unreachable
+_t3_jmp_b:
+    la      t0, _t3_jmp_c
+    jalr    x0, 0(t0)                   # jump to _t3_jmp_c
+    addi    a0, a0, 0x100              # unreachable
+_t3_jmp_c:
+    la      t0, _t3_target
+    jalr    x0, 0(t0)                   # jump to _t3_target
+    addi    a0, a0, 0x100              # unreachable
+_t3_target:
+    li      a0, 0                       # clear sentinel
+
+    ret
+
+.L_fail_t2: addi a0, a0, 1; ret


### PR DESCRIPTION
## Summary

Splits the MEM stage into MEM1 (dTLB + PMP + PMA NC + dcache S0 BRAM-read launch + AMO operand-launch) and MEM2 (dcache S1 hit-detect + LSU rdata + AMO RMW + trap-redirect formation). Pipeline becomes `F0–F3 ─ ID ─ RR ─ EX1 ─ EX2 ─ MEM1 ─ MEM2 ─ WB`.

**This is a partial / WIP PR** — the structural skeleton lands cleanly but several directed tests still fail with data-correctness bugs. Each is individually tractable via VCD analysis but was deferred to a 7d follow-up rather than holding this PR open. **Do not merge unless intent is to land the skeleton + iterate on residual fixes in subsequent PRs.**

## What landed

* New pipeline register `mem1_mem2_q` (typed `mem1_mem2_reg_t` in `kronos_pkg`); legacy struct/enum names (`ex_mem_reg_t`, `FWD_EXMEM`) kept additively to avoid breaking stages 1–6 that share the package.
* `fwd_sel_e` widened additively with `FWD_MEM2` (load-value combinational from MEM2). 5-slot bypass network in `kronos_forward`.
* `kronos_hazard` extended: load-use list 4 positions, CSR-RAW 5/4 positions, JALR-load-fwd-stall narrowed to load-only on MEM1.
* dTLB and PMP relocated to MEM1 cycle. PMP comparator now operates on the dTLB-translated PA — eliminates the EX1-cycle dTLB+PMP cone (the worst Fmax path identified in master spec §1).
* dcache pre-launch retimed from EX2 to MEM1, VIPT VA-indexed (set+offset = 12 bits ≤ page-offset width).
* dcache RAW bypass extended from 1-deep to 2-deep (`prev2_write_*_q`).
* `mem_redirect_d` aggregator moves to MEM2 (5-bubble flush vs 4 in 7b).
* Wrong-path kill cone fixed: `~ex_redirect_q` removed from `ex2_mem1_q.valid` and `mem1_mem2_q.valid` gates per master spec §4 BOOM rule 2.
* `compliance-cycle-diff-s7c` CI gate (baseline `ed9c144`, +12% margin).
* `BASELINE_CYCLES` in `sw/perf/dhrystone/dhry_main.c` rebaked to 904764.
* Six directed asm tests under `sw/stage7c/` covering MEM1/MEM2 behaviour.

## Test plan

- [x] `make lint-rtl-all` clean (all stages s0–s7a)
- [x] `make build-s7a` clean
- [x] ACT4-s5 (307/307) — legacy stage unaffected
- [x] ACT4-s6 (305/305) — legacy stage unaffected
- [x] `sw/stage7c/test_mem_jalr_load_fwd` PASS
- [x] `sw/stage7c/test_mem_pmp_pf` PASS
- [x] `sw/stage6/{test_pmp_basic, test_dcache_raw, test_csr_priv}` PASS on s7a binary
- [ ] `sw/stage7c/test_mem_load_use_3cycle` — x10=2 (2 of 4 sub-tests fail)
- [ ] `sw/stage7c/test_mem_amo_split` — x10=2
- [ ] `sw/stage7c/test_mem_csr_raw_5slot` — x10=1
- [ ] `sw/stage7c/test_mem_target_mispredict` — x10=1
- [ ] `sw/stage6/test_priv_smoke` — x10=60 (regression vs s7b; mret/sret retire ordering)
- [ ] `sw/perf/dhrystone` — TIMEOUT (program repeatedly returns to PC=0 mid-execution; no `trap_taken_pulse` fires, suggests another wrong-path leak)

## Residual bugs to address in 7d

Each is documented in the squashed commit message. Brief summary:

1. **dhrystone hang** — wrong-path corner case causing repeated jump-to-PC-0. Highest priority since it gates the cycle-diff CI gate.
2. **CSR-RAW sub-test 2 fail** — VCD shows regfile values correct at retire; suspect bne reads wrong forwarding source.
3. **AMO RMW correctness** — LR/SC + AMOADD round-trip data corruption.
4. **Target-mispredict precision** — 5-bubble flush hole.
5. **Load-use 3-cycle sub-tests** — Option A (2-deep RAW bypass) didn't help; different corner.
6. **priv_smoke regression** — mret/sret retire ordering through the new mem1_mem2 stage.

## Notes for reviewer

* Spec: `docs/superpowers/specs/2026-05-06-stage7c-mem1-mem2-split-design.md` (gitignored — read locally)
* Plan: `docs/superpowers/plans/2026-05-06-stage7c-mem1-mem2-split.md` (gitignored — read locally)
* The wrong-path kill-cone fix was found via VCD-driven debug after both subagent attempts hit the same class of bug. Same methodology will resolve the residuals.
* ACT4-s7a hasn't been wired as a Make target yet; the `compliance-cycle-diff-s7c` CI gate will exercise s7a end-to-end via dhrystone, so it will fail on this PR until the dhrystone hang is fixed.