### PR TITLE
docs: catch up stage table to current state (7a-7d complete, 7e in progress)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,11 @@ Development follows a staged learning progression:
 | 6g    | Dcache `data_q` BRAM-back (4 × `kronos_ram`, EX-stage pre-launch) | RV64IMAFDC | AXI4 | Complete |
 | 6h    | Cache tag arrays + FP regfile in BRAM/LUTRAM (closes #79)        | RV64IMAFDC | AXI4 | Complete |
 | 6i    | Verification overhaul: dcache RAW regression + CRV-s6 + cosim fuzzer | RV64IMAFDC | AXI4 | Complete |
-| 7a    | BOOM-style fault-bit propagation + EX1/EX2 split (in-order Fmax push) | RV64IMAFDC | AXI4 | In progress |
-| 7b    | RR (register-read) stage + bypass network rebuild               | RV64IMAFDC | AXI4 | Planned  |
-| 7c    | MEM1/MEM2 split (dTLB/PMP separated from dcache hit)            | RV64IMAFDC | AXI4 | Planned  |
-| 7d    | *(Stretch)* dcache tag→data retime + FPU FMA retime + manual physopt | RV64IMAFDC | AXI4 | Planned |
+| 7a    | BOOM-style fault-bit propagation + EX1/EX2 split (in-order Fmax push) | RV64IMAFDC | AXI4 | Complete |
+| 7b    | RR (register-read) stage + bypass network rebuild               | RV64IMAFDC | AXI4 | Complete |
+| 7c    | MEM1/MEM2 split (dTLB/PMP separated from dcache hit)            | RV64IMAFDC | AXI4 | Complete |
+| 7d    | *(Stretch)* MEM1B PMP retime + FWD_MEM2 load suppression + trap_vector retime (RTL-only; Pblock floorplan deferred) | RV64IMAFDC | AXI4 | Complete (RTL) |
+| 7e    | Stall-network retime (event_bus register) + dTLB pipeline split | RV64IMAFDC | AXI4 | In progress |
 | 8     | Out-of-order execution (BOOM-class rename + ROB + IQ + LSU)     | RV64IMAFDC | AXI4 | Planned  |
 
 All five completed stages pass the full `riscv-arch-test` (ACT4) compliance

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Stage 4 widens all datapath elements to 64 bits and adds the A extension.
 | 6i    | Verification overhaul: dcache RAW regression + CRV-s6 + cosim fuzzer | RV64IMAFDC | AXI4    | Complete    |
 | 7a    | BOOM-style fault-bit propagation + EX1/EX2 split (in-order Fmax push) | RV64IMAFDC | AXI4 | Complete    |
 | 7b    | RR (register-read) stage + bypass network rebuild | RV64IMAFDC       | AXI4    | Complete    |
-| 7c    | MEM1/MEM2 split (dTLB/PMP separated from dcache hit) | RV64IMAFDC    | AXI4    | In progress |
-| 7d    | *(Stretch)* dcache tag→data retime + FPU FMA retime + manual physopt | RV64IMAFDC | AXI4 | Planned |
+| 7c    | MEM1/MEM2 split (dTLB/PMP separated from dcache hit) | RV64IMAFDC    | AXI4    | Complete    |
+| 7d    | *(Stretch)* MEM1B PMP retime + FWD_MEM2 load suppression + trap_vector retime (RTL-only; Pblock floorplan deferred) | RV64IMAFDC | AXI4 | Complete (RTL) |
+| 7e    | Stall-network retime (event_bus register, mhpmcounter CE retime) + dTLB pipeline split | RV64IMAFDC | AXI4 | In progress |
 | 8     | Out-of-order execution (BOOM-class rename + ROB + IQ + LSU) | RV64IMAFDC | AXI4 | Planned     |
 
 Each stage lives in its own `rtl/stage<N>/` directory and exposes the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,12 @@ One row per stage. The core pipeline structure (5 stages, AXI4 bus, bimodal bran
 | 4 | RV64IMAC | `kronos_alu` (64-bit), `kronos_muldiv` (64-bit), `kronos_decompress` (RV64C), `kronos_lsu` (LR/SC + AMO), `kronos_csr` (64-bit) | 64-bit datapath widening, atomic operations |
 | 5a | RV64IMAFD | `kronos_regfile_fp`, `kronos_fpu_top`, `kronos_fpu_scoreboard`, `kronos_fpu_fmisc`, `kronos_fpu_fcvt`, `kronos_fpu_fadd`, `kronos_fpu_fmul`, `kronos_fpu_fma` | Separate FP register file, multi-unit FPU dispatch, scoreboard hazard model |
 | 5b | RV64IMAFDC | `kronos_fpu_iter`, `kronos_fpu_fdiv_core`, `kronos_fpu_fsqrt_core` | Iterative FDIV/FSQRT (radix-2 SRT) |
+| 5c–5h | RV64IMAFDC | `kronos_icache`, `kronos_dcache`, `kronos_predecode`, `kronos_fetch_buffer`, `kronos_trigger` | Performance counters, CRV harness, I/D caches (4-way + tree-PLRU), FENCE.I, debug/trace layer |
+| 6a–6c | RV64IMAFDC | `kronos_pmp`, `kronos_tlb`, `kronos_ptw` | M/S/U privileged modes + trap delegation + PMP, Sv39/Sv48 MMU + iTLB/dTLB + HW PTW + sfence.vma, closeout |
+| 6d–6i | RV64IMAFDC | `kronos_ram` (SDP wrapper) | RAM wrapper infrastructure, PMA non-cacheable regions, dcache `data_q` BRAM-back, BOOM-style frontend rewrite, cache tag arrays + FP regfile in BRAM/LUTRAM, verification overhaul |
+| 7a–7c | RV64IMAFDC | (decoder split: `kronos_decode_int`, `kronos_decode_mem`, `kronos_decode_ctrl`, `kronos_decode_sys`, `kronos_decode_fp`) | In-order Fmax push: BOOM-style fault-bit propagation + EX1/EX2 split, RR (register-read) stage + bypass network rebuild, MEM1/MEM2 split (dTLB/PMP separated from dcache hit) |
+| 7d | RV64IMAFDC | (no new modules) | Stretch: MEM1B PMP retime + FWD_MEM2 load suppression + trap_vector retime; post-route WNS −3.128 → −2.872 ns on KV260 (xck26-2LV, Vivado 2025.2). RTL portion complete; Pblock floorplan deferred. |
+| 7e | RV64IMAFDC | (no new modules) | In progress: stall-network retime (`event_bus` register before `mhpmcounter` CE) + dTLB pipeline split |
 
 ---
 

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -220,6 +220,35 @@ per-stage section.
 | `test_fdiv_stall`        | `sw/stage5b/test_fdiv_stall.S`              | Pipeline stall during FDIV iteration  | `make run-s5-test_fdiv_stall`        |
 | `test_fdiv_irq`          | `sw/stage5b/test_fdiv_irq.S`                | FDIV results preserved after IRQ/MRET | `make run-s5b-test_fdiv_irq`         |
 
+## Stage 5c–5h, 6a–6i, 7a–7e — supplemental coverage
+
+Per-stage assembly programs live under `sw/stage<N>/` and are wired into
+the stage's `Makefile` `TESTS` list. Stage-level coverage at the integration
+level is gated by:
+
+- **ACT4 RV64IMAFDC compliance** — `make sim-arch-test-s5` (307/307),
+  `sim-arch-test-s6` (305/305), `sim-arch-test-s6-priv` (305/305 — adds
+  Sv39/Sv48, PMPSm, PMP-misaligned suites).
+- **`make sim-all`** — parallel regression of every unit testbench plus
+  Stage 4 integration suite (42 jobs).
+- **`make sim-cosim-deep TESTS=10000`** — 10 k random programs co-simulated
+  against `sail_riscv_sim` (CRV harness from Stage 5d).
+- **`compliance-cycle-diff-s7c`** — dhrystone cycle-budget gate vs the
+  `files_rtl_s7b@ed9c144` baseline (current budget 18%, raised to absorb
+  Stage 7d's load-use bubble).
+- **`perf-baseline-s6`** — dhrystone perf gate baked at the s6i baseline
+  (992 151 cycles); CI cycle-diff is the source of truth for ongoing drift.
+
+Newer stage-specific test programs are not enumerated row-by-row in this
+testplan — see the per-stage directories:
+
+- `sw/stage6/` — privileged-mode + PMP + MMU smoke (`test_csr_priv`,
+  `test_priv_smoke`, `test_pmp_basic`, `test_dcache_raw`, etc.)
+- `sw/stage7c/` — MEM1/MEM2 split correctness (`test_mem_amo_split`,
+  `test_mem_csr_raw_5slot`, `test_mem_jalr_load_fwd`,
+  `test_mem_load_use_3cycle`, `test_mem_pmp_pf`,
+  `test_mem_target_mispredict`)
+
 ## Cross-cutting verification
 
 ### Sail differential trace (Phase 1 P1.1)


### PR DESCRIPTION
## Summary

The stage tables in README.md and CLAUDE.md were stuck several stages behind:
- 7a was marked "In progress", 7b/7c/7d as "Planned"
- Actual repo state: PR #102 (7d-MEM1B) and PR #103 (7d-closeout-rtl) have merged

This PR catches up the tables and adjacent docs:

- **README.md / CLAUDE.md stage tables** — 7a/7b/7c → Complete; 7d → Complete (RTL), with description updated to reflect what actually landed (MEM1B PMP retime + FWD_MEM2 load suppression + trap_vector retime), Pblock floorplan called out as deferred; 7e added as In progress.
- **docs/architecture.md** — "Design Evolution" table extended with summary rows for 5c-5h, 6a-6c, 6d-6i, 7a-7c, 7d, 7e (previously stopped at 5b).
- **docs/testplan.md** — adds a brief "Stage 5c-5h, 6a-6i, 7a-7e supplemental coverage" section pointing to the per-stage `sw/` directories and naming the integration-level gates.

No RTL changes, no test changes — pure documentation.

## Test plan

- [x] No code changes; CI gates apply only to RTL/sim, not docs
- [x] Visual review of stage tables