### PR TITLE
feat(stage7e-pblock): compact u_core via CLOCK_REGION Pblock floorplan

### DIFF
--- a/fpga/kv260/floorplan.xdc
+++ b/fpga/kv260/floorplan.xdc
@@ -1,0 +1,17 @@
+# Copyright 2026 Vlad-Dumitru Popescu
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage 7e Pblock — compact u_core into a contiguous CLOCK_REGION subset on
+# xck26.  Targets the route component on the post-7d-closeout worst path
+# (ex2_mem1_q.alu_result -> u_dtlb -> u_ptw -> u_dcache -> bypass mux ->
+# rr_ex1_q.D, ~5 ns route).  See:
+#   docs/superpowers/specs/2026-05-06-stage7d-closeout-design.md  Section 4
+#
+# Impl-only (USED_IN_SYNTHESIS=false in synth.tcl).
+
+create_pblock pblock_core
+add_cells_to_pblock [get_pblocks pblock_core] [get_cells u_core]
+resize_pblock [get_pblocks pblock_core] -add { CLOCKREGION_X0Y0:CLOCKREGION_X1Y2 }
+set_property IS_SOFT             FALSE [get_pblocks pblock_core]
+set_property EXCLUDE_PLACEMENT   TRUE  [get_pblocks pblock_core]

--- a/fpga/kv260/synth.tcl
+++ b/fpga/kv260/synth.tcl
@@ -195,6 +195,13 @@ set_property USED_IN_SYNTHESIS      true  [get_files $SYNTH_XDC]
 set_property USED_IN_IMPLEMENTATION false [get_files $SYNTH_XDC]
 set_property PROCESSING_ORDER       EARLY [get_files $SYNTH_XDC]
 
+# Stage 7e Pblock floorplan — compact u_core into a contiguous CLOCK_REGION
+# subset.  Impl-only; not loaded during synthesis.
+set FLOORPLAN_XDC [file join $REPO_ROOT fpga/kv260/floorplan.xdc]
+add_files -fileset constrs_1 -norecurse $FLOORPLAN_XDC
+set_property USED_IN_SYNTHESIS      false [get_files $FLOORPLAN_XDC]
+set_property USED_IN_IMPLEMENTATION true  [get_files $FLOORPLAN_XDC]
+
 # Clock constraint — generated from SYNTH_FREQ_MHZ so no manual XDC edit needed
 file mkdir $PROJ_DIR
 set CLK_XDC [file join $PROJ_DIR clk.xdc]


### PR DESCRIPTION
## Summary

XDC-only.  Adds `fpga/kv260/floorplan.xdc` constraining `u_core` to a contiguous
2-column × 3-row `CLOCK_REGION` subset on xck26 (`CLOCKREGION_X0Y0:X1Y2`)
with `IS_SOFT FALSE + EXCLUDE_PLACEMENT TRUE`, wired into `synth.tcl` impl-only
(`USED_IN_SYNTHESIS=false`).

Targets the ~5 ns route component on the post-7d-closeout worst path
(`ex2_mem1_q.alu_result -> u_dtlb -> u_ptw -> u_dcache -> bypass mux -> rr_ex1_q.rs1_data`).

## Result

Post-route on KV260 (xck26-2LV, Vivado 2025.2, default impl + AggressiveExplore):

| Run                          | WNS       | Fmax     |
|------------------------------|-----------|----------|
| Baseline (post-7d-closeout)  | -2.872 ns | 127 MHz  |
| With Pblock (this PR)        | -2.329 ns | 136 MHz  |
| **Delta**                    | **+543 ps** | **+9 MHz** |

Modest structural gain.  Pblock-only ceiling for this design is bounded by the
19-LUT combinational cone through dTLB+PTW+dcache; further Fmax requires
structural RTL retime (TLB pipeline split, tracked as 7e.1).

## Iteration log

- **Iter 1** (X0Y0:X1Y2, IS_SOFT FALSE): WNS = -2.329 ns / 136 MHz.  **Shipped.**
- **Iter 2** (X0Y0:X1Y1, IS_SOFT FALSE): WNS = -5.085 ns / 99 MHz.  Reverted —
  the tighter region pushed the bottleneck onto the bpred `upd_target_q` update
  cone (24 levels, 9.8 ns).  Place_design wall-clock 4 hr (vs 30 min normal) —
  the placer thrashed.

## Test plan
- [x] No RTL changes — XDC-only.  `make ci-local` not relevant; ACT4 / sim-all
      / cosim are all RTL-gated and unchanged from main.
- [x] Vivado synth + impl on KV260: WNS = -2.329 ns post-route
- [x] WHS = 0 ns, THS = 0 ns (hold met)
- [x] WPWS = 1.738 ns, TPWS = 0 ns (pulse-width met)

Reference: `docs/superpowers/specs/2026-05-06-stage7d-closeout-design.md` §4
(originally a 7d Phase 2 deferred sub-PR; lifted into 7e since 7d shipped as
"Complete (RTL)" without it).